### PR TITLE
インスタンス情報の色のパースに失敗してクラッシュする問題を修正

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/InstanceInfoHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/InstanceInfoHelper.kt
@@ -35,12 +35,12 @@ object InstanceInfoHelper {
             text =  SpannableStringBuilder(":${info.iconUrl}:${info.name}").apply {
                 setSpan(iconDrawable, 0, ":${info.iconUrl}:".length, 0)
             }
-            when(val color = info.themeColor) {
+            when(val color = info.themeColorNumber.getOrNull()) {
                 null -> {
 
                 }
                 else -> {
-                    val parsedColor = ColorUtils.setAlphaComponent(Color.parseColor(color), (255 * 0.42).toInt())
+                    val parsedColor = ColorUtils.setAlphaComponent(color, (255 * 0.42).toInt())
                     setBackgroundColor(parsedColor)
                     val isDark = ColorUtils.calculateLuminance(parsedColor) < 0.5
                     if (isDark) {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/User.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/User.kt
@@ -1,5 +1,6 @@
 package net.pantasystem.milktea.model.user
 
+import android.graphics.Color
 import net.pantasystem.milktea.model.Entity
 import net.pantasystem.milktea.model.EntityId
 import net.pantasystem.milktea.model.account.Account
@@ -101,7 +102,17 @@ sealed interface User : Entity {
         val softwareName: String?,
         val softwareVersion: String?,
         val themeColor: String?,
-    )
+    ) {
+
+        val themeColorNumber: Result<Int?> by lazy {
+            runCatching {
+                themeColor?.let {
+                    Color.parseColor(it)
+                }
+            }
+
+        }
+    }
 
     val displayUserName: String
         get() = "@" + this.userName + if (isSameHost) {


### PR DESCRIPTION
## やったこと
colorのパース時に失敗したエラーをハンドリングするようにしました。
またカラーのパースを失敗した時のエラーは無視して良いと判断できるエラーと考えそのまま握り潰すようにしました。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号

Closed #855

