### PR TITLE
その他のファイルをタップするとクラッシュする問題を修正

### DIFF
--- a/features/note/src/main/java/net/pantasystem/milktea/note/view/url/PreviewListAdapter.kt
+++ b/features/note/src/main/java/net/pantasystem/milktea/note/view/url/PreviewListAdapter.kt
@@ -1,6 +1,7 @@
 package net.pantasystem.milktea.note.view.url
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.view.LayoutInflater
@@ -11,8 +12,9 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import dagger.hilt.android.EntryPointAccessors
-import net.pantasystem.milktea.common_navigation.MediaNavigationArgs
+import dagger.hilt.android.internal.managers.FragmentComponentManager
 import net.pantasystem.milktea.common_android_ui.NavigationEntryPointForBinding
+import net.pantasystem.milktea.common_navigation.MediaNavigationArgs
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.ItemFilePreviewBinding
 import net.pantasystem.milktea.note.databinding.ItemUrlPreviewBinding
@@ -56,11 +58,15 @@ class PreviewListAdapter : ListAdapter<Preview, RecyclerView.ViewHolder>(ItemCal
             val context = this.binding.filePropertyView.context
             binding.filePropertyView.setOnClickListener {
                 if(preview.file.type?.startsWith("audio") == true){
-                    val accessor = EntryPointAccessors.fromView(binding.root, NavigationEntryPointForBinding::class.java)
-                    val intent = accessor.mediaNavigation().newIntent(MediaNavigationArgs.AFile(
-                        preview.file
-                    ))
-                    context?.startActivity(intent)
+                    val activity = FragmentComponentManager.findActivity(binding.root.context)
+                    if (activity is Activity) {
+                        val accessor = EntryPointAccessors.fromActivity(activity, NavigationEntryPointForBinding::class.java)
+                        val intent = accessor.mediaNavigation().newIntent(MediaNavigationArgs.AFile(
+                            preview.file
+                        ))
+                        context?.startActivity(intent)
+                    }
+
                 }else{
                     context?.startActivity(
                         Intent().apply{


### PR DESCRIPTION
## やったこと
画像、動画、以外のファイルをタップするとクラッシュする問題を修正しました

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号


Closed #766
