### PR TITLE
ノートのキャッシュ取得時に発生していた問題を修正しました

### DIFF
--- a/modules/data/build.gradle
+++ b/modules/data/build.gradle
@@ -94,6 +94,7 @@ dependencies {
 
     implementation platform('com.google.firebase:firebase-bom:30.4.0')
     implementation 'com.google.firebase:firebase-messaging'
+    testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
 
 }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/InMemoryNoteDataSource.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/InMemoryNoteDataSource.kt
@@ -4,17 +4,13 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.model.AddResult
 import net.pantasystem.milktea.model.notes.*
 import net.pantasystem.milktea.model.user.User
 import javax.inject.Inject
 
-class InMemoryNoteDataSource @Inject constructor(
-    loggerFactory: Logger.Factory
-): NoteDataSource {
+class InMemoryNoteDataSource @Inject constructor(): NoteDataSource {
 
-    val logger = loggerFactory.create("InMemoryNoteRepository")
 
     private var notes = mapOf<Note.Id, Note>()
 

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/notes/impl/InMemoryNoteDataSourceTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/notes/impl/InMemoryNoteDataSourceTest.kt
@@ -1,0 +1,45 @@
+package net.pantasystem.milktea.data.infrastructure.notes.impl
+
+import kotlinx.coroutines.runBlocking
+import net.pantasystem.milktea.model.notes.Note
+import net.pantasystem.milktea.model.notes.NoteDeletedException
+import net.pantasystem.milktea.model.notes.NoteNotFoundException
+import net.pantasystem.milktea.model.notes.make
+import net.pantasystem.milktea.model.user.User
+import org.junit.Assert
+import org.junit.Test
+
+class InMemoryNoteDataSourceTest {
+
+    @Test
+    fun get_ThrowsNoteDeletedExceptionGiveDeletedNote(): Unit = runBlocking {
+        val noteDataSource = InMemoryNoteDataSource()
+        val id = Note.Id(0L, "testId")
+        noteDataSource.remove(id)
+        val result = noteDataSource.get(id)
+        Assert.assertNotNull(result.exceptionOrNull())
+        Assert.assertThrows(NoteDeletedException::class.java) {
+            result.getOrThrow()
+        }
+    }
+
+    @Test
+    fun get_ThrowsNoteNotFoundExceptionGiveNotExistsNote(): Unit = runBlocking {
+        val noteDataSource = InMemoryNoteDataSource()
+        val id = Note.Id(0L, "testId")
+        val result = noteDataSource.get(id)
+        Assert.assertThrows(NoteNotFoundException::class.java) {
+            result.getOrThrow()
+        }
+    }
+
+    @Test
+    fun get_ReturnsNoteGiveExistsNote(): Unit = runBlocking {
+        val noteDataSource = InMemoryNoteDataSource()
+        val id = Note.Id(0L, "testId")
+        val testNote = Note.make(id, User.Id(0L, "testUserId"))
+        noteDataSource.add(testNote)
+        val result = noteDataSource.get(id)
+        Assert.assertEquals(testNote, result.getOrThrow())
+    }
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
@@ -1,5 +1,6 @@
 package net.pantasystem.milktea.model.notes
 
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import net.pantasystem.milktea.model.Entity
 import net.pantasystem.milktea.model.EntityId
@@ -49,6 +50,7 @@ data class Note(
         val noteId: String
     ) : EntityId
 
+    companion object;
 
     /**
      * 引用リノートであるか
@@ -121,4 +123,54 @@ sealed class NoteRelation : JSerializable {
         override val files: List<FileProperty>?,
         val promotionId: String
     ) : NoteRelation()
+}
+
+fun Note.Companion.make(
+    id: Note.Id,
+    userId: User.Id,
+    createdAt: Instant = Clock.System.now(),
+    text: String? = null,
+    cw: String? = null,
+    replyId: Note.Id? = null,
+    renoteId: Note.Id? = null,
+    viaMobile: Boolean? = null,
+    visibility: Visibility = Visibility.Public(false),
+    localOnly: Boolean? = false,
+    visibleUserIds: List<User.Id>? = null,
+    url: String? = null,
+    uri: String? = null,
+    renoteCount: Int = 0,
+    reactionCounts: List<ReactionCount> = emptyList(),
+    emojis: List<Emoji>? = null,
+    repliesCount: Int = 0,
+    fileIds: List<FileProperty.Id>? = null,
+    poll: Poll? = null,
+    myReaction: String? = null,
+    app: AppType.Misskey? = null,
+    channelId: Channel.Id? = null,
+): Note {
+    return Note(
+        id = id,
+        userId = userId,
+        createdAt = createdAt,
+        text = text,
+        cw = cw,
+        replyId = replyId,
+        renoteId = renoteId,
+        viaMobile = viaMobile,
+        visibility = visibility,
+        localOnly = localOnly,
+        visibleUserIds = visibleUserIds,
+        url = url,
+        uri = uri,
+        renoteCount = renoteCount,
+        reactionCounts = reactionCounts,
+        emojis = emojis,
+        repliesCount = repliesCount,
+        fileIds = fileIds,
+        poll = poll,
+        myReaction = myReaction,
+        app = app,
+        channelId = channelId,
+    )
 }


### PR DESCRIPTION
## やったこと
NoteRepositoryのfindInを呼び出した時に、
削除済みであるにもかかわらずリクエストを呼び出してしまっていた問題を修正しました。
findInを呼び出した時にノートが存在しない場合、正しくリクエストを送信できていなかった問題を修正しました。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号


