### PR TITLE
広告IDが入らないように修正しました

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
-
     <application
             android:name=".MiApplication"
             android:allowBackup="true"
@@ -45,6 +44,9 @@
         <meta-data
                 android:name="firebase_analytics_collection_enabled"
                 android:value="false" />
+
+        <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
+
 
         <service
                 android:name=".FCMService"


### PR DESCRIPTION
## やったこと
AdMobを使用していないにも関わらず広告Idが使用されていると警告が出てしまう問題を修正しました。
原因としてはfirebaseに広告IDを収集する仕組みが含まれていたのが原因のようです。
https://qiita.com/Nkzn/items/326ad03e358b5d3fbafc

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



