### PR TITLE
インスタンス情報の画像のサイズをテキストと同一のサイズにするようにしました。

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/InstanceInfoHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/InstanceInfoHelper.kt
@@ -30,6 +30,7 @@ object InstanceInfoHelper {
             val iconDrawable = DrawableEmojiSpan(emojiAdapter)
             Glide.with(this)
                 .load(info!!.iconUrl)
+                .override(this.textSize.toInt())
                 .into(iconDrawable.target)
             text =  SpannableStringBuilder(":${info.iconUrl}:${info.name}").apply {
                 setSpan(iconDrawable, 0, ":${info.iconUrl}:".length, 0)


### PR DESCRIPTION
## やったこと
インスタンス情報の画像のサイズをテキストと同一のサイズにするようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #851



