### PR TITLE
syncInの呼び出し方が不適切だった問題を修正しました

### DIFF
--- a/features/group/src/main/java/net/pantasystem/milktea/group/GroupListViewModel.kt
+++ b/features/group/src/main/java/net/pantasystem/milktea/group/GroupListViewModel.kt
@@ -99,16 +99,14 @@ class GroupListViewModel @Inject constructor(
         sync()
         combine(joinedGroups, ownedGroups) { joined, owned ->
             (joined.map {
-                it.members
+                it.group.userIds
             }.flatten() + owned.map {
-                it.members
-            }.flatten()).map { member ->
-                member.userId
-            }.distinct()
+                it.group.userIds
+            }.flatten()).distinct()
         }.distinctUntilChanged().map {
-            userRepository.syncIn(it)
-        }.catch {
-            logger.error("ユーザーの同期エラー", it)
+            userRepository.syncIn(it).onFailure { e ->
+                logger.error("ユーザーの同期エラー", e)
+            }
         }.launchIn(viewModelScope)
     }
 


### PR DESCRIPTION
## やったこと
syncIn自体に問題があるのではなく、
syncInの呼び出し方に問題があることがわかりました。
現状GroupWithMember#membersを元にsyncInを行なっていましたが、
membersにデータがある前提として、既にそのユーザーがSQLite上にキャッシュされている必要がありました。
つまりmembersにはキャッシュされていない分のユーザー情報が含まれていないことになります。
そのため足りない分のユーザーデータが同期されないままという問題が発生していました。

GroupWithMember#members<Group#userIds
GroupWIthMember#members=Room上にキャッシュされたデータ




## 動作確認
エミュレーターで動作確認済み



## Issue番号
Closed #793 


