### PR TITLE
返信先全ての投稿のユーザをメンションに含めるように

### DIFF
--- a/model/src/main/java/net/pantasystem/milktea/model/notes/GetAllMentionUsersUseCase.kt
+++ b/model/src/main/java/net/pantasystem/milktea/model/notes/GetAllMentionUsersUseCase.kt
@@ -1,0 +1,56 @@
+package net.pantasystem.milktea.model.notes
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.pantasystem.milktea.model.UseCase
+import net.pantasystem.milktea.model.account.GetAccount
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.UserRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+
+@Singleton
+class GetAllMentionUsersUseCase @Inject constructor(
+    val noteRepository: NoteRepository,
+    val userRepository: UserRepository,
+    val getAccount: GetAccount,
+) : UseCase {
+
+    /**
+     * 返信元を辿りながら、全てのユーザーを取得する
+     * @param noteId 指定されたNoteのIdから親投稿のユーザーを取得していきながらメンション対象のユーザを取得します。
+     */
+    suspend operator fun invoke(
+        noteId: Note.Id,
+        users: List<User> = emptyList(),
+        searchedIds: List<Note.Id> = emptyList()
+    ): Result<List<User>> {
+        return withContext(Dispatchers.IO) {
+            // NOTE:
+            if (searchedIds.contains(noteId)) {
+                return@withContext Result.success(users)
+            }
+            runCatching {
+                val me = getAccount.get(noteId.accountId)
+                val myId = User.Id(me.accountId, me.remoteId)
+                val note = noteRepository.find(noteId).getOrThrow()
+                val user = userRepository.find(note.userId)
+                if (note.replyId == null) {
+                    (users + user).distinctBy { it.id }.filterNot {
+                        it.id == myId
+                    }
+                } else {
+                    invoke(note.replyId, users + user, searchedIds + noteId)
+                        .getOrElse {
+                            users.distinctBy { it.id }.filterNot {
+                                it.id == myId
+                            }
+                        }
+                }
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
## やったこと
現状：直近の投稿のユーザのメンションしか入れることができなかった。
変更後：返信先全ての親投稿のユーザのメンションを入れられるようにした

## 動作確認
エミュレータで動作確認済み

## スクリーンショット(任意)


## 備考


## 関連リンク
Closed 706

## TODO
