### PR TITLE
特定のユーザーの詳細をメンションで開くことができない不具合を修正

### DIFF
--- a/modules/common_viewmodel/src/main/java/net/pantasystem/milktea/common_viewmodel/UserViewData.kt
+++ b/modules/common_viewmodel/src/main/java/net/pantasystem/milktea/common_viewmodel/UserViewData.kt
@@ -19,7 +19,7 @@ open class UserViewData(
     val userId: User.Id?,
     val userName: String? = null,
     val host: String? = null,
-    val accountId: Long? = null,
+    val accountId: Long,
     val userDataSource: UserDataSource,
     val userRepository: UserRepository,
     val logger: Logger,
@@ -143,7 +143,7 @@ open class UserViewData(
         logger: Logger,
         coroutineScope: CoroutineScope,
         dispatcher: CoroutineDispatcher = Dispatchers.IO
-    ) : this(userId, null, null, null, userDataSource, userRepository, logger, coroutineScope, dispatcher)
+    ) : this(userId, null, null, userId.accountId, userDataSource, userRepository, logger, coroutineScope, dispatcher)
 
     init {
 
@@ -160,7 +160,6 @@ open class UserViewData(
         if (user.value == null) {
             runCatching {
                 if (userId == null) {
-                    require(accountId != null)
                     require(userName != null)
                     userRepository.findByUserName(accountId, userName, host)
                 } else {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/InMemoryUserDataSource.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/InMemoryUserDataSource.kt
@@ -142,9 +142,9 @@ class InMemoryUserDataSource @Inject constructor() : UserDataSource {
         }
     }
 
-    override fun observe(acct: String): Flow<User> {
+    override fun observe(accountId: Long, acct: String): Flow<User> {
         return _state.mapNotNull {
-            it.get(acct)
+            it.get(accountId, acct)
         }
     }
 
@@ -156,10 +156,10 @@ class InMemoryUserDataSource @Inject constructor() : UserDataSource {
         }
     }
 
-    override fun observe(userName: String, host: String?, accountId: Long?): Flow<User?> {
+    override fun observe(userName: String, host: String?, accountId: Long): Flow<User?> {
         return state.map { state ->
             state.usersMap.values.filter { user ->
-                accountId == null || accountId == user.id.accountId
+                accountId == user.id.accountId
             }.firstOrNull {
                 it.userName == userName && it.host == host
             }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/MediatorUserDataSource.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/MediatorUserDataSource.kt
@@ -241,15 +241,15 @@ class MediatorUserDataSource @Inject constructor(
         }
     }
 
-    override fun observe(acct: String): Flow<User> {
+    override fun observe(accountId: Long, acct: String): Flow<User> {
         val (userName, host) = Acct(acct).let {
             it.userName to it.host
         }
         return userDao.let {
             if(host == null) {
-                it.observeByUserName(userName).filterNotNull()
+                it.observeByUserName(accountId, userName).filterNotNull()
             } else {
-                it.observeByUserName(userName, host).filterNotNull()
+                it.observeByUserName(accountId, userName, host).filterNotNull()
             }
         }.map {
             it.toModel()
@@ -261,7 +261,7 @@ class MediatorUserDataSource @Inject constructor(
         }
     }
 
-    override fun observe(userName: String, host: String?, accountId: Long?): Flow<User?> {
+    override fun observe(userName: String, host: String?, accountId: Long): Flow<User?> {
         return inMem.observe(userName, host, accountId).distinctUntilChanged().catch {
             logger.error("observe error", it)
             throw it

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/MediatorUserDataSource.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/MediatorUserDataSource.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.withContext
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.data.infrastructure.user.db.*
 import net.pantasystem.milktea.model.AddResult
+import net.pantasystem.milktea.model.user.Acct
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.model.user.UserNotFoundException
@@ -241,9 +242,9 @@ class MediatorUserDataSource @Inject constructor(
     }
 
     override fun observe(acct: String): Flow<User> {
-        val userNameAndHost = acct.split("@").filter { it.isNotBlank() }
-        val userName = userNameAndHost[0]
-        val host = userNameAndHost.getOrNull(1)
+        val (userName, host) = Acct(acct).let {
+            it.userName to it.host
+        }
         return userDao.let {
             if(host == null) {
                 it.observeByUserName(userName).filterNotNull()

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/db/UserDao.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/db/UserDao.kt
@@ -9,17 +9,14 @@ abstract class UserDao {
     @Insert
     abstract suspend fun insert(user: UserRecord): Long
 
-    @Insert
-    abstract suspend fun insertUsers(users: List<UserRecord>): List<Long>
+
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun insertPinnedNoteIds(ids: List<PinnedNoteIdRecord>): List<Long>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun insert(detail: UserDetailedStateRecord): Long
-
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    abstract suspend fun insertDetails(users: List<UserDetailedStateRecord>): List<Long>
+    
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun insertEmojis(emojis: List<UserEmojiRecord>): List<Long>
@@ -109,17 +106,6 @@ abstract class UserDao {
     @Transaction
     abstract fun observeByUserName(accountId: Long, userName: String): Flow<UserRelated?>
 
-    @Query("""
-        select * from user_view where userName = :userName
-    """)
-    @Transaction
-    abstract fun observeByUserName(userName: String): Flow<UserRelated?>
-
-    @Query("""
-        select * from user_view where userName = :userName and host = :host
-    """)
-    @Transaction
-    abstract fun observeByUserName(userName: String, host: String): Flow<UserRelated?>
 
     @Query("""
         select * from user_view where accountId = :accountId and serverId in (:serverIds)

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
@@ -21,6 +21,7 @@ import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.model.account.page.PageableTemplate
 import net.pantasystem.milktea.model.notes.NoteCaptureAPIAdapter
 import net.pantasystem.milktea.model.notes.NoteDataSource
+import net.pantasystem.milktea.model.user.Acct
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.model.user.UserRepository
@@ -283,12 +284,7 @@ class UserDetailViewModel @AssistedInject constructor(
         return userRepository.find(getUserId())
     }
 
-    private fun splitUserNameAndHost(acct: String): Pair<String, String?> {
-        val userNameAndHost = acct.split("@").filter { it.isNotBlank() }
-        val userName = userNameAndHost[0]
-        val host = userNameAndHost.getOrNull(1)
-        return userName to host
-    }
+
 
     private suspend fun getUserId(): User.Id {
         if (userId != null) {
@@ -297,7 +293,9 @@ class UserDetailViewModel @AssistedInject constructor(
 
         val account = accountWatcher.getAccount()
         if (fqdnUserName != null) {
-            val (userName, host) = splitUserNameAndHost(fqdnUserName)
+            val (userName, host) = Acct(fqdnUserName).let {
+                it.userName to it.host
+            }
             return userRepository.findByUserName(account.accountId, userName, host).id
         }
         throw IllegalStateException()

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
@@ -59,12 +59,15 @@ class UserDetailViewModel @AssistedInject constructor(
     private val accountWatcher = CurrentAccountWatcher(userId?.accountId, accountRepository)
 
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     val userState = when {
         userId != null -> {
             userDataSource.observe(userId)
         }
         fqdnUserName != null -> {
-            userDataSource.observe(fqdnUserName)
+            accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
+                userDataSource.observe(it.accountId, fqdnUserName)
+            }
         }
         else -> {
             throw IllegalArgumentException()

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/Acct.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/Acct.kt
@@ -1,0 +1,7 @@
+package net.pantasystem.milktea.model.user
+
+data class Acct(val acct: String) {
+    private val userNameAndHost = acct.split("@").filter { it.isNotBlank() }
+    val userName = userNameAndHost[0]
+    val host = userNameAndHost.getOrNull(1)
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/UserDataSource.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/UserDataSource.kt
@@ -19,11 +19,11 @@ data class UsersState (
         }
     }
 
-    fun get(fqdnUserName: String): User? {
+    fun get(accountId: Long, fqdnUserName: String): User? {
         val userNameAndHost = fqdnUserName.split("@").filter { it.isNotBlank() }
         val userName = userNameAndHost[0]
         val host = userNameAndHost.getOrNull(1)
-        return get(userName, host)
+        return get(userName, host, accountId)
     }
 }
 
@@ -48,9 +48,9 @@ interface UserDataSource {
 
     fun observeIn(accountId: Long, serverIds: List<String>): Flow<List<User>>
     fun observe(userId: User.Id): Flow<User>
-    fun observe(acct: String): Flow<User>
+    fun observe(accountId: Long, acct: String): Flow<User>
 
-    fun observe(userName: String, host: String? = null, accountId: Long? = null): Flow<User?>
+    fun observe(userName: String, host: String? = null, accountId: Long): Flow<User?>
 
     suspend fun searchByName(accountId: Long, name: String): List<User>
 }

--- a/modules/model/src/test/java/net/pantasystem/milktea/model/user/AcctTest.kt
+++ b/modules/model/src/test/java/net/pantasystem/milktea/model/user/AcctTest.kt
@@ -1,0 +1,35 @@
+package net.pantasystem.milktea.model.user
+
+import org.junit.Assert
+import org.junit.Test
+
+class AcctTest {
+
+    @Test
+    fun userName_giveUserNameOnly() {
+        val textAcct = "@Panta"
+        val acct = Acct(textAcct)
+        Assert.assertEquals("Panta", acct.userName)
+    }
+
+    @Test
+    fun host_giveUserNameOnlyReturnsNull() {
+        val textAcct = "@Panta"
+        val acct = Acct(textAcct)
+        Assert.assertNull(acct.host)
+    }
+
+    @Test
+    fun userName_giveUserNameAndHost() {
+        val textAcct = "@Panta@misskey.io"
+        val acct = Acct(textAcct)
+        Assert.assertEquals("Panta", acct.userName)
+    }
+
+    @Test
+    fun host_giveUserNameAndHost() {
+        val textAcct = "@Panta@misskey.io"
+        val acct = Acct(textAcct)
+        Assert.assertEquals("misskey.io", acct.host)
+    }
+}


### PR DESCRIPTION
## やったこと
accountIdが指定されていなかったため、他のアカウントに関連しているデータが取得されてしまい、結果リレーションがうまくいかず、データが欠損してしまっていることが原因で、ユーザーを表示することができていませんでした。
そこでaccountIdを指定して取得するように変更しました。
また一部ロジックと関するデータをクラスに切り出しました。
## 動作確認
エミュレーターで動作確認済み

## スクリーンショット(任意)


## 備考


## Issue番号

Closed #895

