### PR TITLE
グループからメッセージ画面へ遷移できるようにしました

### DIFF
--- a/common_navigation/src/main/java/net/pantasystem/milktea/common_navigation/MessageNavigation.kt
+++ b/common_navigation/src/main/java/net/pantasystem/milktea/common_navigation/MessageNavigation.kt
@@ -1,0 +1,9 @@
+package net.pantasystem.milktea.common_navigation
+
+import net.pantasystem.milktea.model.messaging.MessagingId
+
+interface MessageNavigation :  ActivityNavigation<MessageNavigationArgs>
+
+data class MessageNavigationArgs(
+    val messagingId: MessagingId
+)

--- a/features/group/src/main/java/net/pantasystem/milktea/group/GroupActivity.kt
+++ b/features/group/src/main/java/net/pantasystem/milktea/group/GroupActivity.kt
@@ -15,6 +15,7 @@ import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import net.pantasystem.milktea.common.ui.ApplyTheme
 import net.pantasystem.milktea.common_navigation.*
+import net.pantasystem.milktea.model.messaging.MessagingId
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -30,6 +31,9 @@ class GroupActivity : AppCompatActivity() {
 
     @Inject
     lateinit var searchAndSelectUserNavigation: SearchAndSelectUserNavigation
+
+    @Inject
+    lateinit var messageNavigation: MessageNavigation
 
     private val groupDetailViewModel: GroupDetailViewModel by viewModels()
 
@@ -93,6 +97,11 @@ class GroupActivity : AppCompatActivity() {
                                                 SearchAndSelectUserNavigationArgs()
                                             )
                                         )
+                                    }
+                                    is GroupDetailStatePageAction.OnShowMessage -> {
+                                        startActivity(messageNavigation.newIntent(
+                                            MessageNavigationArgs(MessagingId.Group(action.group.id))
+                                        ))
                                     }
                                 }
                             })

--- a/features/group/src/main/java/net/pantasystem/milktea/group/GroupDetailPage.kt
+++ b/features/group/src/main/java/net/pantasystem/milktea/group/GroupDetailPage.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.GroupAdd
+import androidx.compose.material.icons.filled.Message
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import net.pantasystem.milktea.model.group.Group
@@ -59,6 +60,11 @@ fun GroupDetailPage(uiState: GroupDetailUiState, onAction: (GroupDetailPageActio
                             Icon(Icons.Default.Edit, contentDescription = null)
                         }
                     }
+                    IconButton(onClick = {
+
+                    }) {
+                        Icon(Icons.Default.Message, contentDescription = null)
+                    }
                 }
             )
         },
@@ -96,4 +102,5 @@ sealed interface GroupDetailPageAction {
     object OnEdit : GroupDetailPageAction
     data class OnMemberAction(val action: GroupMemberCardAction) : GroupDetailPageAction
     data class OnInviteUsers(val group: Group) : GroupDetailPageAction
+    data class ShowMessaging(val group: Group) : GroupDetailPageAction
 }

--- a/features/group/src/main/java/net/pantasystem/milktea/group/GroupDetailPage.kt
+++ b/features/group/src/main/java/net/pantasystem/milktea/group/GroupDetailPage.kt
@@ -61,6 +61,9 @@ fun GroupDetailPage(uiState: GroupDetailUiState, onAction: (GroupDetailPageActio
                         }
                     }
                     IconButton(onClick = {
+                        uiState.group?.let {
+                            onAction(GroupDetailPageAction.ShowMessaging(it))
+                        }
 
                     }) {
                         Icon(Icons.Default.Message, contentDescription = null)

--- a/features/group/src/main/java/net/pantasystem/milktea/group/GroupDetailStatePage.kt
+++ b/features/group/src/main/java/net/pantasystem/milktea/group/GroupDetailStatePage.kt
@@ -27,6 +27,9 @@ fun GroupDetailStatePage(
             GroupDetailPageAction.OnEditingCanceled -> {
                 groupDetailViewModel.cancelEditing()
             }
+            is GroupDetailPageAction.ShowMessaging -> {
+                onAction(GroupDetailStatePageAction.OnShowMessage(action.group))
+            }
             is GroupDetailPageAction.OnMemberAction -> {
                 when(action.action) {
                     is GroupMemberCardAction.OnClick -> {
@@ -53,4 +56,5 @@ sealed interface GroupDetailStatePageAction {
     object PopBackStack : GroupDetailStatePageAction
     data class OnShowUser(val user: User) : GroupDetailStatePageAction
     data class OnInviteUsers(val group: Group) : GroupDetailStatePageAction
+    data class OnShowMessage(val group: Group) : GroupDetailStatePageAction
 }

--- a/features/messaging/src/main/java/net/pantasystem/milktea/messaging/MessageActivity.kt
+++ b/features/messaging/src/main/java/net/pantasystem/milktea/messaging/MessageActivity.kt
@@ -1,14 +1,28 @@
 package net.pantasystem.milktea.messaging
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import dagger.hilt.android.AndroidEntryPoint
 import net.pantasystem.milktea.common.ui.ApplyTheme
+import net.pantasystem.milktea.common_navigation.MessageNavigation
+import net.pantasystem.milktea.common_navigation.MessageNavigationArgs
 import net.pantasystem.milktea.messaging.databinding.ActivityMessageBinding
 import net.pantasystem.milktea.model.messaging.MessagingId
 import javax.inject.Inject
+
+class MessageNavigationImpl @Inject constructor(
+    val activity: Activity
+) : MessageNavigation {
+    override fun newIntent(args: MessageNavigationArgs): Intent {
+        val intent = Intent(activity, MessageActivity::class.java)
+        intent.putExtra(MessageActivity.EXTRA_MESSAGING_ID, args.messagingId)
+        return intent
+    }
+}
 
 @AndroidEntryPoint
 class MessageActivity : AppCompatActivity() {

--- a/features/messaging/src/main/java/net/pantasystem/milktea/messaging/di/NavigationModule.kt
+++ b/features/messaging/src/main/java/net/pantasystem/milktea/messaging/di/NavigationModule.kt
@@ -1,0 +1,15 @@
+package net.pantasystem.milktea.messaging.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+import net.pantasystem.milktea.common_navigation.MessageNavigation
+import net.pantasystem.milktea.messaging.MessageNavigationImpl
+
+@Module
+@InstallIn(ActivityComponent::class)
+abstract class NavigationModule {
+    @Binds
+    abstract fun bindMessageActivityNavigation(impl: MessageNavigationImpl): MessageNavigation
+}


### PR DESCRIPTION
## やったこと
グループ収納場所にメッセージボタンを追加しました。
クリックするとメッセージ画面へ遷移するようにしました。

## 動作確認
エミュレーターで動作確認済み

## スクリーンショット(任意)


## 備考


## 関連リンク
Closed #733 

