### PR TITLE
グループメッセージが問答無用で未読状態になってしまう問題を修正

### DIFF
--- a/api/src/main/java/net/pantasystem/milktea/api/misskey/messaging/MessageDTO.kt
+++ b/api/src/main/java/net/pantasystem/milktea/api/misskey/messaging/MessageDTO.kt
@@ -23,6 +23,7 @@ data class MessageDTO(
     val fileId: String? = null,
     val file: FilePropertyDTO? = null,
     val isRead: Boolean,
-    val emojis: List<Emoji>? = null
+    val emojis: List<Emoji>? = null,
+    val reads: List<String>? = null,
 ): JavaSerializable
 

--- a/data/src/main/java/net/pantasystem/milktea/data/infrastructure/entity_converters.kt
+++ b/data/src/main/java/net/pantasystem/milktea/data/infrastructure/entity_converters.kt
@@ -80,9 +80,12 @@ fun MessageDTO.entities(account: Account): Pair<Message, List<User>> {
             User.Id(account.accountId, userId),
             fileId,
             file?.toFileProperty(account),
-            isRead,
+            isRead = reads?.contains(account.remoteId) ?: false,
             emojis?: emptyList(),
             Group.Id(account.accountId, groupId!!),
+            reads = reads?.map {
+                User.Id(account.accountId, it)
+            }?: emptyList()
         )
     }
     return message to list

--- a/model/src/main/java/net/pantasystem/milktea/model/messaging/Message.kt
+++ b/model/src/main/java/net/pantasystem/milktea/model/messaging/Message.kt
@@ -51,6 +51,7 @@ sealed class Message {
         override val isRead: Boolean,
         override val emojis: List<Emoji>,
         val groupId: GroupEntity.Id,
+        val reads: List<User.Id>
     ) : Message() {
         override fun read(): Message {
             return this.copy(isRead = true)


### PR DESCRIPTION
## やったこと
グループメッセージの場合readsという既読したユーザーのIdを持つ
配列なフィールドで管理されていたので、
合わせて変更しました。

## 動作確認
エミュレーターで動作確認済み

## スクリーンショット(任意)


## 備考


## 関連リンク
Closed #696 

## TODO
