### PR TITLE
画面表示時直後にプログレスがしっかりと表示されるようにしました

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
@@ -28,6 +28,7 @@ import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.FragmentSwipeRefreshRecyclerViewBinding
 import net.pantasystem.milktea.note.timeline.viewmodel.TimeMachineEventViewModel
+import net.pantasystem.milktea.note.timeline.viewmodel.TimelineListItem
 import net.pantasystem.milktea.note.timeline.viewmodel.TimelineViewModel
 import net.pantasystem.milktea.note.timeline.viewmodel.provideViewModel
 import net.pantasystem.milktea.note.view.NoteCardActionHandler
@@ -146,6 +147,9 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
 
 
         mBinding.listView.adapter = adapter
+        if (savedInstanceState == null) {
+            adapter.submitList(listOf(TimelineListItem.Loading))
+        }
 
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
@@ -155,12 +159,6 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
             }
 
         }
-//
-//        mBinding.retryLoadButton.setOnClickListener {
-//            Log.d("TimelineFragment", "リトライボタンを押しました")
-//            mViewModel.loadInit()
-//        }
-
 
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
@@ -183,8 +181,7 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
         mViewModel.position.let {
             try {
                 mLinearLayoutManager.scrollToPosition(it)
-            } catch (e: Exception) {
-
+            } catch (_: Exception) {
             }
         }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
@@ -28,7 +28,6 @@ import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.FragmentSwipeRefreshRecyclerViewBinding
 import net.pantasystem.milktea.note.timeline.viewmodel.TimeMachineEventViewModel
-import net.pantasystem.milktea.note.timeline.viewmodel.TimelineListItem
 import net.pantasystem.milktea.note.timeline.viewmodel.TimelineViewModel
 import net.pantasystem.milktea.note.timeline.viewmodel.provideViewModel
 import net.pantasystem.milktea.note.view.NoteCardActionHandler
@@ -147,9 +146,6 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
 
 
         mBinding.listView.adapter = adapter
-        if (savedInstanceState == null) {
-            adapter.submitList(listOf(TimelineListItem.Loading))
-        }
 
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
@@ -178,12 +174,6 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
             }
         })
 
-        mViewModel.position.let {
-            try {
-                mLinearLayoutManager.scrollToPosition(it)
-            } catch (_: Exception) {
-            }
-        }
 
 
 
@@ -223,6 +213,10 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
 
         isShowing = true
         currentPageableTimelineViewModel.setCurrentPageable(mPageable)
+        try {
+            mLinearLayoutManager.scrollToPosition(mViewModel.position)
+        } catch (_: Exception) {
+        }
 
     }
 
@@ -267,7 +261,6 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
             val itemCount = mLinearLayoutManager.itemCount
 
             if (endVisibleItemPosition == (itemCount - 1)) {
-                Log.d("", "後ろ")
                 mViewModel.loadOld()
             }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.core.view.isVisible
 import androidx.core.view.marginTop
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
@@ -154,9 +155,23 @@ class TimelineListAdapter(
 
     class LoadingViewHolder(view: View) : TimelineListItemViewHolderBase(view)
 
-    class ErrorViewHolder(val binding: ItemTimelineEmptyOrErrorBinding) : TimelineListItemViewHolderBase(binding.root)
+    class ErrorViewHolder(val binding: ItemTimelineEmptyOrErrorBinding) : TimelineListItemViewHolderBase(binding.root) {
+        fun bind(throwable: Throwable) {
+            binding.errorView.isVisible = false
+            binding.showErrorMessageButton.isVisible = true
+            binding.errorView.text = throwable.toString()
+            binding.showErrorMessageButton.setOnClickListener {
+                binding.errorView.isVisible = true
+            }
+        }
+    }
 
-    class EmptyViewHolder(val binding: ItemTimelineEmptyOrErrorBinding) : TimelineListItemViewHolderBase(binding.root)
+    class EmptyViewHolder(val binding: ItemTimelineEmptyOrErrorBinding) : TimelineListItemViewHolderBase(binding.root) {
+        fun bind() {
+            binding.errorView.isVisible = false
+            binding.showErrorMessageButton.isVisible = false
+        }
+    }
 
     enum class ViewHolderType {
         NormalNote, HasReplyToNote, Loading, Empty, Error
@@ -244,12 +259,13 @@ class TimelineListAdapter(
                 p0.binding.retryLoadButton.setOnClickListener {
                     onRefreshAction()
                 }
+                p0.bind()
             }
             is ErrorViewHolder -> {
                 p0.binding.retryLoadButton.setOnClickListener {
                     onRefreshAction()
-
                 }
+                p0.bind((item as TimelineListItem.Error).throwable)
             }
         }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -86,17 +86,13 @@ class TimelineViewModel @AssistedInject constructor(
                 }
             }
         }
-    }.stateIn(
-        viewModelScope + Dispatchers.IO,
-        SharingStarted.WhileSubscribed(5_000),
-        PageableState.Loading.Init()
-    )
+    }
 
     val timelineListState: StateFlow<List<TimelineListItem>> = timelineState.map { state ->
         state.toList()
     }.stateIn(
         viewModelScope + Dispatchers.IO,
-        SharingStarted.WhileSubscribed(5_000),
+        SharingStarted.Lazily,
         listOf(TimelineListItem.Loading)
     )
 

--- a/modules/features/note/src/main/res/layout/item_timeline_empty_or_error.xml
+++ b/modules/features/note/src/main/res/layout/item_timeline_empty_or_error.xml
@@ -18,5 +18,16 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/retry"/>
+
+        <TextView
+                android:id="@+id/showErrorMessageButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/show_error"
+                />
+        <TextView
+                android:id="@+id/errorView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
     </LinearLayout>
 </layout>

--- a/modules/features/note/src/main/res/values-ja/strings.xml
+++ b/modules/features/note/src/main/res/values-ja/strings.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="time_machine">タイムマシーン</string>
     <string name="dialog_timemachine_message">表示したいタイムラインの時間を指定してください</string>
+    <string name="show_error">Show Error</string>
 </resources>

--- a/modules/features/note/src/main/res/values-zh/strings.xml
+++ b/modules/features/note/src/main/res/values-zh/strings.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="time_machine">回到未来</string>
     <string name="dialog_timemachine_message">请指定您要显示的时间线的时间</string>
+    <string name="show_error">Show Error</string>
 </resources>

--- a/modules/features/note/src/main/res/values/strings.xml
+++ b/modules/features/note/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="time_machine">Back to the future</string>
     <string name="dialog_timemachine_message">Please specify the time of the timeline you want to display</string>
+    <string name="show_error">Show Error</string>
 </resources>


### PR DESCRIPTION
## やったこと
画面表示直後だとプログレスが表示されない問題を修正しました。
エラーが発生した場合エラーの内容を展開表示できるようにしました。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #871