### PR TITLE
メンバーが全て表示されない問題を修正

### DIFF
--- a/features/group/src/main/java/net/pantasystem/milktea/group/GroupListViewModel.kt
+++ b/features/group/src/main/java/net/pantasystem/milktea/group/GroupListViewModel.kt
@@ -16,7 +16,6 @@ import net.pantasystem.milktea.model.group.Group
 import net.pantasystem.milktea.model.group.GroupDataSource
 import net.pantasystem.milktea.model.group.GroupRepository
 import net.pantasystem.milktea.model.group.GroupWithMember
-import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserRepository
 import java.util.*
 import javax.inject.Inject
@@ -124,9 +123,4 @@ data class GroupListUiState(
     val ownedGroups: List<GroupWithMember>,
     val syncJoinedGroupsState: ResultState<List<Group>>,
     val syncOwnedGroupsState: ResultState<List<Group>>,
-)
-
-data class GroupItem(
-    val group: Group,
-    val users: List<User>
 )

--- a/features/group/src/main/java/net/pantasystem/milktea/group/GroupListViewModel.kt
+++ b/features/group/src/main/java/net/pantasystem/milktea/group/GroupListViewModel.kt
@@ -105,8 +105,8 @@ class GroupListViewModel @Inject constructor(
                 it.members
             }.flatten()).map { member ->
                 member.userId
-            }
-        }.map {
+            }.distinct()
+        }.distinctUntilChanged().map {
             userRepository.syncIn(it)
         }.catch {
             logger.error("ユーザーの同期エラー", it)


### PR DESCRIPTION
## やったこと
グループ一覧表示時に、
メンバーが全て表示されない問題を修正しました。
具体的には、グループ取得時にグループに含むメンバーIdを使ってユーザーの取得＆同期処理を行うようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


