### PR TITLE
UserDaoのConflictStrategyをOnConflictStrategy.IGNOREに修正

### DIFF
--- a/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/db/UserDao.kt
+++ b/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/db/UserDao.kt
@@ -6,10 +6,10 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 abstract class UserDao {
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     abstract suspend fun insert(user: UserRecord): Long
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     abstract suspend fun insertUsers(users: List<UserRecord>): List<Long>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)


### PR DESCRIPTION
## やったこと
UserRecordをInsertする時に重複が発生した時に欲しかった期待値は
戻り値-1であって例外ではなかったのでOnConflictStrategy.IGNORE返すように修正しました

## 動作確認


## スクリーンショット(任意)


## 備考


## 関連リンク


## TODO