### PR TITLE
クライアントワードミュート機能を実装

### DIFF
--- a/modules/data/schemas/net.pantasystem.milktea.data.infrastructure.DataBase/24.json
+++ b/modules/data/schemas/net.pantasystem.milktea.data.infrastructure.DataBase/24.json
@@ -1,0 +1,2759 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 24,
+    "identityHash": "0bdc3d0d1d4bb924d433f3c0ae7813c0",
+    "entities": [
+      {
+        "tableName": "connection_information",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` TEXT NOT NULL, `instanceBaseUrl` TEXT NOT NULL, `encryptedI` TEXT NOT NULL, `viaName` TEXT, `createdAt` TEXT NOT NULL, `isDirect` INTEGER NOT NULL, `updatedAt` TEXT NOT NULL, PRIMARY KEY(`accountId`, `encryptedI`, `instanceBaseUrl`), FOREIGN KEY(`accountId`) REFERENCES `Account`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceBaseUrl",
+            "columnName": "instanceBaseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "encryptedI",
+            "columnName": "encryptedI",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viaName",
+            "columnName": "viaName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDirect",
+            "columnName": "isDirect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "accountId",
+            "encryptedI",
+            "instanceBaseUrl"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Account",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reaction_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`reaction` TEXT NOT NULL, `instance_domain` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "reaction",
+            "columnName": "reaction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instance_domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Account",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "reaction_user_setting",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`reaction` TEXT NOT NULL, `instance_domain` TEXT NOT NULL, `weight` INTEGER NOT NULL, PRIMARY KEY(`reaction`, `instance_domain`))",
+        "fields": [
+          {
+            "fieldPath": "reaction",
+            "columnName": "reaction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instance_domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "reaction",
+            "instance_domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "page",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` TEXT, `title` TEXT NOT NULL, `pageNumber` INTEGER, `id` INTEGER PRIMARY KEY AUTOINCREMENT, `global_timeline_with_files` INTEGER, `global_timeline_type` TEXT, `local_timeline_with_files` INTEGER, `local_timeline_exclude_nsfw` INTEGER, `local_timeline_type` TEXT, `hybrid_timeline_withFiles` INTEGER, `hybrid_timeline_includeLocalRenotes` INTEGER, `hybrid_timeline_includeMyRenotes` INTEGER, `hybrid_timeline_includeRenotedMyRenotes` INTEGER, `hybrid_timeline_type` TEXT, `home_timeline_withFiles` INTEGER, `home_timeline_includeLocalRenotes` INTEGER, `home_timeline_includeMyRenotes` INTEGER, `home_timeline_includeRenotedMyRenotes` INTEGER, `home_timeline_type` TEXT, `user_list_timeline_listId` TEXT, `user_list_timeline_withFiles` INTEGER, `user_list_timeline_includeLocalRenotes` INTEGER, `user_list_timeline_includeMyRenotes` INTEGER, `user_list_timeline_includeRenotedMyRenotes` INTEGER, `user_list_timeline_type` TEXT, `mention_following` INTEGER, `mention_visibility` TEXT, `mention_type` TEXT, `show_noteId` TEXT, `show_type` TEXT, `tag_tag` TEXT, `tag_reply` INTEGER, `tag_renote` INTEGER, `tag_withFiles` INTEGER, `tag_poll` INTEGER, `tag_type` TEXT, `featured_offset` INTEGER, `featured_type` TEXT, `notification_following` INTEGER, `notification_markAsRead` INTEGER, `notification_type` TEXT, `user_userId` TEXT, `user_includeReplies` INTEGER, `user_includeMyRenotes` INTEGER, `user_withFiles` INTEGER, `user_type` TEXT, `search_query` TEXT, `search_host` TEXT, `search_userId` TEXT, `search_type` TEXT, `favorite_type` TEXT, `antenna_antennaId` TEXT, `antenna_type` TEXT, FOREIGN KEY(`accountId`) REFERENCES `Account`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageNumber",
+            "columnName": "pageNumber",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "globalTimeline.withFiles",
+            "columnName": "global_timeline_with_files",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "globalTimeline.type",
+            "columnName": "global_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localTimeline.withFiles",
+            "columnName": "local_timeline_with_files",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localTimeline.excludeNsfw",
+            "columnName": "local_timeline_exclude_nsfw",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localTimeline.type",
+            "columnName": "local_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.withFiles",
+            "columnName": "hybrid_timeline_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.includeLocalRenotes",
+            "columnName": "hybrid_timeline_includeLocalRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.includeMyRenotes",
+            "columnName": "hybrid_timeline_includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.includeRenotedMyRenotes",
+            "columnName": "hybrid_timeline_includeRenotedMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.type",
+            "columnName": "hybrid_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.withFiles",
+            "columnName": "home_timeline_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.includeLocalRenotes",
+            "columnName": "home_timeline_includeLocalRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.includeMyRenotes",
+            "columnName": "home_timeline_includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.includeRenotedMyRenotes",
+            "columnName": "home_timeline_includeRenotedMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.type",
+            "columnName": "home_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.listId",
+            "columnName": "user_list_timeline_listId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.withFiles",
+            "columnName": "user_list_timeline_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.includeLocalRenotes",
+            "columnName": "user_list_timeline_includeLocalRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.includeMyRenotes",
+            "columnName": "user_list_timeline_includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.includeRenotedMyRenotes",
+            "columnName": "user_list_timeline_includeRenotedMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.type",
+            "columnName": "user_list_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mention.following",
+            "columnName": "mention_following",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mention.visibility",
+            "columnName": "mention_visibility",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mention.type",
+            "columnName": "mention_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "show.noteId",
+            "columnName": "show_noteId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "show.type",
+            "columnName": "show_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.tag",
+            "columnName": "tag_tag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.reply",
+            "columnName": "tag_reply",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.renote",
+            "columnName": "tag_renote",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.withFiles",
+            "columnName": "tag_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.poll",
+            "columnName": "tag_poll",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.type",
+            "columnName": "tag_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "featured.offset",
+            "columnName": "featured_offset",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "featured.type",
+            "columnName": "featured_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notification.following",
+            "columnName": "notification_following",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notification.markAsRead",
+            "columnName": "notification_markAsRead",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notification.type",
+            "columnName": "notification_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.userId",
+            "columnName": "user_userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.includeReplies",
+            "columnName": "user_includeReplies",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.includeMyRenotes",
+            "columnName": "user_includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.withFiles",
+            "columnName": "user_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.type",
+            "columnName": "user_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "search.query",
+            "columnName": "search_query",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "search.host",
+            "columnName": "search_host",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "search.userId",
+            "columnName": "search_userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "search.type",
+            "columnName": "search_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "favorite.type",
+            "columnName": "favorite_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "antenna.antennaId",
+            "columnName": "antenna_antennaId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "antenna.type",
+            "columnName": "antenna_type",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_page_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Account",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "poll_choice_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`choice` TEXT NOT NULL, `draft_note_id` INTEGER NOT NULL, `weight` INTEGER NOT NULL, PRIMARY KEY(`choice`, `weight`, `draft_note_id`), FOREIGN KEY(`draft_note_id`) REFERENCES `draft_note_table`(`draft_note_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "choice",
+            "columnName": "choice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draft_note_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "choice",
+            "weight",
+            "draft_note_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_poll_choice_table_draft_note_id_choice",
+            "unique": false,
+            "columnNames": [
+              "draft_note_id",
+              "choice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_poll_choice_table_draft_note_id_choice` ON `${TABLE_NAME}` (`draft_note_id`, `choice`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "draft_note_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "draft_note_id"
+            ],
+            "referencedColumns": [
+              "draft_note_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_id",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `draft_note_id` INTEGER NOT NULL, PRIMARY KEY(`userId`, `draft_note_id`), FOREIGN KEY(`draft_note_id`) REFERENCES `draft_note_table`(`draft_note_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draft_note_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "userId",
+            "draft_note_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_user_id_draft_note_id",
+            "unique": false,
+            "columnNames": [
+              "draft_note_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_id_draft_note_id` ON `${TABLE_NAME}` (`draft_note_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "draft_note_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "draft_note_id"
+            ],
+            "referencedColumns": [
+              "draft_note_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "draft_file_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL DEFAULT 'name none', `remote_file_id` TEXT, `file_path` TEXT, `is_sensitive` INTEGER, `type` TEXT, `thumbnailUrl` TEXT, `draft_note_id` INTEGER NOT NULL, `folder_id` TEXT, `file_id` INTEGER PRIMARY KEY AUTOINCREMENT, FOREIGN KEY(`draft_note_id`) REFERENCES `draft_note_table`(`draft_note_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'name none'"
+          },
+          {
+            "fieldPath": "remoteFileId",
+            "columnName": "remote_file_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isSensitive",
+            "columnName": "is_sensitive",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draft_note_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folder_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fileId",
+            "columnName": "file_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "file_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_draft_file_table_draft_note_id",
+            "unique": false,
+            "columnNames": [
+              "draft_note_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_file_table_draft_note_id` ON `${TABLE_NAME}` (`draft_note_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "draft_note_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "draft_note_id"
+            ],
+            "referencedColumns": [
+              "draft_note_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "draft_note_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `visibility` TEXT NOT NULL, `text` TEXT, `cw` TEXT, `viaMobile` INTEGER, `localOnly` INTEGER, `noExtractMentions` INTEGER, `noExtractHashtags` INTEGER, `noExtractEmojis` INTEGER, `replyId` TEXT, `renoteId` TEXT, `channelId` TEXT, `scheduleWillPostAt` TEXT, `draft_note_id` INTEGER PRIMARY KEY AUTOINCREMENT, `multiple` INTEGER, `expiresAt` INTEGER, FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cw",
+            "columnName": "cw",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "viaMobile",
+            "columnName": "viaMobile",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localOnly",
+            "columnName": "localOnly",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noExtractMentions",
+            "columnName": "noExtractMentions",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noExtractHashtags",
+            "columnName": "noExtractHashtags",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noExtractEmojis",
+            "columnName": "noExtractEmojis",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "replyId",
+            "columnName": "replyId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "renoteId",
+            "columnName": "renoteId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "scheduleWillPostAt",
+            "columnName": "scheduleWillPostAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draft_note_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "poll.multiple",
+            "columnName": "multiple",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "poll.expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "draft_note_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_draft_note_table_accountId_text",
+            "unique": false,
+            "columnNames": [
+              "accountId",
+              "text"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_note_table_accountId_text` ON `${TABLE_NAME}` (`accountId`, `text`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "url_preview",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `title` TEXT NOT NULL, `icon` TEXT, `description` TEXT, `thumbnail` TEXT, `siteName` TEXT, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnail",
+            "columnName": "thumbnail",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "siteName",
+            "columnName": "siteName",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "url"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "account_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`remoteId` TEXT NOT NULL, `instanceDomain` TEXT NOT NULL, `userName` TEXT NOT NULL, `encryptedToken` TEXT NOT NULL, `instanceType` TEXT NOT NULL DEFAULT 'misskey', `accountId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instanceDomain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "userName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "encryptedToken",
+            "columnName": "encryptedToken",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceType",
+            "columnName": "instanceType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'misskey'"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "accountId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_account_table_remoteId",
+            "unique": false,
+            "columnNames": [
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_table_remoteId` ON `${TABLE_NAME}` (`remoteId`)"
+          },
+          {
+            "name": "index_account_table_instanceDomain",
+            "unique": false,
+            "columnNames": [
+              "instanceDomain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_table_instanceDomain` ON `${TABLE_NAME}` (`instanceDomain`)"
+          },
+          {
+            "name": "index_account_table_userName",
+            "unique": false,
+            "columnNames": [
+              "userName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_table_userName` ON `${TABLE_NAME}` (`userName`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "page_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `title` TEXT NOT NULL, `weight` INTEGER NOT NULL, `pageId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `withFiles` INTEGER, `excludeNsfw` INTEGER, `includeLocalRenotes` INTEGER, `includeMyRenotes` INTEGER, `includeRenotedMyRenotes` INTEGER, `listId` TEXT, `following` INTEGER, `visibility` TEXT, `noteId` TEXT, `tag` TEXT, `reply` INTEGER, `renote` INTEGER, `poll` INTEGER, `offset` INTEGER, `markAsRead` INTEGER, `userId` TEXT, `includeReplies` INTEGER, `query` TEXT, `host` TEXT, `antennaId` TEXT, `channelId` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageId",
+            "columnName": "pageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageParams.type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageParams.withFiles",
+            "columnName": "withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.excludeNsfw",
+            "columnName": "excludeNsfw",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.includeLocalRenotes",
+            "columnName": "includeLocalRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.includeMyRenotes",
+            "columnName": "includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.includeRenotedMyRenotes",
+            "columnName": "includeRenotedMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.listId",
+            "columnName": "listId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.following",
+            "columnName": "following",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.visibility",
+            "columnName": "visibility",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.reply",
+            "columnName": "reply",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.renote",
+            "columnName": "renote",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.poll",
+            "columnName": "poll",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.offset",
+            "columnName": "offset",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.markAsRead",
+            "columnName": "markAsRead",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.includeReplies",
+            "columnName": "includeReplies",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.antennaId",
+            "columnName": "antennaId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "pageId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_page_table_weight",
+            "unique": false,
+            "columnNames": [
+              "weight"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_table_weight` ON `${TABLE_NAME}` (`weight`)"
+          },
+          {
+            "name": "index_page_table_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_table_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "meta_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uri` TEXT NOT NULL, `bannerUrl` TEXT, `cacheRemoteFiles` INTEGER, `description` TEXT, `disableGlobalTimeline` INTEGER, `disableLocalTimeline` INTEGER, `disableRegistration` INTEGER, `driveCapacityPerLocalUserMb` INTEGER, `driveCapacityPerRemoteUserMb` INTEGER, `enableDiscordIntegration` INTEGER, `enableEmail` INTEGER, `enableEmojiReaction` INTEGER, `enableGithubIntegration` INTEGER, `enableRecaptcha` INTEGER, `enableServiceWorker` INTEGER, `enableTwitterIntegration` INTEGER, `errorImageUrl` TEXT, `feedbackUrl` TEXT, `iconUrl` TEXT, `maintainerEmail` TEXT, `maintainerName` TEXT, `mascotImageUrl` TEXT, `maxNoteTextLength` INTEGER, `name` TEXT, `recaptchaSiteKey` TEXT, `secure` INTEGER, `swPublicKey` TEXT, `toSUrl` TEXT, `version` TEXT NOT NULL, PRIMARY KEY(`uri`))",
+        "fields": [
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bannerUrl",
+            "columnName": "bannerUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cacheRemoteFiles",
+            "columnName": "cacheRemoteFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "disableGlobalTimeline",
+            "columnName": "disableGlobalTimeline",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "disableLocalTimeline",
+            "columnName": "disableLocalTimeline",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "disableRegistration",
+            "columnName": "disableRegistration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "driveCapacityPerLocalUserMb",
+            "columnName": "driveCapacityPerLocalUserMb",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "driveCapacityPerRemoteUserMb",
+            "columnName": "driveCapacityPerRemoteUserMb",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableDiscordIntegration",
+            "columnName": "enableDiscordIntegration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableEmail",
+            "columnName": "enableEmail",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableEmojiReaction",
+            "columnName": "enableEmojiReaction",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableGithubIntegration",
+            "columnName": "enableGithubIntegration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableRecaptcha",
+            "columnName": "enableRecaptcha",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableServiceWorker",
+            "columnName": "enableServiceWorker",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableTwitterIntegration",
+            "columnName": "enableTwitterIntegration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "errorImageUrl",
+            "columnName": "errorImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "feedbackUrl",
+            "columnName": "feedbackUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "iconUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maintainerEmail",
+            "columnName": "maintainerEmail",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maintainerName",
+            "columnName": "maintainerName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mascotImageUrl",
+            "columnName": "mascotImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxNoteTextLength",
+            "columnName": "maxNoteTextLength",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recaptchaSiteKey",
+            "columnName": "recaptchaSiteKey",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "secure",
+            "columnName": "secure",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "swPublicKey",
+            "columnName": "swPublicKey",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "toSUrl",
+            "columnName": "toSUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uri"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "emoji_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `instanceDomain` TEXT NOT NULL, `host` TEXT, `url` TEXT, `uri` TEXT, `type` TEXT, `category` TEXT, `id` TEXT, PRIMARY KEY(`name`, `instanceDomain`), FOREIGN KEY(`instanceDomain`) REFERENCES `meta_table`(`uri`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instanceDomain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "name",
+            "instanceDomain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_emoji_table_instanceDomain",
+            "unique": false,
+            "columnNames": [
+              "instanceDomain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_emoji_table_instanceDomain` ON `${TABLE_NAME}` (`instanceDomain`)"
+          },
+          {
+            "name": "index_emoji_table_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_emoji_table_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meta_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "instanceDomain"
+            ],
+            "referencedColumns": [
+              "uri"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "emoji_alias_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `name` TEXT NOT NULL, `instanceDomain` TEXT NOT NULL, PRIMARY KEY(`alias`, `name`, `instanceDomain`), FOREIGN KEY(`name`, `instanceDomain`) REFERENCES `emoji_table`(`name`, `instanceDomain`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instanceDomain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "alias",
+            "name",
+            "instanceDomain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_emoji_alias_table_name_instanceDomain",
+            "unique": false,
+            "columnNames": [
+              "name",
+              "instanceDomain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_emoji_alias_table_name_instanceDomain` ON `${TABLE_NAME}` (`name`, `instanceDomain`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "emoji_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "name",
+              "instanceDomain"
+            ],
+            "referencedColumns": [
+              "name",
+              "instanceDomain"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "unread_notifications_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `notificationId` TEXT NOT NULL, PRIMARY KEY(`accountId`, `notificationId`), FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationId",
+            "columnName": "notificationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "accountId",
+            "notificationId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "nicknames",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`nickname` TEXT NOT NULL, `username` TEXT NOT NULL, `host` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_nicknames_username_host",
+            "unique": true,
+            "columnNames": [
+              "username",
+              "host"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_nicknames_username_host` ON `${TABLE_NAME}` (`username`, `host`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "utf8_emojis_by_amio",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`codes` TEXT NOT NULL, `name` TEXT NOT NULL, `char` TEXT NOT NULL, PRIMARY KEY(`codes`))",
+        "fields": [
+          {
+            "fieldPath": "codes",
+            "columnName": "codes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charCode",
+            "columnName": "char",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "codes"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "drive_file_v1",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `relatedAccountId` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `md5` TEXT NOT NULL, `size` INTEGER NOT NULL, `url` TEXT NOT NULL, `isSensitive` INTEGER NOT NULL, `thumbnailUrl` TEXT, `folderId` TEXT, `userId` TEXT, `comment` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`relatedAccountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatedAccountId",
+            "columnName": "relatedAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "md5",
+            "columnName": "md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSensitive",
+            "columnName": "isSensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_drive_file_v1_serverId_relatedAccountId",
+            "unique": true,
+            "columnNames": [
+              "serverId",
+              "relatedAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_drive_file_v1_serverId_relatedAccountId` ON `${TABLE_NAME}` (`serverId`, `relatedAccountId`)"
+          },
+          {
+            "name": "index_drive_file_v1_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drive_file_v1_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_drive_file_v1_relatedAccountId",
+            "unique": false,
+            "columnNames": [
+              "relatedAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drive_file_v1_relatedAccountId` ON `${TABLE_NAME}` (`relatedAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "relatedAccountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "draft_file_v2_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`draftNoteId` INTEGER NOT NULL, `filePropertyId` INTEGER, `localFileId` INTEGER, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`filePropertyId`) REFERENCES `drive_file_v1`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`localFileId`) REFERENCES `draft_local_file_v2_table`(`localFileId`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draftNoteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePropertyId",
+            "columnName": "filePropertyId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localFileId",
+            "columnName": "localFileId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_draft_file_v2_table_draftNoteId_filePropertyId_localFileId",
+            "unique": true,
+            "columnNames": [
+              "draftNoteId",
+              "filePropertyId",
+              "localFileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_draft_file_v2_table_draftNoteId_filePropertyId_localFileId` ON `${TABLE_NAME}` (`draftNoteId`, `filePropertyId`, `localFileId`)"
+          },
+          {
+            "name": "index_draft_file_v2_table_draftNoteId",
+            "unique": false,
+            "columnNames": [
+              "draftNoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_file_v2_table_draftNoteId` ON `${TABLE_NAME}` (`draftNoteId`)"
+          },
+          {
+            "name": "index_draft_file_v2_table_localFileId",
+            "unique": false,
+            "columnNames": [
+              "localFileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_file_v2_table_localFileId` ON `${TABLE_NAME}` (`localFileId`)"
+          },
+          {
+            "name": "index_draft_file_v2_table_filePropertyId",
+            "unique": false,
+            "columnNames": [
+              "filePropertyId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_file_v2_table_filePropertyId` ON `${TABLE_NAME}` (`filePropertyId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "drive_file_v1",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "filePropertyId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "draft_local_file_v2_table",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "localFileId"
+            ],
+            "referencedColumns": [
+              "localFileId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "draft_local_file_v2_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `file_path` TEXT NOT NULL, `is_sensitive` INTEGER, `type` TEXT NOT NULL, `thumbnailUrl` TEXT, `folder_id` TEXT, `localFileId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSensitive",
+            "columnName": "is_sensitive",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folder_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localFileId",
+            "columnName": "localFileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localFileId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "group_v1",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `name` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_group_v1_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_v1_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_group_v1_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_v1_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_group_v1_accountId_serverId",
+            "unique": true,
+            "columnNames": [
+              "accountId",
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_group_v1_accountId_serverId` ON `${TABLE_NAME}` (`accountId`, `serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "group_member_v1",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `userId` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`groupId`) REFERENCES `group_v1`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_group_member_v1_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_member_v1_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_group_member_v1_groupId_userId",
+            "unique": true,
+            "columnNames": [
+              "groupId",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_group_member_v1_groupId_userId` ON `${TABLE_NAME}` (`groupId`, `userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "group_v1",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `userName` TEXT NOT NULL, `name` TEXT, `avatarUrl` TEXT, `isCat` INTEGER, `isBot` INTEGER, `host` TEXT NOT NULL, `isSameHost` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "userName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isCat",
+            "columnName": "isCat",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isBot",
+            "columnName": "isBot",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSameHost",
+            "columnName": "isSameHost",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_user_serverId_accountId",
+            "unique": true,
+            "columnNames": [
+              "serverId",
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_serverId_accountId` ON `${TABLE_NAME}` (`serverId`, `accountId`)"
+          },
+          {
+            "name": "index_user_userName",
+            "unique": false,
+            "columnNames": [
+              "userName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_userName` ON `${TABLE_NAME}` (`userName`)"
+          },
+          {
+            "name": "index_user_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_user_host",
+            "unique": false,
+            "columnNames": [
+              "host"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_host` ON `${TABLE_NAME}` (`host`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_detailed_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`description` TEXT, `followersCount` INTEGER, `followingCount` INTEGER, `hostLower` TEXT, `notesCount` INTEGER, `bannerUrl` TEXT, `url` TEXT, `isFollowing` INTEGER NOT NULL, `isFollower` INTEGER NOT NULL, `isBlocking` INTEGER NOT NULL, `isMuting` INTEGER NOT NULL, `hasPendingFollowRequestFromYou` INTEGER NOT NULL, `hasPendingFollowRequestToYou` INTEGER NOT NULL, `isLocked` INTEGER NOT NULL, `birthday` TEXT, `createdAt` TEXT, `updatedAt` TEXT, `userId` INTEGER NOT NULL, PRIMARY KEY(`userId`), FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followersCount",
+            "columnName": "followersCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followingCount",
+            "columnName": "followingCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hostLower",
+            "columnName": "hostLower",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesCount",
+            "columnName": "notesCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bannerUrl",
+            "columnName": "bannerUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isFollowing",
+            "columnName": "isFollowing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFollower",
+            "columnName": "isFollower",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBlocking",
+            "columnName": "isBlocking",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMuting",
+            "columnName": "isMuting",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasPendingFollowRequestFromYou",
+            "columnName": "hasPendingFollowRequestFromYou",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasPendingFollowRequestToYou",
+            "columnName": "hasPendingFollowRequestToYou",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLocked",
+            "columnName": "isLocked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "birthday",
+            "columnName": "birthday",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "userId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_user_detailed_state_userId",
+            "unique": true,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_detailed_state_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_emoji",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `url` TEXT, `uri` TEXT, `userId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_user_emoji_name_userId",
+            "unique": true,
+            "columnNames": [
+              "name",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_emoji_name_userId` ON `${TABLE_NAME}` (`name`, `userId`)"
+          },
+          {
+            "name": "index_user_emoji_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_emoji_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pinned_note_id",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`noteId` TEXT NOT NULL, `userId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_pinned_note_id_noteId_userId",
+            "unique": true,
+            "columnNames": [
+              "noteId",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_pinned_note_id_noteId_userId` ON `${TABLE_NAME}` (`noteId`, `userId`)"
+          },
+          {
+            "name": "index_pinned_note_id_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pinned_note_id_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_instance_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`faviconUrl` TEXT, `iconUrl` TEXT, `name` TEXT, `softwareName` TEXT, `softwareVersion` TEXT, `themeColor` TEXT, `userId` INTEGER NOT NULL, PRIMARY KEY(`userId`), FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "faviconUrl",
+            "columnName": "faviconUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "iconUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "softwareName",
+            "columnName": "softwareName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "softwareVersion",
+            "columnName": "softwareVersion",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "userId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_user_instance_info_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_instance_info_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile_field",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `value` TEXT NOT NULL, `userId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_user_profile_field_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_profile_field_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "word_filter_condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "word_filter_regex_condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pattern` TEXT NOT NULL, `parentId` INTEGER NOT NULL, PRIMARY KEY(`parentId`), FOREIGN KEY(`parentId`) REFERENCES `word_filter_condition`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "pattern",
+            "columnName": "pattern",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "parentId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_word_filter_regex_condition_parentId",
+            "unique": false,
+            "columnNames": [
+              "parentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_word_filter_regex_condition_parentId` ON `${TABLE_NAME}` (`parentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "word_filter_condition",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "parentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "word_filter_word_condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`word` TEXT NOT NULL, `parentId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`parentId`) REFERENCES `word_filter_condition`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "word",
+            "columnName": "word",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_word_filter_word_condition_parentId",
+            "unique": false,
+            "columnNames": [
+              "parentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_word_filter_word_condition_parentId` ON `${TABLE_NAME}` (`parentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "word_filter_condition",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "parentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [
+      {
+        "viewName": "user_view",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS select user.*, nicknames.nickname from user left join nicknames on user.userName = nicknames.username and user.host = nicknames.host"
+      },
+      {
+        "viewName": "group_member_view",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS select m.groupId, u.id as userId, u.avatarUrl, u.serverId from group_member_v1 as m \n            inner join group_v1 as g\n            inner join user as u\n            on m.groupId = g.id\n                and m.userId = u.serverId\n                and g.accountId = u.accountId"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0bdc3d0d1d4bb924d433f3c0ae7813c0')"
+    ]
+  }
+}

--- a/modules/data/src/androidTest/java/net/pantasystem/milktea/data/infrastructure/notes/wordmute/WordFilterConfigRepositoryImplTest.kt
+++ b/modules/data/src/androidTest/java/net/pantasystem/milktea/data/infrastructure/notes/wordmute/WordFilterConfigRepositoryImplTest.kt
@@ -1,0 +1,68 @@
+package net.pantasystem.milktea.data.infrastructure.notes.wordmute
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import net.pantasystem.milktea.common.Logger
+import net.pantasystem.milktea.data.infrastructure.DataBase
+import net.pantasystem.milktea.model.notes.muteword.FilterConditionType
+import net.pantasystem.milktea.model.notes.muteword.WordFilterConfig
+import net.pantasystem.milktea.model.notes.muteword.WordFilterConfigRepository
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class WordFilterConfigRepositoryImplTest {
+
+    lateinit var repository: WordFilterConfigRepository
+    lateinit var scope: CoroutineScope
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        scope = CoroutineScope(SupervisorJob())
+        val database = Room.inMemoryDatabaseBuilder(context, DataBase::class.java).build()
+        repository = WordFilterConfigRepositoryImpl(scope, database.wordFilterConfigDao(), object : Logger.Factory {
+            override fun create(tag: String): Logger {
+                return object : Logger {
+                    override val defaultTag: String
+                        get() = ""
+
+                    override fun debug(msg: String, tag: String, e: Throwable?) {
+                    }
+
+                    override fun error(msg: String, e: Throwable?, tag: String) {
+                    }
+
+                    override fun info(msg: String, tag: String, e: Throwable?) {
+                    }
+
+                    override fun warning(msg: String, tag: String, e: Throwable?) {
+                    }
+
+                }
+            }
+
+        })
+    }
+
+    @Test
+    fun saveAndGet() {
+        val config = WordFilterConfig(
+            listOf(
+                FilterConditionType.Normal(listOf("hoge", "fizz", "panta")),
+                FilterConditionType.Normal(listOf("piyo", "buzz")),
+                FilterConditionType.Normal(listOf("fuga", "moga")),
+                FilterConditionType.Regex("\\hogepiyo\\")
+            )
+        )
+        runBlocking {
+            repository.save(config).getOrThrow()
+            Assert.assertEquals(config, repository.get().getOrThrow())
+
+        }
+
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/DbModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/DbModule.kt
@@ -12,6 +12,7 @@ import net.pantasystem.milktea.data.infrastructure.account.db.AccountDAO
 import net.pantasystem.milktea.data.infrastructure.drive.DriveFileRecordDao
 import net.pantasystem.milktea.data.infrastructure.group.GroupDao
 import net.pantasystem.milktea.data.infrastructure.notes.draft.db.DraftNoteDao
+import net.pantasystem.milktea.data.infrastructure.notes.wordmute.WordFilterConfigDao
 import net.pantasystem.milktea.data.infrastructure.notification.db.UnreadNotificationDAO
 import net.pantasystem.milktea.data.infrastructure.url.db.UrlPreviewDAO
 import net.pantasystem.milktea.data.infrastructure.user.UserNicknameDAO
@@ -86,4 +87,8 @@ object DbModule {
     @Provides
     @Singleton
     fun provideUserDao(db: DataBase): UserDao = db.userDao()
+
+    @Provides
+    @Singleton
+    fun provideWordFilterDao(db: DataBase): WordFilterConfigDao = db.wordFilterConfigDao()
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/WordFilterConfigModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/WordFilterConfigModule.kt
@@ -1,0 +1,20 @@
+package net.pantasystem.milktea.data.di.module
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import net.pantasystem.milktea.data.infrastructure.notes.wordmute.WordFilterConfigRepositoryImpl
+import net.pantasystem.milktea.model.notes.muteword.WordFilterConfigRepository
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class WordFilterConfigModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindWordFilterConfigRepository(impl: WordFilterConfigRepositoryImpl): WordFilterConfigRepository
+
+
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/DataBase.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/DataBase.kt
@@ -20,6 +20,10 @@ import net.pantasystem.milktea.data.infrastructure.group.GroupMemberView
 import net.pantasystem.milktea.data.infrastructure.group.GroupRecord
 import net.pantasystem.milktea.data.infrastructure.instance.db.*
 import net.pantasystem.milktea.data.infrastructure.notes.draft.db.*
+import net.pantasystem.milktea.data.infrastructure.notes.wordmute.WordFilterConditionRecord
+import net.pantasystem.milktea.data.infrastructure.notes.wordmute.WordFilterConditionRegexRecord
+import net.pantasystem.milktea.data.infrastructure.notes.wordmute.WordFilterConditionWordRecord
+import net.pantasystem.milktea.data.infrastructure.notes.wordmute.WordFilterConfigDao
 import net.pantasystem.milktea.data.infrastructure.notification.db.UnreadNotification
 import net.pantasystem.milktea.data.infrastructure.notification.db.UnreadNotificationDAO
 import net.pantasystem.milktea.data.infrastructure.url.db.UrlPreviewDAO
@@ -65,8 +69,12 @@ import net.pantasystem.milktea.model.url.UrlPreview
         PinnedNoteIdRecord::class,
         UserInstanceInfoRecord::class,
         UserProfileFieldRecord::class,
+
+        WordFilterConditionRecord::class,
+        WordFilterConditionRegexRecord::class,
+        WordFilterConditionWordRecord::class,
     ],
-    version = 23,
+    version = 24,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 11, to = 12),
@@ -81,6 +89,7 @@ import net.pantasystem.milktea.model.url.UrlPreview
         AutoMigration(from = 20, to = 21),
         AutoMigration(from = 21, to = 22),
         AutoMigration(from = 22, to = 23),
+        AutoMigration(from = 23, to = 24)
     ],
     views = [UserView::class, GroupMemberView::class,]
 )
@@ -125,4 +134,6 @@ abstract class DataBase : RoomDatabase() {
     abstract fun groupDao(): GroupDao
 
     abstract fun userDao(): UserDao
+
+    abstract fun wordFilterConfigDao(): WordFilterConfigDao
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/wordmute/WordFilterConditionRecord.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/wordmute/WordFilterConditionRecord.kt
@@ -1,0 +1,67 @@
+package net.pantasystem.milktea.data.infrastructure.notes.wordmute
+
+import androidx.room.*
+import net.pantasystem.milktea.model.notes.muteword.FilterConditionType
+import net.pantasystem.milktea.model.notes.muteword.WordFilterConfig
+
+@Entity(
+    tableName = "word_filter_condition"
+)
+data class WordFilterConditionRecord(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0L
+)
+
+@Entity(
+    tableName = "word_filter_regex_condition",
+    foreignKeys = [
+        ForeignKey(
+            entity = WordFilterConditionRecord::class,
+            parentColumns = ["id"],
+            childColumns = ["parentId"],
+            onDelete = ForeignKey.CASCADE,
+            onUpdate = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("parentId")]
+)
+data class WordFilterConditionRegexRecord(
+    val pattern: String,
+    @PrimaryKey(autoGenerate = false) val parentId: Long = 0L
+)
+
+@Entity(
+    tableName = "word_filter_word_condition",
+    foreignKeys = [
+        ForeignKey(
+            entity = WordFilterConditionRecord::class,
+            parentColumns = ["id"],
+            childColumns = ["parentId"],
+            onDelete = ForeignKey.CASCADE,
+            onUpdate = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("parentId")]
+)
+data class WordFilterConditionWordRecord(
+    val word: String,
+    val parentId: Long,
+    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
+)
+
+data class WordFilterConditionRelated(
+    @Embedded val condition: WordFilterConditionRecord,
+    @Relation(parentColumn = "id", entityColumn = "parentId")
+    val regexRecord: WordFilterConditionRegexRecord?,
+    @Relation(parentColumn = "id", entityColumn = "parentId")
+    val words: List<WordFilterConditionWordRecord>
+)
+
+fun List<WordFilterConditionRelated>.toModel(): WordFilterConfig {
+    return WordFilterConfig(map { related ->
+        if (related.regexRecord == null) {
+            FilterConditionType.Normal(related.words.map { it.word })
+        } else {
+            FilterConditionType.Regex(related.regexRecord.pattern)
+        }
+    })
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/wordmute/WordFilterConfigDao.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/wordmute/WordFilterConfigDao.kt
@@ -1,0 +1,28 @@
+package net.pantasystem.milktea.data.infrastructure.notes.wordmute
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface WordFilterConfigDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(conditions: List<WordFilterConditionRecord>): List<Long>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertRegexList(regexList: List<WordFilterConditionRegexRecord>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertWords(words: List<WordFilterConditionWordRecord>): List<Long>
+
+    @Query("select * from word_filter_condition order by id asc")
+    @Transaction
+    suspend fun findAll(): List<WordFilterConditionRelated>
+
+    @Query("select * from word_filter_condition order by id asc")
+    @Transaction
+    fun observeAll(): Flow<List<WordFilterConditionRelated>>
+
+    @Query("delete from word_filter_condition")
+    suspend fun clear()
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/wordmute/WordFilterConfigDao.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/wordmute/WordFilterConfigDao.kt
@@ -10,7 +10,7 @@ interface WordFilterConfigDao {
     suspend fun insertAll(conditions: List<WordFilterConditionRecord>): List<Long>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertRegexList(regexList: List<WordFilterConditionRegexRecord>)
+    suspend fun insertRegex(regex: WordFilterConditionRegexRecord)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertWords(words: List<WordFilterConditionWordRecord>): List<Long>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/wordmute/WordFilterConfigRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/wordmute/WordFilterConfigRepositoryImpl.kt
@@ -1,0 +1,67 @@
+package net.pantasystem.milktea.data.infrastructure.notes.wordmute
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.withContext
+import net.pantasystem.milktea.common.BuildConfig
+import net.pantasystem.milktea.common.Logger
+import net.pantasystem.milktea.model.notes.muteword.FilterConditionType
+import net.pantasystem.milktea.model.notes.muteword.WordFilterConfig
+import net.pantasystem.milktea.model.notes.muteword.WordFilterConfigRepository
+import javax.inject.Inject
+
+class WordFilterConfigRepositoryImpl @Inject constructor(
+    coroutineScope: CoroutineScope,
+    private val wordFilterConfigDao: WordFilterConfigDao,
+    loggerFactory: Logger.Factory
+) : WordFilterConfigRepository {
+
+    val logger = loggerFactory.create("WordFilterConfigRepositoryImpl")
+
+    private val shared = wordFilterConfigDao.observeAll().map {
+        it.toModel()
+    }.catch {
+        logger.error("observe error", it)
+    }.flowOn(Dispatchers.IO).stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    override suspend fun get(): Result<WordFilterConfig> = runCatching{
+        withContext(Dispatchers.IO) {
+            wordFilterConfigDao.findAll().toModel()
+        }
+    }
+
+    override fun observe(): Flow<WordFilterConfig> {
+        return shared.filterNotNull()
+    }
+
+    override suspend fun save(config: WordFilterConfig): Result<Unit> = runCatching {
+        withContext(Dispatchers.IO) {
+            wordFilterConfigDao.clear()
+            val records = config.conditions.map {
+                WordFilterConditionRecord()
+            }
+            val ids = wordFilterConfigDao.insertAll(records)
+            config.conditions.forEachIndexed { index, filterConditionType ->
+                val id = ids[index]
+                when(filterConditionType) {
+                    is FilterConditionType.Normal -> {
+                        val wordRecords = filterConditionType.words.map {
+                            WordFilterConditionWordRecord(it, parentId = id)
+                        }
+                        wordFilterConfigDao.insertWords(wordRecords)
+                    }
+                    is FilterConditionType.Regex -> {
+                        wordFilterConfigDao.insertRegex(WordFilterConditionRegexRecord(filterConditionType.pattern, id))
+                    }
+                }
+            }
+            if (BuildConfig.DEBUG) {
+                val dbModel = wordFilterConfigDao.findAll().toModel()
+                require(dbModel == config) {
+                    "正常に保存できていない可能性 db:$dbModel, args:$config"
+                }
+            }
+        }
+    }
+}

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -26,6 +26,7 @@ import net.pantasystem.milktea.model.account.CurrentAccountWatcher
 import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.model.notes.NoteCaptureAPIAdapter
 import net.pantasystem.milktea.model.notes.NoteStreaming
+import net.pantasystem.milktea.model.notes.muteword.WordFilterConfigRepository
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewDataCache
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -39,6 +40,7 @@ class TimelineViewModel @AssistedInject constructor(
     noteTranslationStore: NoteTranslationStore,
     private val urlPreviewStoreProvider: UrlPreviewStoreProvider,
     private val accountStore: AccountStore,
+    private val wordFilterConfigRepository: WordFilterConfigRepository,
     @Assisted val account: Account?,
     @Assisted val accountId: Long? = account?.accountId,
     @Assisted val pageable: Pageable,

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -73,6 +73,17 @@ class TimelineViewModel @AssistedInject constructor(
         pageableState.suspendConvert { list ->
             cache.getByIds(list)
         }
+    }.flatMapLatest { state ->
+        wordFilterConfigRepository.observe().distinctUntilChanged().map { config ->
+            state.suspendConvert { notes ->
+                notes.filterNot {
+                    config.checkMatchText(it.text)
+                            || config.checkMatchText(it.cw)
+                            || config.checkMatchText(it.subNote?.note?.text)
+                            || config.checkMatchText(it.subNote?.note?.cw)
+                }
+            }
+        }
     }.stateIn(viewModelScope + Dispatchers.IO, SharingStarted.Lazily, PageableState.Loading.Init())
 
 

--- a/modules/features/setting/build.gradle
+++ b/modules/features/setting/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     implementation libs.androidx.core.ktx
     implementation libs.appcompat.appcompat
     implementation libs.android.material.material
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'com.google.android.material:material:1.4.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/modules/features/setting/src/main/AndroidManifest.xml
+++ b/modules/features/setting/src/main/AndroidManifest.xml
@@ -2,4 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="net.pantasystem.milktea.setting">
 
+    <application>
+        <activity
+                android:name="net.pantasystem.milktea.setting.activities.ClientWordFilterSettingActivity"
+                android:exported="false" />
+    </application>
+
 </manifest>

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ClientWordFilterSettingActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ClientWordFilterSettingActivity.kt
@@ -1,0 +1,75 @@
+package net.pantasystem.milktea.setting.activities
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.google.android.material.composethemeadapter.MdcTheme
+import dagger.hilt.android.AndroidEntryPoint
+import net.pantasystem.milktea.common.ui.ApplyTheme
+import net.pantasystem.milktea.setting.R
+import net.pantasystem.milktea.setting.viewmodel.muteword.ClientWordFilterSettingViewModel
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class ClientWordFilterSettingActivity : AppCompatActivity() {
+
+
+    @Inject
+    lateinit var applyTheme: ApplyTheme
+
+    private val viewModel by viewModels<ClientWordFilterSettingViewModel>()
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        applyTheme()
+        setContent {
+            MdcTheme {
+                Scaffold(
+                    topBar = {
+                        TopAppBar(
+                            title = {
+                                Text(stringResource(id = R.string.client_word_mute))
+                            },
+                            navigationIcon = {
+                                IconButton(onClick = { finish() }) {
+                                    Icon(Icons.Default.ArrowBack, null)
+                                }
+                            }
+                        )
+                    },
+                    floatingActionButton = {
+                        FloatingActionButton(onClick = { viewModel.save() }) {
+                            Icon(Icons.Default.Save, contentDescription = "Save")
+                        }
+                    }
+                ) {
+                    LazyColumn(Modifier.padding(it)) {
+                        item {
+                            OutlinedTextField(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                value = viewModel.muteWordsFieldState,
+                                onValueChange = {
+                                viewModel.updateText(it)
+                            })
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingsActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingsActivity.kt
@@ -80,6 +80,15 @@ class SettingsActivity : AppCompatActivity() {
             }
         }
 
+        val clientMuteWordSetting = MoveSettingActivityPanel(
+            titleStringRes = R.string.client_word_mute,
+            activity = ClientWordFilterSettingActivity::class.java,
+            context = this
+        ).apply {
+            startActivityEventBus.observe(this@SettingsActivity) {
+                startActivity(Intent(this@SettingsActivity, it))
+            }
+        }
 
         val licenseActivitySetting =
             MoveSettingActivityPanel(
@@ -102,6 +111,7 @@ class SettingsActivity : AppCompatActivity() {
                 appearanceSetting,
                 securitySetting,
                 reactionSetting,
+                clientMuteWordSetting,
                 licenseActivitySetting
             )
         )

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/muteword/ClientWordFilterSettingViewModel.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/muteword/ClientWordFilterSettingViewModel.kt
@@ -1,0 +1,47 @@
+package net.pantasystem.milktea.setting.viewmodel.muteword
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import net.pantasystem.milktea.model.notes.muteword.WordFilterConfigRepository
+import net.pantasystem.milktea.model.notes.muteword.WordFilterConfigTextParser
+import javax.inject.Inject
+
+@HiltViewModel
+class ClientWordFilterSettingViewModel @Inject constructor(
+    private val repository: WordFilterConfigRepository
+) : ViewModel() {
+
+
+    var muteWordsFieldState by mutableStateOf("")
+        private set
+
+    init {
+        viewModelScope.launch {
+            repository.get().mapCatching {
+                WordFilterConfigTextParser.fromConfig(it).getOrThrow()
+            }.onSuccess {
+                muteWordsFieldState = it
+            }
+        }
+    }
+
+    fun updateText(text: String) {
+        muteWordsFieldState = text
+    }
+
+    fun save() {
+        viewModelScope.launch {
+            WordFilterConfigTextParser.fromText(muteWordsFieldState).mapCatching {
+                repository.save(it).getOrThrow()
+            }.onSuccess {
+
+            }
+
+        }
+    }
+}

--- a/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
+++ b/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="client_word_mute">Client Word mute</string>
+
+</resources>

--- a/modules/features/setting/src/main/res/values-zh/strings.xml
+++ b/modules/features/setting/src/main/res/values-zh/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="client_word_mute">Client Word mute</string>
+</resources>

--- a/modules/features/setting/src/main/res/values/strings.xml
+++ b/modules/features/setting/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="client_word_mute">Client Word mute</string>
+</resources>

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/FilterConditionType.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/FilterConditionType.kt
@@ -1,0 +1,6 @@
+package net.pantasystem.milktea.model.notes.muteword
+
+sealed interface FilterConditionType {
+    data class Normal(val words: List<String>) : FilterConditionType
+    data class Regex(val pattern: String) : FilterConditionType
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/FilterConditionType.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/FilterConditionType.kt
@@ -2,5 +2,9 @@ package net.pantasystem.milktea.model.notes.muteword
 
 sealed interface FilterConditionType {
     data class Normal(val words: List<String>) : FilterConditionType
-    data class Regex(val pattern: String) : FilterConditionType
+    data class Regex(val pattern: String) : FilterConditionType {
+        val regex: kotlin.text.Regex by lazy {
+            kotlin.text.Regex(pattern.substring(1 until (pattern.length - 1)))
+        }
+    }
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/WordFilterConfig.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/WordFilterConfig.kt
@@ -4,4 +4,22 @@ data class WordFilterConfig(
     val conditions: List<FilterConditionType>
 ) {
     companion object
+
+    fun checkMatchText(text: String?): Boolean {
+        if (text == null) {
+            return false
+        }
+        return conditions.any { type ->
+            when(type) {
+                is FilterConditionType.Normal -> {
+                    type.words.all { word ->
+                        text.contains(word)
+                    }
+                }
+                is FilterConditionType.Regex -> {
+                    type.regex.matches(text)
+                }
+            }
+        }
+    }
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/WordFilterConfig.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/WordFilterConfig.kt
@@ -1,0 +1,5 @@
+package net.pantasystem.milktea.model.notes.muteword
+
+data class WordFilterConfig(
+    val conditions: List<FilterConditionType>
+)

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/WordFilterConfig.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/WordFilterConfig.kt
@@ -2,4 +2,6 @@ package net.pantasystem.milktea.model.notes.muteword
 
 data class WordFilterConfig(
     val conditions: List<FilterConditionType>
-)
+) {
+    companion object
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/WordFilterConfigRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/WordFilterConfigRepository.kt
@@ -1,0 +1,12 @@
+package net.pantasystem.milktea.model.notes.muteword
+
+import kotlinx.coroutines.flow.Flow
+
+
+interface WordFilterConfigRepository {
+    suspend fun save(config: WordFilterConfig): Result<Unit>
+
+    suspend fun get(): Result<WordFilterConfig>
+
+    fun observe(): Flow<WordFilterConfig>
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/WordFilterConfigTextParser.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/muteword/WordFilterConfigTextParser.kt
@@ -1,0 +1,49 @@
+package net.pantasystem.milktea.model.notes.muteword
+
+object WordFilterConfigTextParser {
+
+    fun fromText(text: String): Result<WordFilterConfig> {
+        val conditions = text.split("\n").filterNot {
+            it.isBlank()
+        }.map { line ->
+            if (line.startsWith("\\") && line.endsWith("\\")) {
+                FilterConditionType.Regex(line)
+            } else {
+                val words = line.split(" ").filterNot {
+                    it.isBlank()
+                }
+                FilterConditionType.Normal(words)
+            }
+        }
+        return Result.success(WordFilterConfig(conditions))
+    }
+
+    fun fromConfig(config: WordFilterConfig): Result<String> {
+        val text = config.conditions.filter {
+            when(it) {
+                is FilterConditionType.Normal -> it.words.isNotEmpty()
+                is FilterConditionType.Regex -> it.pattern.isNotBlank()
+            }
+        }.map { filterConditionType ->
+            when(filterConditionType) {
+                is FilterConditionType.Normal -> {
+                    if (filterConditionType.words.size > 1) {
+                        filterConditionType.words.reduce { acc, s ->
+                            "$acc $s"
+                        }
+                    } else {
+                        filterConditionType.words.first()
+                    }
+                }
+                is FilterConditionType.Regex -> {
+                    filterConditionType.pattern
+                }
+            }
+        }.reduce { acc, s ->
+            "$acc\n$s"
+        }
+        return Result.success(text)
+    }
+
+
+}

--- a/modules/model/src/test/java/net/pantasystem/milktea/model/notes/muteword/WordFilterConfigTextParserTest.kt
+++ b/modules/model/src/test/java/net/pantasystem/milktea/model/notes/muteword/WordFilterConfigTextParserTest.kt
@@ -1,0 +1,122 @@
+package net.pantasystem.milktea.model.notes.muteword
+
+import org.junit.Assert
+import org.junit.Test
+
+class WordFilterConfigTextParserTest {
+
+    @Test
+    fun fromText_Give1LineWord() {
+        val text = "test\n"
+        val result = WordFilterConfigTextParser.fromText(text).getOrThrow()
+        Assert.assertEquals(
+            WordFilterConfig(listOf(FilterConditionType.Normal(listOf("test")))),
+            result
+        )
+
+    }
+
+    @Test
+    fun fromText_Give1LineWordNotExistsReturnCode() {
+        val text = "test"
+        val result = WordFilterConfigTextParser.fromText(text).getOrThrow()
+        Assert.assertEquals(
+            WordFilterConfig(listOf(FilterConditionType.Normal(listOf("test")))),
+            result
+        )
+    }
+
+
+    @Test
+    fun fromText_GiveAnyOrText() {
+        val text = "hoge piyo fuga"
+        val result = WordFilterConfigTextParser.fromText(text).getOrThrow()
+        Assert.assertEquals(
+            WordFilterConfig(listOf(FilterConditionType.Normal(listOf("hoge", "piyo", "fuga")))),
+            result
+        )
+    }
+
+    @Test
+    fun fromText_GiveAnyAndConditionsText() {
+        val text = "hoge\npiyo \nfuga"
+        val result = WordFilterConfigTextParser.fromText(text).getOrThrow()
+        Assert.assertEquals(
+            WordFilterConfig(
+                listOf(
+                    FilterConditionType.Normal(listOf("hoge")),
+                    FilterConditionType.Normal(listOf("piyo")),
+                    FilterConditionType.Normal(listOf("fuga"))
+                )
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun fromText_GiveAnyAndConditionAndOrConditionText() {
+        val text = "hoge fizz panta\npiyo buzz\n fuga moga"
+        val result = WordFilterConfigTextParser.fromText(text).getOrThrow()
+        Assert.assertEquals(
+            WordFilterConfig(
+                listOf(
+                    FilterConditionType.Normal(listOf("hoge", "fizz", "panta")),
+                    FilterConditionType.Normal(listOf("piyo", "buzz")),
+                    FilterConditionType.Normal(listOf("fuga", "moga"))
+                )
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun fromText_GiveRegex() {
+        val text = "hoge fizz panta\npiyo buzz\n fuga moga\n\\hogepiyo\\"
+        val result = WordFilterConfigTextParser.fromText(text).getOrThrow()
+        Assert.assertEquals(
+            WordFilterConfig(
+                listOf(
+                    FilterConditionType.Normal(listOf("hoge", "fizz", "panta")),
+                    FilterConditionType.Normal(listOf("piyo", "buzz")),
+                    FilterConditionType.Normal(listOf("fuga", "moga")),
+                    FilterConditionType.Regex("\\hogepiyo\\")
+                )
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun fromConfig_GiveAnyAndConditionAndOrCondition() {
+        val config = WordFilterConfig(
+            listOf(
+                FilterConditionType.Normal(listOf("hoge", "fizz", "panta")),
+                FilterConditionType.Normal(listOf("piyo", "buzz")),
+                FilterConditionType.Normal(listOf("fuga", "moga"))
+            )
+        )
+        Assert.assertEquals(
+            "hoge fizz panta\npiyo buzz\nfuga moga",
+            WordFilterConfigTextParser.fromConfig(config).getOrThrow()
+        )
+    }
+
+    @Test
+    fun fromConfig_GiveRegex() {
+        val config = WordFilterConfig(
+            listOf(
+                FilterConditionType.Normal(listOf("hoge", "fizz", "panta")),
+                FilterConditionType.Normal(listOf("piyo", "buzz")),
+                FilterConditionType.Normal(listOf("fuga", "moga")),
+                FilterConditionType.Regex("\\hogepiyo\\")
+            )
+        )
+        Assert.assertEquals(
+            "hoge fizz panta\npiyo buzz\nfuga moga\n\\hogepiyo\\",
+            WordFilterConfigTextParser.fromConfig(config).getOrThrow()
+        )
+
+    }
+
+
+}


### PR DESCRIPTION
## やったこと
ミュートにするワードを保存するための設定画面と内部のロジックの実装を行いました。
今回はタイムラインを中心にフィルタリングを行うようにしました。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #639 


