### PR TITLE
めいすきーでタイムラインを取得できなくなる不具合を修正

### DIFF
--- a/api/src/main/java/net/pantasystem/milktea/api/misskey/auth/App.kt
+++ b/api/src/main/java/net/pantasystem/milktea/api/misskey/auth/App.kt
@@ -11,7 +11,7 @@ data class App(
     val name: String,
     val callbackUrl: String? = null,
     val isAuthorized: Boolean? = null,
-    val permission: List<String> = emptyList(),
+    val permission: List<String>? = emptyList(),
     val secret: String? = null
 ) : Serializable {
     fun toModel(): AppType.Misskey {
@@ -20,7 +20,7 @@ data class App(
             name = name,
             callbackUrl = callbackUrl,
             isAuthorized = isAuthorized,
-            permission = permission,
+            permission = permission ?: emptyList(),
             secret = secret
         )
     }


### PR DESCRIPTION
## やったこと
- めいすきーでタイムライを取得できなくなる不具合を修正しました。
- Appをデコードが原因でした。

## 動作確認
- エミュレーターで動作チェックを行いました。


## 関連リンク
* Closed #618 

