### PR TITLE
メッセージ一覧画面がクラッシュする問題を修正しました

### DIFF
--- a/features/messaging/src/main/java/net/pantasystem/milktea/messaging/viewmodel/MessageHistoryViewModel.kt
+++ b/features/messaging/src/main/java/net/pantasystem/milktea/messaging/viewmodel/MessageHistoryViewModel.kt
@@ -18,10 +18,7 @@ import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.account.AccountStore
 import net.pantasystem.milktea.model.group.GroupRepository
-import net.pantasystem.milktea.model.messaging.MessageHistoryRelation
-import net.pantasystem.milktea.model.messaging.MessageObserver
-import net.pantasystem.milktea.model.messaging.MessagingRepository
-import net.pantasystem.milktea.model.messaging.toHistory
+import net.pantasystem.milktea.model.messaging.*
 import net.pantasystem.milktea.model.user.UserRepository
 import javax.inject.Inject
 
@@ -93,9 +90,15 @@ class MessageHistoryViewModel @Inject constructor(
             } else {
                 ResultState.Fixed(content)
             }
+        }.map {
+            it.convert { list ->
+                list.distinctBy { msg ->
+                    msg.messagingId
+                }
+            }
         }.flowOn(Dispatchers.IO)
 
-    val histories = usersAndGroups.stateIn(
+    private val histories = usersAndGroups.stateIn(
         viewModelScope,
         SharingStarted.Lazily,
         ResultState.Loading(StateContent.NotExist())


### PR DESCRIPTION
## やったこと
めいすきーでメッセージ一覧画面を開こうとするとクラッシュする問題を修正しました。
### 不具合の原因
まず直接的な原因としては同一Idを持つエンティティが重複していたことが原因で、
ComposeのLazyColumnがKeyが重複しているとのことでクラッシュしていました。
重複していた原因としては、めいすきーではグループメッセージ機能が存在しないため、
グループ+ダイレクトメッセージをリクエストしても実際に帰ってくる結果は
ダイレクト+ダイレクトメッセージになってしまうため、２重に表示されてしまう原因となっていました。
そこで、最終的にはdistinctを使用して重複を排除するようにしました。


## 動作確認
エミュレーターで動作確認を行いました。

## 関連リンク
Closed #626 
