### PR TITLE
通知のボタン類が反応しない不具合を修正しました

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/ActionNoteHandler.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/ActionNoteHandler.kt
@@ -4,7 +4,8 @@ import android.util.Log
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
-import jp.panta.misskeyandroidclient.*
+import jp.panta.misskeyandroidclient.NoteEditorActivity
+import jp.panta.misskeyandroidclient.R
 import jp.panta.misskeyandroidclient.ui.confirm.ConfirmDialog
 import jp.panta.misskeyandroidclient.ui.notes.viewmodel.NotesViewModel
 import jp.panta.misskeyandroidclient.ui.notes.viewmodel.PlaneNoteViewData
@@ -17,13 +18,12 @@ import net.pantasystem.milktea.data.infrastructure.settings.SettingStore
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.NoteRelation
 import net.pantasystem.milktea.model.notes.draft.DraftNote
-import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.report.Report
 
 
 class ActionNoteHandler(
     val activity: AppCompatActivity,
-    val mNotesViewModel: NotesViewModel,
+    private val mNotesViewModel: NotesViewModel,
     val confirmViewModel: ConfirmViewModel,
     val settingStore: SettingStore,
 
@@ -33,15 +33,6 @@ class ActionNoteHandler(
     private val shareTargetObserver = Observer<PlaneNoteViewData> {
         Log.d("MainActivity", "share clicked :$it")
         ShareBottomSheetDialog().show(activity.supportFragmentManager, "MainActivity")
-    }
-    private val targetUserObserver = Observer<User> {
-        Log.d("MainActivity", "user clicked :$it")
-        val intent = UserDetailActivity.newInstance(activity, userId = it.id)
-
-        intent.putActivity(Activities.ACTIVITY_IN_APP)
-
-
-        activity.startActivity(intent)
     }
 
     private val statusMessageObserver = Observer<String> {

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/ActionNoteHandler.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/ActionNoteHandler.kt
@@ -118,8 +118,6 @@ class ActionNoteHandler(
         mNotesViewModel.shareTarget.removeObserver(shareTargetObserver)
         mNotesViewModel.shareTarget.observe(activity, shareTargetObserver)
 
-        mNotesViewModel.targetUser.removeObserver(targetUserObserver)
-        mNotesViewModel.targetUser.observe(activity, targetUserObserver)
 
         mNotesViewModel.statusMessage.removeObserver(statusMessageObserver)
         mNotesViewModel.statusMessage.observe(activity, statusMessageObserver)

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/NoteCardActionHandler.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/NoteCardActionHandler.kt
@@ -1,8 +1,7 @@
 package jp.panta.misskeyandroidclient.ui.notes.view
 
 import androidx.appcompat.app.AppCompatActivity
-import jp.panta.misskeyandroidclient.NoteDetailActivity
-import jp.panta.misskeyandroidclient.NoteEditorActivity
+import jp.panta.misskeyandroidclient.*
 import jp.panta.misskeyandroidclient.ui.notes.view.reaction.ReactionSelectionDialog
 import jp.panta.misskeyandroidclient.ui.notes.view.reaction.RemoteReactionEmojiSuggestionDialog
 import jp.panta.misskeyandroidclient.ui.notes.view.reaction.history.ReactionHistoryPagerDialog
@@ -84,6 +83,13 @@ class NoteCardActionHandler(
                         activity,
                         replyTo = action.note.toShowNote.note.id
                     )
+                )
+            }
+            is NoteCardAction.OnUserClicked -> {
+                val intent = UserDetailActivity.newInstance(activity, action.user.id)
+                intent.putActivity(Activities.ACTIVITY_IN_APP)
+                activity.startActivity(
+                    intent
                 )
             }
         }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/NoteCardActionListenerAdapter.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/NoteCardActionListenerAdapter.kt
@@ -4,6 +4,7 @@ import jp.panta.misskeyandroidclient.ui.notes.view.reaction.ReactionCountAction
 import jp.panta.misskeyandroidclient.ui.notes.viewmodel.PlaneNoteViewData
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.poll.Poll
+import net.pantasystem.milktea.model.user.User
 
 class NoteCardActionListenerAdapter(
     val onAction: (NoteCardAction) -> Unit,
@@ -25,12 +26,10 @@ class NoteCardActionListenerAdapter(
         onAction(NoteCardAction.OnReactionButtonClicked(note))
     }
 
-    fun onReactionClicked(note: PlaneNoteViewData, reaction: String) {
-        onAction(NoteCardAction.OnReactionClicked(note, reaction))
-    }
-
-    fun onReactionLongClicked(note: PlaneNoteViewData, reaction: String) {
-        onAction(NoteCardAction.OnReactionLongClicked(note, reaction))
+    fun onUserClicked(user: User?) {
+        if (user != null) {
+            onAction(NoteCardAction.OnUserClicked(user))
+        }
     }
 
     fun onPollChoiceClicked(noteId: Note.Id, poll: Poll, choice: Poll.Choice) {
@@ -71,4 +70,5 @@ sealed interface NoteCardAction {
     data class OnPollChoiceClicked(val noteId: Note.Id, val poll: Poll, val choice: Poll.Choice) : NoteCardAction
     data class OnRenoteButtonLongClicked(val note: PlaneNoteViewData) : NoteCardAction
     data class OnNoteCardClicked(val note: Note) : NoteCardAction
+    data class OnUserClicked(val user: User) : NoteCardAction
 }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/TimelineFragment.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/TimelineFragment.kt
@@ -113,7 +113,7 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
 
 
         mLinearLayoutManager = LinearLayoutManager(this.requireContext())
-        val adapter = TimelineListAdapter(diffUtilCallBack, viewLifecycleOwner, notesViewModel) {
+        val adapter = TimelineListAdapter(diffUtilCallBack, viewLifecycleOwner) {
             NoteCardActionHandler(
                 requireActivity() as AppCompatActivity,
                 notesViewModel,

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/TimelineListAdapter.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/TimelineListAdapter.kt
@@ -22,7 +22,6 @@ import jp.panta.misskeyandroidclient.databinding.ItemNoteBinding
 import jp.panta.misskeyandroidclient.ui.notes.view.poll.PollListAdapter
 import jp.panta.misskeyandroidclient.ui.notes.view.reaction.ReactionCountAdapter
 import jp.panta.misskeyandroidclient.ui.notes.viewmodel.HasReplyToNoteViewData
-import jp.panta.misskeyandroidclient.ui.notes.viewmodel.NotesViewModel
 import jp.panta.misskeyandroidclient.ui.notes.viewmodel.PlaneNoteViewData
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.reaction.ReactionCount
@@ -30,7 +29,6 @@ import net.pantasystem.milktea.model.notes.reaction.ReactionCount
 class TimelineListAdapter(
     diffUtilCallBack: DiffUtil.ItemCallback<PlaneNoteViewData>,
     private val lifecycleOwner: LifecycleOwner,
-    private val notesViewModel: NotesViewModel,
     val onAction: (NoteCardAction) -> Unit,
 ) : ListAdapter<PlaneNoteViewData, TimelineListAdapter.NoteViewHolderBase<ViewDataBinding>>(diffUtilCallBack){
 
@@ -41,7 +39,6 @@ class TimelineListAdapter(
         private var mNoteIdAndPollListAdapter: Pair<Note.Id, PollListAdapter>? = null
         abstract val lifecycleOwner: LifecycleOwner
         abstract val reactionCountsView: RecyclerView
-        abstract val notesViewModel: NotesViewModel
         abstract val noteCardActionListenerAdapter: NoteCardActionListenerAdapter
 
         private var reactionCountAdapter: ReactionCountAdapter? = null
@@ -136,15 +133,13 @@ class TimelineListAdapter(
             get() = this@TimelineListAdapter.lifecycleOwner
         override val reactionCountsView: RecyclerView
             get() = binding.simpleNote.reactionView
-        override val notesViewModel: NotesViewModel
-            get() = this@TimelineListAdapter.notesViewModel
+
 
         override val noteCardActionListenerAdapter: NoteCardActionListenerAdapter
             get() = this@TimelineListAdapter.cardActionListener
 
         override fun onBind(note: PlaneNoteViewData) {
             binding.note = note
-            binding.notesViewModel = notesViewModel
             binding.noteCardActionListener = noteCardActionListenerAdapter
 
         }
@@ -160,8 +155,6 @@ class TimelineListAdapter(
 
         override val reactionCountsView: RecyclerView
             get() = binding.simpleNote.reactionView
-        override val notesViewModel: NotesViewModel
-            get() = this@TimelineListAdapter.notesViewModel
 
         override val noteCardActionListenerAdapter: NoteCardActionListenerAdapter
             get() = this@TimelineListAdapter.cardActionListener
@@ -170,7 +163,6 @@ class TimelineListAdapter(
             if(note is HasReplyToNoteViewData){
                 binding.hasReplyToNote = note
 
-                binding.notesViewModel = notesViewModel
                 binding.noteCardActionListener = noteCardActionListenerAdapter
 
             }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/detail/NoteChildConversationAdapter.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/detail/NoteChildConversationAdapter.kt
@@ -15,12 +15,10 @@ import jp.panta.misskeyandroidclient.databinding.ItemSimpleNoteBinding
 import jp.panta.misskeyandroidclient.ui.notes.view.NoteCardAction
 import jp.panta.misskeyandroidclient.ui.notes.view.NoteCardActionListenerAdapter
 import jp.panta.misskeyandroidclient.ui.notes.view.reaction.ReactionCountAdapter
-import jp.panta.misskeyandroidclient.ui.notes.viewmodel.NotesViewModel
 import jp.panta.misskeyandroidclient.ui.notes.viewmodel.PlaneNoteViewData
 import net.pantasystem.milktea.model.notes.reaction.ReactionCount
 
 class NoteChildConversationAdapter(
-    val notesViewModel: NotesViewModel,
     val lifecycleOwner: LifecycleOwner,
     val onAction: (NoteCardAction) -> Unit,
 ) : ListAdapter<PlaneNoteViewData, NoteChildConversationAdapter.SimpleNoteHolder>(object : DiffUtil.ItemCallback<PlaneNoteViewData>(){

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/detail/NoteDetailAdapter.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/view/detail/NoteDetailAdapter.kt
@@ -91,7 +91,6 @@ class NoteDetailAdapter(
         when(holder){
             is NoteHolder ->{
                 holder.binding.note = note
-                holder.binding.notesViewModel = notesViewModel
                 setReactionCounter(note, holder.binding.simpleNote.reactionView)
 
                 holder.binding.lifecycleOwner = viewLifecycleOwner
@@ -108,11 +107,10 @@ class NoteDetailAdapter(
             is ConversationHolder ->{
                 Log.d("NoteDetailAdapter", "conversation: ${(note as NoteConversationViewData).conversation.value?.size}")
                 holder.binding.childrenViewData = note
-                holder.binding.notesViewModel = notesViewModel
                 setReactionCounter(note, holder.binding.childNote.reactionView)
 
                 holder.binding.noteDetailViewModel = noteDetailViewModel
-                val adapter = NoteChildConversationAdapter(notesViewModel, viewLifecycleOwner, onAction)
+                val adapter = NoteChildConversationAdapter(viewLifecycleOwner, onAction)
                 holder.binding.conversationView.adapter = adapter
                 holder.binding.conversationView.layoutManager = LinearLayoutManager(holder.itemView.context)
                 holder.binding.noteCardActionListener = noteCardActionListenerAdapter

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/NotesViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/NotesViewModel.kt
@@ -65,7 +65,6 @@ class NotesViewModel @Inject constructor(
 
     val shareNoteState = MutableLiveData<NoteState>()
 
-//    val targetUser = EventBus<User>()
 
     val openNoteEditor = EventBus<DraftNote?>()
 
@@ -74,10 +73,6 @@ class NotesViewModel @Inject constructor(
         shareTarget.event = note
         loadNoteState(note)
     }
-
-//    fun setTargetToUser(user: User) {
-//        targetUser.event = user
-//    }
 
 
     fun renote(noteId: Note.Id) {

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/NotesViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notes/viewmodel/NotesViewModel.kt
@@ -30,7 +30,6 @@ import net.pantasystem.milktea.model.notes.favorite.FavoriteRepository
 import net.pantasystem.milktea.model.notes.poll.Poll
 import net.pantasystem.milktea.model.notes.reaction.ToggleReactionUseCase
 import net.pantasystem.milktea.model.notes.renote.CreateRenoteUseCase
-import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.report.Report
 import javax.inject.Inject
 
@@ -66,7 +65,7 @@ class NotesViewModel @Inject constructor(
 
     val shareNoteState = MutableLiveData<NoteState>()
 
-    val targetUser = EventBus<User>()
+//    val targetUser = EventBus<User>()
 
     val openNoteEditor = EventBus<DraftNote?>()
 
@@ -76,9 +75,9 @@ class NotesViewModel @Inject constructor(
         loadNoteState(note)
     }
 
-    fun setTargetToUser(user: User) {
-        targetUser.event = user
-    }
+//    fun setTargetToUser(user: User) {
+//        targetUser.event = user
+//    }
 
 
     fun renote(noteId: Note.Id) {

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notification/NotificationFragment.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notification/NotificationFragment.kt
@@ -48,7 +48,6 @@ class NotificationFragment : Fragment(R.layout.fragment_notification), Scrollabl
 
         val adapter = NotificationListAdapter(
             diffUtilItemCallBack,
-            notesViewModel,
             mViewModel,
             viewLifecycleOwner
         ) {

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notification/NotificationListAdapter.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notification/NotificationListAdapter.kt
@@ -38,6 +38,7 @@ class NotificationListAdapter constructor(
         holder.binding.notification = getItem(position)
         holder.binding.simpleNote
         holder.binding.notificationViewModel = notificationViewModel
+        holder.binding.noteCardActionListener = noteCardActionListenerAdapter
 
         val note = getItem(position).noteViewData
         note?: return

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/notification/NotificationListAdapter.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/notification/NotificationListAdapter.kt
@@ -15,7 +15,6 @@ import jp.panta.misskeyandroidclient.databinding.ItemNotificationBinding
 import jp.panta.misskeyandroidclient.ui.notes.view.NoteCardAction
 import jp.panta.misskeyandroidclient.ui.notes.view.NoteCardActionListenerAdapter
 import jp.panta.misskeyandroidclient.ui.notes.view.reaction.ReactionCountAdapter
-import jp.panta.misskeyandroidclient.ui.notes.viewmodel.NotesViewModel
 import jp.panta.misskeyandroidclient.ui.notes.viewmodel.PlaneNoteViewData
 import jp.panta.misskeyandroidclient.ui.notification.viewmodel.NotificationViewData
 import jp.panta.misskeyandroidclient.ui.notification.viewmodel.NotificationViewModel
@@ -24,7 +23,6 @@ import net.pantasystem.milktea.model.notes.reaction.ReactionCount
 
 class NotificationListAdapter constructor(
     diffUtilCallBack: DiffUtil.ItemCallback<NotificationViewData>,
-    val notesViewModel: NotesViewModel,
     val notificationViewModel: NotificationViewModel,
     private val lifecycleOwner: LifecycleOwner,
     onNoteCardAction: (NoteCardAction) -> Unit
@@ -34,7 +32,6 @@ class NotificationListAdapter constructor(
     val noteCardActionListenerAdapter = NoteCardActionListenerAdapter(onNoteCardAction)
 
     override fun onBindViewHolder(holder: NotificationHolder, position: Int) {
-        holder.binding.notesViewModel = notesViewModel
         holder.binding.notification = getItem(position)
         holder.binding.simpleNote
         holder.binding.notificationViewModel = notificationViewModel

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/users/PinNoteFragment.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/users/PinNoteFragment.kt
@@ -92,7 +92,7 @@ class PinNoteFragment : Fragment(R.layout.fragment_pin_note) {
             ): Boolean {
                 return oldItem.id == newItem.id
             }
-        }, viewLifecycleOwner, notesViewModel) {
+        }, viewLifecycleOwner) {
             NoteCardActionHandler(
                 requireActivity() as AppCompatActivity,
                 notesViewModel,

--- a/app/src/main/res/layout/item_conversation.xml
+++ b/app/src/main/res/layout/item_conversation.xml
@@ -8,9 +8,6 @@
                 name="childrenViewData"
                 type="jp.panta.misskeyandroidclient.ui.notes.viewmodel.detail.NoteConversationViewData" />
         <variable
-                name="notesViewModel"
-                type="jp.panta.misskeyandroidclient.ui.notes.viewmodel.NotesViewModel" />
-        <variable
                 name="noteDetailViewModel"
                 type="jp.panta.misskeyandroidclient.ui.notes.viewmodel.detail.NoteDetailViewModel" />
         <variable

--- a/app/src/main/res/layout/item_has_reply_to_note.xml
+++ b/app/src/main/res/layout/item_has_reply_to_note.xml
@@ -7,9 +7,6 @@
         <import type="jp.panta.misskeyandroidclient.ui.SafeUnbox"/>
         <variable name="hasReplyToNote" type="jp.panta.misskeyandroidclient.ui.notes.viewmodel.HasReplyToNoteViewData"/>
         <variable
-                name="notesViewModel"
-                type="jp.panta.misskeyandroidclient.ui.notes.viewmodel.NotesViewModel" />
-        <variable
                 name="noteCardActionListener"
                 type="jp.panta.misskeyandroidclient.ui.notes.view.NoteCardActionListenerAdapter" />
     </data>

--- a/app/src/main/res/layout/item_note.xml
+++ b/app/src/main/res/layout/item_note.xml
@@ -11,9 +11,6 @@
         <import type="jp.panta.misskeyandroidclient.R"/>
 
         <variable
-                name="notesViewModel"
-                type="jp.panta.misskeyandroidclient.ui.notes.viewmodel.NotesViewModel" />
-        <variable
                 name="noteCardActionListener"
                 type="jp.panta.misskeyandroidclient.ui.notes.view.NoteCardActionListenerAdapter" />
     </data>
@@ -39,7 +36,7 @@
                     android:paddingStart="8dp"
                     android:paddingEnd="8dp"
                     android:paddingTop="8dp"
-                    android:onClick="@{()-> notesViewModel.setTargetToUser(note.note.user)}"
+                    android:onClick="@{()-> noteCardActionListener.onUserClicked(note.note.user)}"
                     app:statusMessageTargetViewNote="@{note}"
             />
             <include

--- a/app/src/main/res/layout/item_notification.xml
+++ b/app/src/main/res/layout/item_notification.xml
@@ -10,9 +10,6 @@
         <import type="jp.panta.misskeyandroidclient.R"/>
 
         <variable
-                name="notesViewModel"
-                type="jp.panta.misskeyandroidclient.ui.notes.viewmodel.NotesViewModel" />
-        <variable
                 name="notificationViewModel"
                 type="jp.panta.misskeyandroidclient.ui.notification.viewmodel.NotificationViewModel" />
         <variable
@@ -84,7 +81,7 @@
                         tools:srcCompat="@mipmap/ic_launcher_round"
                         android:layout_marginEnd="5dp"
                         app:circleIcon="@{notification.avatarIconUrl}"
-                        android:onClick="@{()-> notesViewModel.setTargetToUser(notification.user)}"
+                        android:onClick="@{()-> noteCardActionListener.onUserClicked(notification.user)}"
                         android:visibility="@{ notification.user == null ? View.GONE : View.VISIBLE }"
                         tools:ignore="ContentDescription" />
 


### PR DESCRIPTION
## やったこと
通知のボタン類を押しても、ただリップルが発生するだけで、
何もダイアログも、HTTPリクエストも発生しない不具合を修正しました。
具体的には、NotificationAdapterのコード中で、NoteCardActionAdapterにうまく繋ぎこめていないのが原因でした。
またnote系のxmlがNotesViewModelに依存しないようにリファクタリングを行いました。
## 動作確認
エミュレータで動作確認済み


## 備考


## 関連リンク
Closed #669 

