### PR TITLE
ホーム画面のタブの状態を維持できない問題を修正

### DIFF
--- a/model/build.gradle
+++ b/model/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'kotlin-kapt'
     id 'dagger.hilt.android.plugin'
     id 'org.jetbrains.kotlin.plugin.serialization'
+    id 'kotlin-parcelize'
 
 }
 

--- a/model/src/main/java/net/pantasystem/milktea/model/account/page/Page.kt
+++ b/model/src/main/java/net/pantasystem/milktea/model/account/page/Page.kt
@@ -1,19 +1,22 @@
 package net.pantasystem.milktea.model.account.page
 
+import android.os.Parcelable
 import androidx.room.*
+import kotlinx.parcelize.Parcelize
 import java.io.Serializable
 
 @Entity(
     tableName = "page_table",
     indices = [Index("weight"), Index("accountId")]
 )
+@Parcelize
 data class Page(
     var accountId: Long,
     val title: String,
     var weight: Int,
     @Embedded val pageParams: PageParams,
     @PrimaryKey(autoGenerate = true) var pageId: Long
-) : Serializable {
+) : Serializable, Parcelable {
 
     constructor(accountId: Long, title: String, weight: Int, pageable: Pageable, pageId: Long = 0)
             : this(accountId, title, weight, pageable.toParams(), pageId)

--- a/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
+++ b/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
@@ -1,9 +1,12 @@
 package net.pantasystem.milktea.model.account.page
 
 
+import android.os.Parcelable
 import net.pantasystem.milktea.model.account.page.PageType.*
 import java.io.Serializable
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class PageParams (
     val type: PageType = HOME,
     val withFiles: Boolean? = null,
@@ -27,7 +30,7 @@ data class PageParams (
     var host: String? = null,
     val antennaId: String? = null,
     val channelId: String? = null,
-) : Serializable{
+) : Serializable, Parcelable{
 
 
     // * Global, Local, Hybrid, Home, UserList, Mention, Show, SearchByTag, Featured, Notification, UserTimeline, Search, Antenna


### PR DESCRIPTION
## やったこと
画面切り替え時にメイン画面のタブの状態が初期化されてしまい
ユーザビリティが低下していた問題を修正しました。
具体的にはonSaveInstanceStateに状態を保存して次回復帰時に取り出して初期値としていれるようにすることで解決しました。
