### PR TITLE
カスタム絵文字を検索するときは部分一致検索で抽出するようにしました

### DIFF
--- a/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/ReactionSelectionDialogViewModel.kt
+++ b/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/ReactionSelectionDialogViewModel.kt
@@ -34,7 +34,7 @@ class ReactionSelectionDialogViewModel @Inject constructor(
             word.replace(":", "")
         }.map { word ->
             emojis.filter { emoji ->
-                emoji.name.startsWith(word)
+                emoji.name.contains(word)
                         || emoji.aliases?.any { alias ->
                     alias.startsWith(word)
                 } ?: false


### PR DESCRIPTION
## やったこと
カスタム絵文字を検索するときは前方一致ではなく部分一致検索で表示するようにしました。
aliasについては前方一致のままにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号

Closed #776


