### PR TITLE
Android 13向けにプッシュ通知送信の許可を得るようにしました

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.READ_USER_DICTIONARY" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
             android:name=".MiApplication"

--- a/app/src/main/java/jp/panta/misskeyandroidclient/MainActivity.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/MainActivity.kt
@@ -158,19 +158,6 @@ class MainActivity : AppCompatActivity(), ToolbarSetter {
             showBottomNavBadgeCountDelegate(uiState)
         }.launchIn(lifecycleScope)
 
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.CREATED) {
-                mainViewModel.isRequestPushNotificationPermission.collect { requestPermission ->
-                    if ( requestPermission &&
-                        checkSelfPermission(
-                            Manifest.permission.POST_NOTIFICATIONS
-                        ) == PackageManager.PERMISSION_DENIED
-                    ) {
-                        requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                    }
-                }
-            }
-        }
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
@@ -197,6 +184,7 @@ class MainActivity : AppCompatActivity(), ToolbarSetter {
         collectCreateNoteState()
         collectUnauthorizedState()
         collectConfirmGoogleAnalyticsState()
+        collectRequestPostNotificationState()
 
         onBackPressedDispatcher.addCallback {
             val drawerLayout: DrawerLayout = binding.drawerLayout
@@ -433,6 +421,22 @@ class MainActivity : AppCompatActivity(), ToolbarSetter {
                             authorizationNavigation.newIntent(Unit)
                         )
                         finish()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun collectRequestPostNotificationState() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.CREATED) {
+                mainViewModel.isRequestPushNotificationPermission.collect { requestPermission ->
+                    if ( requestPermission &&
+                        checkSelfPermission(
+                            Manifest.permission.POST_NOTIFICATIONS
+                        ) == PackageManager.PERMISSION_DENIED
+                    ) {
+                        requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                     }
                 }
             }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/MainActivity.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/MainActivity.kt
@@ -1,12 +1,15 @@
 package jp.panta.misskeyandroidclient
 
+import android.Manifest
 import android.app.Activity
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.Gravity
 import android.view.View
 import android.widget.Toast
 import androidx.activity.addCallback
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.MainThread
 import androidx.appcompat.app.AppCompatActivity
@@ -155,6 +158,19 @@ class MainActivity : AppCompatActivity(), ToolbarSetter {
             showBottomNavBadgeCountDelegate(uiState)
         }.launchIn(lifecycleScope)
 
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.CREATED) {
+                mainViewModel.isRequestPushNotificationPermission.collect { requestPermission ->
+                    if ( requestPermission &&
+                        checkSelfPermission(
+                            Manifest.permission.POST_NOTIFICATIONS
+                        ) == PackageManager.PERMISSION_DENIED
+                    ) {
+                        requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    }
+                }
+            }
+        }
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
@@ -274,9 +290,6 @@ class MainActivity : AppCompatActivity(), ToolbarSetter {
         mAccountViewModel.showFollowers.observe(this, showFollowersObserver)
         mAccountViewModel.showProfile.observe(this, showProfileObserver)
     }
-
-
-
 
 
     @MainThread
@@ -424,6 +437,13 @@ class MainActivity : AppCompatActivity(), ToolbarSetter {
                 }
             }
         }
+    }
+
+
+    private val requestPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) {
+        mainViewModel.onPushNotificationConfirmed()
     }
 }
 

--- a/app/src/main/java/jp/panta/misskeyandroidclient/MainActivity.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.activity.viewModels
 import androidx.annotation.MainThread
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.content.ContextCompat
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.*
@@ -432,7 +433,8 @@ class MainActivity : AppCompatActivity(), ToolbarSetter {
             repeatOnLifecycle(Lifecycle.State.CREATED) {
                 mainViewModel.isRequestPushNotificationPermission.collect { requestPermission ->
                     if ( requestPermission &&
-                        checkSelfPermission(
+                        ContextCompat.checkSelfPermission(
+                            this@MainActivity,
                             Manifest.permission.POST_NOTIFICATIONS
                         ) == PackageManager.PERMISSION_DENIED
                     ) {

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/viewmodel/MainViewModel.kt
@@ -85,6 +85,10 @@ class MainViewModel @Inject constructor(
                 && config.isCrashlyticsCollectionEnabled.isConfirmed
     }.distinctUntilChanged().shareIn(viewModelScope, SharingStarted.Lazily)
 
+    val isRequestPushNotificationPermission = settingStore.configState.map { config ->
+        !config.isConfirmedPostNotification
+    }.distinctUntilChanged().shareIn(viewModelScope, SharingStarted.WhileSubscribed())
+
     @OptIn(ExperimentalCoroutinesApi::class)
     val currentAccountSocketStateEvent =
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
@@ -129,6 +133,17 @@ class MainViewModel @Inject constructor(
             it?.let {
                 misskeyAPIProvider.get(it.uri, it.getVersion())
             }
+        }
+    }
+
+    fun onPushNotificationConfirmed() {
+        viewModelScope.launch(Dispatchers.IO) {
+            configRepository.get().mapCatching {
+                configRepository.save(it.copy(isConfirmedPostNotification = true))
+            }.onFailure {
+
+            }
+
         }
     }
 

--- a/app/src/test/java/jp/panta/misskeyandroidclient/streaming/TestSocketImpl.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/streaming/TestSocketImpl.kt
@@ -21,7 +21,7 @@ class TestSocketImpl : Socket {
         return true
     }
 
-    override fun send(msg: String): Boolean {
+    override fun send(msg: String, isAutoConnect: Boolean): Boolean {
         println("send: $msg")
         return true
     }

--- a/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
+++ b/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
@@ -94,7 +94,10 @@ fun Config.Companion.from(map: Map<Keys, PrefType?>): Config {
                 ?: DefaultConfig.config.isAnalyticsCollectionEnabled.isEnabled,
             isConfirmed = map.getValue<PrefType.BoolPref>(Keys.IsConfirmedAnalyticsCollection)?.value
                 ?: DefaultConfig.config.isAnalyticsCollectionEnabled.isConfirmed,
-        )
+        ),
+        isConfirmedPostNotification = map.getValue<PrefType.BoolPref>(
+            Keys.IsConfirmedPostNotification
+        )?.value ?: false
     )
 }
 
@@ -170,6 +173,9 @@ fun Config.pref(key: Keys): PrefType? {
         }
         Keys.IsConfirmedAnalyticsCollection -> {
             PrefType.BoolPref(isAnalyticsCollectionEnabled.isConfirmed)
+        }
+        Keys.IsConfirmedPostNotification -> {
+            PrefType.BoolPref(isConfirmedPostNotification)
         }
     }
 }

--- a/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Keys.kt
+++ b/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Keys.kt
@@ -21,6 +21,7 @@ val Keys.Companion.allKeys by lazy {
         Keys.IsConfirmedCrashlyticsCollection,
         Keys.IsConfirmedAnalyticsCollection,
         Keys.IsAnalyticsCollectionEnabled,
+        Keys.IsConfirmedPostNotification,
     )
 }
 
@@ -56,6 +57,7 @@ sealed interface Keys {
     object IsAnalyticsCollectionEnabled : Keys
     object IsConfirmedAnalyticsCollection : Keys
 
+    object IsConfirmedPostNotification : Keys
     companion object
 }
 
@@ -80,5 +82,6 @@ fun Keys.str(): String {
         is Keys.IsConfirmedCrashlyticsCollection -> "IsConfirmedCrashlyticsCollection"
         is Keys.IsConfirmedAnalyticsCollection -> "IsConfirmedAnalyticsCollection"
         is Keys.IsAnalyticsCollectionEnabled -> "IsAnalyticsCollectionEnabled"
+        is Keys.IsConfirmedPostNotification -> "IsConfirmedPostNotification"
     }
 }

--- a/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
+++ b/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
@@ -105,6 +105,10 @@ class ConfigKtTest {
                     config.isCrashlyticsCollectionEnabled.isConfirmed,
                     (u as PrefType.BoolPref).value
                 )
+                Keys.IsConfirmedPostNotification -> Assert.assertEquals(
+                    config.isConfirmedPostNotification,
+                    (u as PrefType.BoolPref).value
+                )
             }
         }
     }

--- a/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
+++ b/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
@@ -58,6 +58,7 @@ class KeysKtTest {
                 Keys.IsConfirmedCrashlyticsCollection -> Assert.assertEquals("IsConfirmedCrashlyticsCollection", key.str())
                 Keys.IsAnalyticsCollectionEnabled -> Assert.assertEquals("IsAnalyticsCollectionEnabled", key.str())
                 Keys.IsConfirmedAnalyticsCollection -> Assert.assertEquals("IsConfirmedAnalyticsCollection", key.str())
+                Keys.IsConfirmedPostNotification -> Assert.assertEquals("IsConfirmedPostNotification", key.str())
             }
         }
     }
@@ -65,8 +66,8 @@ class KeysKtTest {
 
     @Test
     fun checkAllKeysCount() {
-        Assert.assertEquals(19, Keys.allKeys.size)
-        Assert.assertEquals(19, Keys.allKeys.map { it.str() }.toSet().size)
+        Assert.assertEquals(20, Keys.allKeys.size)
+        Assert.assertEquals(20, Keys.allKeys.map { it.str() }.toSet().size)
     }
 
 

--- a/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
+++ b/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
@@ -41,6 +41,20 @@ data class IsAnalyticsCollectionEnabled(
     val isConfirmed: Boolean,
 )
 
+/**
+ * @param isSimpleEditorEnabled シンプルエディターを使用するのか
+ * @param reactionPickerType リアクションピッカーの種別　
+ * @param backgroundImagePath 背景画像のパス
+ * @param isClassicUI BottomNavを使用しないタイプのUI
+ * @param isUserNameDefault User@usernameを主体とする表示
+ * @param isPostButtonAtTheBottom ノート編集画面の投稿ボタンを下に持ってくる
+ * @param urlPreviewConfig OGPの設定
+ * @param noteExpandedHeightSize ノートを強制的に折り畳むサイズ
+ * @param theme テーマカラー
+ * @param isCrashlyticsCollectionEnabled クラシュリティクスの許可状態
+ * @param isAnalyticsCollectionEnabled アナリティクスの許可状態
+ * @param isShownConfirmPushNotification プッシュ通知の顕現許可の状態
+ */
 data class Config(
     val isSimpleEditorEnabled: Boolean,
     val reactionPickerType: ReactionPickerType,
@@ -58,6 +72,7 @@ data class Config(
     val isEnableTimelineScrollAnimation: Boolean,
     val isCrashlyticsCollectionEnabled: IsCrashlyticsCollectionEnabled,
     val isAnalyticsCollectionEnabled: IsAnalyticsCollectionEnabled,
+    val isShownConfirmPushNotification: Boolean,
 ) {
     companion object
 
@@ -103,7 +118,8 @@ object DefaultConfig {
         isAnalyticsCollectionEnabled = IsAnalyticsCollectionEnabled(
             isConfirmed = false,
             isEnabled = false,
-        )
+        ),
+        isShownConfirmPushNotification = false,
     )
 
     fun getRememberVisibilityConfig(accountId: Long): RememberVisibility.Remember {

--- a/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
+++ b/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
@@ -53,7 +53,7 @@ data class IsAnalyticsCollectionEnabled(
  * @param theme テーマカラー
  * @param isCrashlyticsCollectionEnabled クラシュリティクスの許可状態
  * @param isAnalyticsCollectionEnabled アナリティクスの許可状態
- * @param isShownConfirmPushNotification プッシュ通知の顕現許可の状態
+ * @param isConfirmedPostNotification プッシュ通知の顕現許可の状態
  */
 data class Config(
     val isSimpleEditorEnabled: Boolean,
@@ -72,7 +72,7 @@ data class Config(
     val isEnableTimelineScrollAnimation: Boolean,
     val isCrashlyticsCollectionEnabled: IsCrashlyticsCollectionEnabled,
     val isAnalyticsCollectionEnabled: IsAnalyticsCollectionEnabled,
-    val isShownConfirmPushNotification: Boolean,
+    val isConfirmedPostNotification: Boolean,
 ) {
     companion object
 
@@ -119,7 +119,7 @@ object DefaultConfig {
             isConfirmed = false,
             isEnabled = false,
         ),
-        isShownConfirmPushNotification = false,
+        isConfirmedPostNotification = false,
     )
 
     fun getRememberVisibilityConfig(accountId: Long): RememberVisibility.Remember {


### PR DESCRIPTION
## やったこと
プッシュ通知の許可を得るようにしました。
Android 13以上の端末の時は、POST_NOTIFICATIONSの状態を取得して
未許可の状態である＆＆一度もパーミッションのリクエストを送信していない状態であれば
パーミッションのリクエストを出すようにしました。

## 動作確認
Android 13のエミュレーターで動作確認済み

## スクリーンショット(任意)


## 備考


## 関連リンク
* Closed #521 

## TODO