### PR TITLE
ユーザーミュート時にミュートの期限を指定できるようにしました

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
@@ -222,7 +222,7 @@ interface MisskeyAPI {
     suspend fun readMessage(@Body messageAction: MessageAction): Response<Unit>
 
     @POST("api/mute/create")
-    suspend fun muteUser(@Body requestUser: RequestUser): Response<Unit>
+    suspend fun muteUser(@Body createMuteRequest: CreateMuteUserRequest): Response<Unit>
 
     @POST("api/mute/delete")
     suspend fun unmuteUser(@Body requestUser: RequestUser): Response<Unit>

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/CreateMuteUserRequest.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/CreateMuteUserRequest.kt
@@ -1,0 +1,8 @@
+package net.pantasystem.milktea.api.misskey.users
+
+@kotlinx.serialization.Serializable
+data class CreateMuteUserRequest(
+    val i: String,
+    val userId: String,
+    val expiresAt: Long? = null,
+)

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/v10/MisskeyAPIV10.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/v10/MisskeyAPIV10.kt
@@ -98,7 +98,7 @@ open class MisskeyAPIV10(val misskey: MisskeyAPI, private val diff: MisskeyAPIV1
 
     override suspend fun localTimeline(noteRequest: NoteRequest): Response<List<NoteDTO>?> = misskey.localTimeline(noteRequest)
 
-    override suspend fun muteUser(requestUser: RequestUser): Response<Unit> = misskey.muteUser(requestUser)
+    override suspend fun muteUser(createMuteRequest: CreateMuteUserRequest): Response<Unit> = misskey.muteUser(createMuteRequest)
 
     override suspend fun myApps(i: I): Response<List<App>> = misskey.myApps(i)
 

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/v11/MisskeyAPIV11.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/v11/MisskeyAPIV11.kt
@@ -1,30 +1,27 @@
 package net.pantasystem.milktea.api.misskey.v11
 
 import net.pantasystem.milktea.api.misskey.I
-import net.pantasystem.milktea.api.misskey.groups.*
-import net.pantasystem.milktea.api.misskey.list.*
-import net.pantasystem.milktea.api.misskey.notification.NotificationDTO
 import net.pantasystem.milktea.api.misskey.MisskeyAPI
 import net.pantasystem.milktea.api.misskey.app.CreateApp
 import net.pantasystem.milktea.api.misskey.app.ShowApp
 import net.pantasystem.milktea.api.misskey.auth.App
 import net.pantasystem.milktea.api.misskey.drive.*
 import net.pantasystem.milktea.api.misskey.favorite.Favorite
+import net.pantasystem.milktea.api.misskey.groups.*
 import net.pantasystem.milktea.api.misskey.hashtag.RequestHashTagList
-
-import net.pantasystem.milktea.api.misskey.messaging.MessageDTO
+import net.pantasystem.milktea.api.misskey.list.*
 import net.pantasystem.milktea.api.misskey.messaging.MessageAction
+import net.pantasystem.milktea.api.misskey.messaging.MessageDTO
 import net.pantasystem.milktea.api.misskey.messaging.RequestMessage
 import net.pantasystem.milktea.api.misskey.notes.*
 import net.pantasystem.milktea.api.misskey.notes.favorite.CreateFavorite
 import net.pantasystem.milktea.api.misskey.notes.favorite.DeleteFavorite
-import net.pantasystem.milktea.model.messaging.RequestMessageHistory
-import net.pantasystem.milktea.model.notes.poll.Vote
-import net.pantasystem.milktea.api.misskey.notification.NotificationRequest
 import net.pantasystem.milktea.api.misskey.notes.reaction.ReactionHistoryDTO
 import net.pantasystem.milktea.api.misskey.notes.reaction.RequestReactionHistoryDTO
 import net.pantasystem.milktea.api.misskey.notes.translation.Translate
 import net.pantasystem.milktea.api.misskey.notes.translation.TranslationResult
+import net.pantasystem.milktea.api.misskey.notification.NotificationDTO
+import net.pantasystem.milktea.api.misskey.notification.NotificationRequest
 import net.pantasystem.milktea.api.misskey.register.Subscription
 import net.pantasystem.milktea.api.misskey.register.SubscriptionState
 import net.pantasystem.milktea.api.misskey.register.UnSubscription
@@ -34,6 +31,8 @@ import net.pantasystem.milktea.model.drive.Directory
 import net.pantasystem.milktea.model.hashtag.HashTag
 import net.pantasystem.milktea.model.instance.Meta
 import net.pantasystem.milktea.model.instance.RequestMeta
+import net.pantasystem.milktea.model.messaging.RequestMessageHistory
+import net.pantasystem.milktea.model.notes.poll.Vote
 import retrofit2.Response
 
 open class MisskeyAPIV11(private val misskeyAPI: MisskeyAPI, private val apiDiff: MisskeyAPIV11Diff): MisskeyAPI by misskeyAPI{
@@ -68,7 +67,7 @@ open class MisskeyAPIV11(private val misskeyAPI: MisskeyAPI, private val apiDiff
     override suspend fun i(i: I): Response<UserDTO> = misskeyAPI.i(i)
     override suspend fun localTimeline(noteRequest: NoteRequest): Response<List<NoteDTO>?> = misskeyAPI.localTimeline(noteRequest)
     override suspend fun mentions(noteRequest: NoteRequest): Response<List<NoteDTO>?> = misskeyAPI.mentions(noteRequest)
-    override suspend fun muteUser(requestUser: RequestUser): Response<Unit> = misskeyAPI.muteUser(requestUser)
+    override suspend fun muteUser(createMuteRequest: CreateMuteUserRequest): Response<Unit> = misskeyAPI.muteUser(createMuteRequest)
     override suspend fun followUser(requestUser: RequestUser): Response<UserDTO> = misskeyAPI.followUser(requestUser)
     override suspend fun myApps(i: I): Response<List<App>> = misskeyAPI.myApps(i)
     override suspend fun noteState(noteRequest: NoteRequest): Response<NoteState> = misskeyAPI.noteState(noteRequest)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimeMachineDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimeMachineDialog.kt
@@ -22,7 +22,7 @@ import net.pantasystem.milktea.note.timeline.viewmodel.TimeMachineEventViewModel
 class TimeMachineDialog : AppCompatDialogFragment() {
 
     val viewModel by activityViewModels<TimeMachineDialogViewModel>()
-    val timeMachineEventViewModel by activityViewModels<TimeMachineEventViewModel>()
+    private val timeMachineEventViewModel by activityViewModels<TimeMachineEventViewModel>()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val view = View.inflate(this.context, R.layout.dialog_time_machine, null)

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
@@ -53,6 +53,7 @@ import net.pantasystem.milktea.user.databinding.ActivityUserDetailBinding
 import net.pantasystem.milktea.user.nickname.EditNicknameDialog
 import net.pantasystem.milktea.user.profile.ConfirmUserBlockDialog
 import net.pantasystem.milktea.user.profile.UserProfileFieldListAdapter
+import net.pantasystem.milktea.user.profile.mute.SpecifyMuteExpiredAtDialog
 import net.pantasystem.milktea.user.viewmodel.UserDetailViewModel
 import net.pantasystem.milktea.user.viewmodel.provideFactory
 import javax.inject.Inject
@@ -350,7 +351,8 @@ class UserDetailActivity : AppCompatActivity() {
                 ConfirmUserBlockDialog().show(supportFragmentManager, "ConfirmUserBlockDialog")
             }
             R.id.mute -> {
-                mViewModel.mute()
+                SpecifyMuteExpiredAtDialog()
+                    .show(supportFragmentManager, "SpecifyMuteExpiredAtDialog")
             }
             R.id.unblock -> {
                 mViewModel.unblock()

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/SpecifyMuteExpiredAtDialog.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/SpecifyMuteExpiredAtDialog.kt
@@ -1,0 +1,168 @@
+package net.pantasystem.milktea.user.profile
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Button
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.activityViewModels
+import com.google.android.material.composethemeadapter.MdcTheme
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import net.pantasystem.milktea.user.R
+import net.pantasystem.milktea.user.viewmodel.UserDetailViewModel
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+@AndroidEntryPoint
+class SpecifyMuteExpiredAtDialog : AppCompatDialogFragment() {
+
+    val viewModel by activityViewModels<UserDetailViewModel>()
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.mute)
+            .setView(ComposeView(requireContext()).apply {
+                setContent {
+                    MdcTheme {
+                        SpecifyMuteExpiredAtDialogContent()
+                    }
+                }
+            })
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+
+            }
+            .setNegativeButton(android.R.string.cancel) { _, _ ->
+
+            }
+            .create()
+    }
+}
+
+@Composable
+fun SpecifyMuteExpiredAtDialogContent() {
+    var state: SpecifyUserMuteUiState by remember {
+        mutableStateOf(SpecifyUserMuteUiState.IndefinitePeriod)
+    }
+    Column(Modifier.fillMaxWidth()) {
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("無期限")
+            Switch(
+                checked = state is SpecifyUserMuteUiState.IndefinitePeriod,
+                onCheckedChange = {
+                    state = if (it) {
+                        SpecifyUserMuteUiState.IndefinitePeriod
+                    } else {
+                        SpecifyUserMuteUiState.Specified(Clock.System.now() + 15.hours)
+                    }
+                })
+
+
+        }
+
+        when (val s = state) {
+            is SpecifyUserMuteUiState.Specified -> {
+                val localDateTime = s.localDateTime
+
+                TextButton(
+                    onClick = {
+                        state = s.applyDuration(15.minutes)
+                    },
+                    Modifier.fillMaxWidth()
+                ) {
+                    Text("15分後")
+                }
+                TextButton(
+                    onClick = {
+                        state = s.applyDuration(30.minutes)
+                    },
+                    Modifier.fillMaxWidth()
+                ) {
+                    Text("30分後")
+                }
+                TextButton(
+                    onClick = {
+                        state = s.applyDuration(1.hours)
+                    },
+                    Modifier.fillMaxWidth()
+                ) {
+                    Text("1時間後")
+                }
+                TextButton(
+                    onClick = {
+                        state = s.applyDuration(7.days)
+                    },
+                    Modifier.fillMaxWidth()
+                ) {
+                    Text("1週間後")
+                }
+                TextButton(
+                    onClick = {
+                        state = s.applyDuration(30.days)
+                    },
+                    Modifier.fillMaxWidth()
+                ) {
+                    Text("1ヶ月後")
+                }
+
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                ) {
+                    Button(
+                        onClick = {
+
+                        },
+                        Modifier.weight(1f),
+                    ) {
+                        Text("${localDateTime.year}/${localDateTime.monthNumber}/${localDateTime.dayOfMonth}")
+                    }
+                    Spacer(Modifier.width(4.dp))
+                    Button(
+                        onClick = { /*TODO*/ },
+                        Modifier.weight(1f),
+                    ) {
+                        Text("${localDateTime.hour}:${localDateTime.minute}")
+                    }
+                }
+            }
+            is SpecifyUserMuteUiState.IndefinitePeriod -> {}
+        }
+
+    }
+}
+
+sealed interface SpecifyUserMuteUiState {
+    object IndefinitePeriod : SpecifyUserMuteUiState
+    data class Specified(val dateTime: Instant) : SpecifyUserMuteUiState {
+        fun applyDuration(duration: Duration): Specified {
+            return copy(dateTime = Clock.System.now() + duration)
+        }
+
+        val localDateTime by lazy {
+            dateTime.toLocalDateTime(TimeZone.currentSystemDefault())
+        }
+    }
+}

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialog.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialog.kt
@@ -1,0 +1,55 @@
+package net.pantasystem.milktea.user.profile.mute
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.activityViewModels
+import com.google.android.material.composethemeadapter.MdcTheme
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import dagger.hilt.android.AndroidEntryPoint
+import net.pantasystem.milktea.user.R
+import net.pantasystem.milktea.user.viewmodel.MuteUserViewModel
+import net.pantasystem.milktea.user.viewmodel.UserDetailViewModel
+
+@AndroidEntryPoint
+class SpecifyMuteExpiredAtDialog : AppCompatDialogFragment() {
+
+    val userDetailViewModel by activityViewModels<UserDetailViewModel>()
+    val viewModel by activityViewModels<MuteUserViewModel>()
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.mute)
+            .setView(ComposeView(requireContext()).apply {
+                setContent {
+                    MdcTheme {
+                        SpecifyMuteExpiredAtDialogContent(
+                            state = viewModel.state,
+                            onAction = { action ->
+                                when(action) {
+                                    is SpecifyMuteUserAction.OnChangeState -> {
+                                        viewModel.onUpdateState(action.state)
+                                    }
+                                    SpecifyMuteUserAction.OnDateChangeButtonClicked -> {
+
+                                    }
+                                    SpecifyMuteUserAction.OnTimeChangeButtonClicked -> {
+
+                                    }
+                                }
+                            }
+                        )
+                    }
+                }
+            })
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+
+            }
+            .setNegativeButton(android.R.string.cancel) { _, _ ->
+
+            }
+            .create()
+    }
+}

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialog.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialog.kt
@@ -1,15 +1,22 @@
 package net.pantasystem.milktea.user.profile.mute
 
+import android.app.DatePickerDialog
 import android.app.Dialog
+import android.app.TimePickerDialog
 import android.os.Bundle
+import android.widget.DatePicker
+import android.widget.TimePicker
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.activityViewModels
 import com.google.android.material.composethemeadapter.MdcTheme
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import net.pantasystem.milktea.user.R
 import net.pantasystem.milktea.user.viewmodel.MuteUserViewModel
+import net.pantasystem.milktea.user.viewmodel.SpecifyUserMuteUiState
 import net.pantasystem.milktea.user.viewmodel.UserDetailViewModel
 
 @AndroidEntryPoint
@@ -33,10 +40,12 @@ class SpecifyMuteExpiredAtDialog : AppCompatDialogFragment() {
                                         viewModel.onUpdateState(action.state)
                                     }
                                     SpecifyMuteUserAction.OnDateChangeButtonClicked -> {
-
+                                        UserMuteExpiredDatePickerDialog()
+                                            .show(childFragmentManager, "UserMuteExpiredDatePickerDialog")
                                     }
                                     SpecifyMuteUserAction.OnTimeChangeButtonClicked -> {
-
+                                        UserMuteExpiredTimePickerDialog()
+                                            .show(childFragmentManager, "UserMuteExpiredTimePickerDialog")
                                     }
                                 }
                             }
@@ -45,11 +54,47 @@ class SpecifyMuteExpiredAtDialog : AppCompatDialogFragment() {
                 }
             })
             .setPositiveButton(android.R.string.ok) { _, _ ->
+                when(viewModel.state) {
+                    SpecifyUserMuteUiState.IndefinitePeriod -> {
 
+                    }
+                    is SpecifyUserMuteUiState.Specified -> {
+
+                    }
+                }
+                viewModel.onConfirmed()
             }
             .setNegativeButton(android.R.string.cancel) { _, _ ->
-
             }
             .create()
+    }
+}
+
+@AndroidEntryPoint
+class UserMuteExpiredDatePickerDialog : AppCompatDialogFragment(), DatePickerDialog.OnDateSetListener {
+
+    val viewModel: MuteUserViewModel by activityViewModels()
+
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val local = viewModel.expiredAt.toLocalDateTime(TimeZone.currentSystemDefault())
+        return DatePickerDialog(requireActivity(), this, local.year, local.monthNumber - 1, local.dayOfMonth)
+    }
+
+    override fun onDateSet(view: DatePicker?, year: Int, month: Int, dayOfMonth: Int) {
+        viewModel.setDate(year, month, dayOfMonth)
+    }
+}
+
+@AndroidEntryPoint
+class UserMuteExpiredTimePickerDialog : AppCompatDialogFragment(), TimePickerDialog.OnTimeSetListener {
+    val viewModel: MuteUserViewModel by activityViewModels()
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val local = viewModel.expiredAt.toLocalDateTime(TimeZone.currentSystemDefault())
+        return TimePickerDialog(requireActivity(), this, local.hour, local.minute, true)
+    }
+    override fun onTimeSet(view: TimePicker?, hourOfDay: Int, minute: Int) {
+        viewModel.setTime(hourOfDay, minute)
     }
 }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialog.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialog.kt
@@ -54,17 +54,19 @@ class SpecifyMuteExpiredAtDialog : AppCompatDialogFragment() {
                 }
             })
             .setPositiveButton(android.R.string.ok) { _, _ ->
-                when(viewModel.state) {
+                val expiredAt = when(val state = viewModel.state) {
                     SpecifyUserMuteUiState.IndefinitePeriod -> {
-
+                        null
                     }
                     is SpecifyUserMuteUiState.Specified -> {
-
+                        state.dateTime
                     }
                 }
+                userDetailViewModel.mute(expiredAt)
                 viewModel.onConfirmed()
             }
             .setNegativeButton(android.R.string.cancel) { _, _ ->
+                viewModel.onCanceled()
             }
             .create()
     }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialogContent.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialogContent.kt
@@ -32,7 +32,7 @@ fun SpecifyMuteExpiredAtDialogContent(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text("無期限")
+            Text(stringResource(R.string.user_mute_specify_time_indefinite_period))
             Switch(
                 checked = state is SpecifyUserMuteUiState.IndefinitePeriod,
                 onCheckedChange = {

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialogContent.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialogContent.kt
@@ -8,8 +8,10 @@ import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.datetime.Clock
+import net.pantasystem.milktea.user.R
 import net.pantasystem.milktea.user.viewmodel.SpecifyUserMuteUiState
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
@@ -48,69 +50,69 @@ fun SpecifyMuteExpiredAtDialogContent(
 
         }
 
-        when (val s = state) {
+        when (state) {
             is SpecifyUserMuteUiState.Specified -> {
-                val localDateTime = s.localDateTime
+                val localDateTime = state.localDateTime
 
                 TextButton(
                     onClick = {
                         onAction(
                             SpecifyMuteUserAction.OnChangeState(
-                                s.applyDuration(15.minutes)
+                                state.applyDuration(15.minutes)
                             )
                         )
                     },
                     Modifier.fillMaxWidth()
                 ) {
-                    Text("15分後")
+                    Text(stringResource(R.string.user_mute_specify_time_15_minutes_later))
                 }
                 TextButton(
                     onClick = {
                         onAction(
                             SpecifyMuteUserAction.OnChangeState(
-                                s.applyDuration(30.minutes)
+                                state.applyDuration(30.minutes)
                             )
                         )
                     },
                     Modifier.fillMaxWidth()
                 ) {
-                    Text("30分後")
+                    Text(stringResource(R.string.user_mute_specify_time_30_minutes_later))
                 }
                 TextButton(
                     onClick = {
                         onAction(
                             SpecifyMuteUserAction.OnChangeState(
-                                s.applyDuration(1.hours)
+                                state.applyDuration(1.hours)
                             )
                         )
                     },
                     Modifier.fillMaxWidth()
                 ) {
-                    Text("1時間後")
+                    Text(stringResource(R.string.user_mute_specify_time_1_hours_later))
                 }
                 TextButton(
                     onClick = {
                         onAction(
                             SpecifyMuteUserAction.OnChangeState(
-                                s.applyDuration(7.days)
+                                state.applyDuration(7.days)
                             )
                         )
                     },
                     Modifier.fillMaxWidth()
                 ) {
-                    Text("1週間後")
+                    Text(stringResource(R.string.user_mute_specify_time_1_week_later))
                 }
                 TextButton(
                     onClick = {
                         onAction(
                             SpecifyMuteUserAction.OnChangeState(
-                                s.applyDuration(30.days)
+                                state.applyDuration(30.days)
                             )
                         )
                     },
                     Modifier.fillMaxWidth()
                 ) {
-                    Text("1ヶ月後")
+                    Text(stringResource(R.string.user_mute_specify_time_1_month_later))
                 }
 
                 Row(
@@ -120,7 +122,7 @@ fun SpecifyMuteExpiredAtDialogContent(
                 ) {
                     Button(
                         onClick = {
-
+                            onAction(SpecifyMuteUserAction.OnDateChangeButtonClicked)
                         },
                         Modifier.weight(1f),
                     ) {
@@ -128,7 +130,9 @@ fun SpecifyMuteExpiredAtDialogContent(
                     }
                     Spacer(Modifier.width(4.dp))
                     Button(
-                        onClick = { /*TODO*/ },
+                        onClick = {
+                            onAction(SpecifyMuteUserAction.OnTimeChangeButtonClicked)
+                        },
                         Modifier.weight(1f),
                     ) {
                         Text("${localDateTime.hour}:${localDateTime.minute}")

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialogContent.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialogContent.kt
@@ -1,64 +1,27 @@
-package net.pantasystem.milktea.user.profile
+package net.pantasystem.milktea.user.profile.mute
 
-import android.app.Dialog
-import android.os.Bundle
-import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
-import androidx.fragment.app.activityViewModels
-import com.google.android.material.composethemeadapter.MdcTheme
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
-import net.pantasystem.milktea.user.R
-import net.pantasystem.milktea.user.viewmodel.UserDetailViewModel
-import kotlin.time.Duration
+import net.pantasystem.milktea.user.viewmodel.SpecifyUserMuteUiState
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
-@AndroidEntryPoint
-class SpecifyMuteExpiredAtDialog : AppCompatDialogFragment() {
-
-    val viewModel by activityViewModels<UserDetailViewModel>()
-
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-
-        return MaterialAlertDialogBuilder(requireContext())
-            .setTitle(R.string.mute)
-            .setView(ComposeView(requireContext()).apply {
-                setContent {
-                    MdcTheme {
-                        SpecifyMuteExpiredAtDialogContent()
-                    }
-                }
-            })
-            .setPositiveButton(android.R.string.ok) { _, _ ->
-
-            }
-            .setNegativeButton(android.R.string.cancel) { _, _ ->
-
-            }
-            .create()
-    }
-}
 
 @Composable
-fun SpecifyMuteExpiredAtDialogContent() {
-    var state: SpecifyUserMuteUiState by remember {
-        mutableStateOf(SpecifyUserMuteUiState.IndefinitePeriod)
-    }
+fun SpecifyMuteExpiredAtDialogContent(
+    state: SpecifyUserMuteUiState,
+    onAction: (SpecifyMuteUserAction) -> Unit,
+) {
+
     Column(Modifier.fillMaxWidth()) {
         Row(
             Modifier
@@ -71,11 +34,15 @@ fun SpecifyMuteExpiredAtDialogContent() {
             Switch(
                 checked = state is SpecifyUserMuteUiState.IndefinitePeriod,
                 onCheckedChange = {
-                    state = if (it) {
-                        SpecifyUserMuteUiState.IndefinitePeriod
-                    } else {
-                        SpecifyUserMuteUiState.Specified(Clock.System.now() + 15.hours)
-                    }
+                    onAction(
+                        SpecifyMuteUserAction.OnChangeState(
+                            if (it) {
+                                SpecifyUserMuteUiState.IndefinitePeriod
+                            } else {
+                                SpecifyUserMuteUiState.Specified(Clock.System.now() + 15.hours)
+                            }
+                        )
+                    )
                 })
 
 
@@ -87,7 +54,11 @@ fun SpecifyMuteExpiredAtDialogContent() {
 
                 TextButton(
                     onClick = {
-                        state = s.applyDuration(15.minutes)
+                        onAction(
+                            SpecifyMuteUserAction.OnChangeState(
+                                s.applyDuration(15.minutes)
+                            )
+                        )
                     },
                     Modifier.fillMaxWidth()
                 ) {
@@ -95,7 +66,11 @@ fun SpecifyMuteExpiredAtDialogContent() {
                 }
                 TextButton(
                     onClick = {
-                        state = s.applyDuration(30.minutes)
+                        onAction(
+                            SpecifyMuteUserAction.OnChangeState(
+                                s.applyDuration(30.minutes)
+                            )
+                        )
                     },
                     Modifier.fillMaxWidth()
                 ) {
@@ -103,7 +78,11 @@ fun SpecifyMuteExpiredAtDialogContent() {
                 }
                 TextButton(
                     onClick = {
-                        state = s.applyDuration(1.hours)
+                        onAction(
+                            SpecifyMuteUserAction.OnChangeState(
+                                s.applyDuration(1.hours)
+                            )
+                        )
                     },
                     Modifier.fillMaxWidth()
                 ) {
@@ -111,7 +90,11 @@ fun SpecifyMuteExpiredAtDialogContent() {
                 }
                 TextButton(
                     onClick = {
-                        state = s.applyDuration(7.days)
+                        onAction(
+                            SpecifyMuteUserAction.OnChangeState(
+                                s.applyDuration(7.days)
+                            )
+                        )
                     },
                     Modifier.fillMaxWidth()
                 ) {
@@ -119,7 +102,11 @@ fun SpecifyMuteExpiredAtDialogContent() {
                 }
                 TextButton(
                     onClick = {
-                        state = s.applyDuration(30.days)
+                        onAction(
+                            SpecifyMuteUserAction.OnChangeState(
+                                s.applyDuration(30.days)
+                            )
+                        )
                     },
                     Modifier.fillMaxWidth()
                 ) {
@@ -154,15 +141,8 @@ fun SpecifyMuteExpiredAtDialogContent() {
     }
 }
 
-sealed interface SpecifyUserMuteUiState {
-    object IndefinitePeriod : SpecifyUserMuteUiState
-    data class Specified(val dateTime: Instant) : SpecifyUserMuteUiState {
-        fun applyDuration(duration: Duration): Specified {
-            return copy(dateTime = Clock.System.now() + duration)
-        }
-
-        val localDateTime by lazy {
-            dateTime.toLocalDateTime(TimeZone.currentSystemDefault())
-        }
-    }
+sealed interface SpecifyMuteUserAction {
+    data class OnChangeState(val state: SpecifyUserMuteUiState) : SpecifyMuteUserAction
+    object OnDateChangeButtonClicked : SpecifyMuteUserAction
+    object OnTimeChangeButtonClicked : SpecifyMuteUserAction
 }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialogContent.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/mute/SpecifyMuteExpiredAtDialogContent.kt
@@ -1,5 +1,6 @@
 package net.pantasystem.milktea.user.profile.mute
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
 import androidx.compose.material.Switch
@@ -28,7 +29,18 @@ fun SpecifyMuteExpiredAtDialogContent(
         Row(
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = 16.dp)
+                .clickable {
+                    onAction(
+                        SpecifyMuteUserAction.OnChangeState(
+                            if (state is SpecifyUserMuteUiState.Specified) {
+                                SpecifyUserMuteUiState.IndefinitePeriod
+                            } else {
+                                SpecifyUserMuteUiState.Specified(Clock.System.now() + 15.minutes)
+                            }
+                        )
+                    )
+                },
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/MuteUserViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/MuteUserViewModel.kt
@@ -17,6 +17,11 @@ import kotlin.time.Duration
 class MuteUserViewModel @Inject constructor(): ViewModel() {
     var state by mutableStateOf<SpecifyUserMuteUiState>(SpecifyUserMuteUiState.IndefinitePeriod)
         private set
+    val expiredAt: Instant
+        get() {
+            return (state as? SpecifyUserMuteUiState.Specified)?.dateTime
+                ?: Clock.System.now()
+        }
 
     fun setDate(year: Int, month: Int, dayOfMonth: Int) {
         val dateTime = (state as? SpecifyUserMuteUiState.Specified)?.dateTime ?: Clock.System.now()
@@ -38,6 +43,10 @@ class MuteUserViewModel @Inject constructor(): ViewModel() {
     }
 
     fun onConfirmed() {
+        state = SpecifyUserMuteUiState.IndefinitePeriod
+    }
+
+    fun onCanceled() {
         state = SpecifyUserMuteUiState.IndefinitePeriod
     }
 

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/MuteUserViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/MuteUserViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import java.util.*
 import javax.inject.Inject
 import kotlin.time.Duration
 
@@ -17,12 +18,23 @@ class MuteUserViewModel @Inject constructor(): ViewModel() {
     var state by mutableStateOf<SpecifyUserMuteUiState>(SpecifyUserMuteUiState.IndefinitePeriod)
         private set
 
-    fun setDate(year: Int, month: Int, monthOfDay: Int) {
-
+    fun setDate(year: Int, month: Int, dayOfMonth: Int) {
+        val dateTime = (state as? SpecifyUserMuteUiState.Specified)?.dateTime ?: Clock.System.now()
+        val calendar = Calendar.getInstance()
+        calendar.time = Date(dateTime.toEpochMilliseconds())
+        calendar.set(Calendar.YEAR, year)
+        calendar.set(Calendar.MONTH, month)
+        calendar.set(Calendar.DAY_OF_MONTH, dayOfMonth)
+        state = SpecifyUserMuteUiState.Specified(Instant.fromEpochMilliseconds(calendar.time.time))
     }
 
-    fun setTime(time: Int, hour: Int) {
-
+    fun setTime(hour: Int, minutes: Int) {
+        val dateTime = (state as? SpecifyUserMuteUiState.Specified)?.dateTime ?: Clock.System.now()
+        val calendar = Calendar.getInstance()
+        calendar.time = Date(dateTime.toEpochMilliseconds())
+        calendar.set(Calendar.HOUR_OF_DAY, hour)
+        calendar.set(Calendar.MINUTE, minutes)
+        state = SpecifyUserMuteUiState.Specified(Instant.fromEpochMilliseconds(calendar.time.time))
     }
 
     fun onConfirmed() {

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/MuteUserViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/MuteUserViewModel.kt
@@ -1,0 +1,48 @@
+package net.pantasystem.milktea.user.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import javax.inject.Inject
+import kotlin.time.Duration
+
+@HiltViewModel
+class MuteUserViewModel @Inject constructor(): ViewModel() {
+    var state by mutableStateOf<SpecifyUserMuteUiState>(SpecifyUserMuteUiState.IndefinitePeriod)
+        private set
+
+    fun setDate(year: Int, month: Int, monthOfDay: Int) {
+
+    }
+
+    fun setTime(time: Int, hour: Int) {
+
+    }
+
+    fun onConfirmed() {
+        state = SpecifyUserMuteUiState.IndefinitePeriod
+    }
+
+    fun onUpdateState(state: SpecifyUserMuteUiState) {
+        this.state = state
+    }
+}
+
+sealed interface SpecifyUserMuteUiState {
+    object IndefinitePeriod : SpecifyUserMuteUiState
+    data class Specified(val dateTime: Instant) : SpecifyUserMuteUiState {
+        val localDateTime by lazy {
+            dateTime.toLocalDateTime(TimeZone.currentSystemDefault())
+        }
+
+        fun applyDuration(duration: Duration): Specified {
+            return copy(dateTime = Clock.System.now() + duration)
+        }
+    }
+}

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
@@ -6,6 +6,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
+import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import net.pantasystem.milktea.app_store.account.AccountStore
@@ -184,11 +185,11 @@ class UserDetailViewModel @AssistedInject constructor(
         showFollowers.event = user.value
     }
 
-    fun mute() {
+    fun mute(expiredAt: Instant?) {
         viewModelScope.launch(Dispatchers.IO) {
             userState.value?.let {
                 runCatching {
-                    userRepository.mute(CreateMute(it.id))
+                    userRepository.mute(CreateMute(it.id, expiredAt))
                     userRepository.sync(it.id).getOrThrow()
                 }.onFailure {
                     logger.error("unmute", e = it)

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
@@ -25,6 +25,7 @@ import net.pantasystem.milktea.model.user.Acct
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.model.user.UserRepository
+import net.pantasystem.milktea.model.user.mute.CreateMute
 import net.pantasystem.milktea.model.user.nickname.DeleteNicknameUseCase
 import net.pantasystem.milktea.model.user.nickname.UpdateNicknameUseCase
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
@@ -187,7 +188,7 @@ class UserDetailViewModel @AssistedInject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             userState.value?.let {
                 runCatching {
-                    userRepository.mute(it.id)
+                    userRepository.mute(CreateMute(it.id))
                     userRepository.sync(it.id).getOrThrow()
                 }.onFailure {
                     logger.error("unmute", e = it)

--- a/modules/features/user/src/main/res/values-ja/strings.xml
+++ b/modules/features/user/src/main/res/values-ja/strings.xml
@@ -5,4 +5,11 @@
     <string name="registration_date">%sに登録をしました</string>
     <string name="confirm_user_block_title">確認</string>
     <string name="confirm_user_block_description">本当に%sさんをブロックしますか？</string>
+
+    <string name="user_mute_specify_time_15_minutes_later">15分後</string>
+    <string name="user_mute_specify_time_30_minutes_later">30分後</string>
+    <string name="user_mute_specify_time_1_hours_later">1時間後</string>
+    <string name="user_mute_specify_time_1_day_later">1日後</string>
+    <string name="user_mute_specify_time_1_week_later">1週間後</string>
+    <string name="user_mute_specify_time_1_month_later">1ヶ月後</string>
 </resources>

--- a/modules/features/user/src/main/res/values-ja/strings.xml
+++ b/modules/features/user/src/main/res/values-ja/strings.xml
@@ -12,4 +12,6 @@
     <string name="user_mute_specify_time_1_day_later">1日後</string>
     <string name="user_mute_specify_time_1_week_later">1週間後</string>
     <string name="user_mute_specify_time_1_month_later">1ヶ月後</string>
+    <string name="user_mute_specify_time_indefinite_period">無期限</string>
+
 </resources>

--- a/modules/features/user/src/main/res/values-zh/strings.xml
+++ b/modules/features/user/src/main/res/values-zh/strings.xml
@@ -12,4 +12,6 @@
     <string name="user_mute_specify_time_1_day_later">1天后</string>
     <string name="user_mute_specify_time_1_week_later">1 周后</string>
     <string name="user_mute_specify_time_1_month_later">1 个月后</string>
+    <string name="user_mute_specify_time_indefinite_period">无限期</string>
+
 </resources>

--- a/modules/features/user/src/main/res/values-zh/strings.xml
+++ b/modules/features/user/src/main/res/values-zh/strings.xml
@@ -5,4 +5,11 @@
     <string name="registration_date">注册于 %s</string>
     <string name="confirm_user_block_title">确认</string>
     <string name="confirm_user_block_description">您确定要阻止%s吗？</string>
+
+    <string name="user_mute_specify_time_15_minutes_later">15 分钟后</string>
+    <string name="user_mute_specify_time_30_minutes_later">30 分钟后</string>
+    <string name="user_mute_specify_time_1_hours_later">1 小时后</string>
+    <string name="user_mute_specify_time_1_day_later">1天后</string>
+    <string name="user_mute_specify_time_1_week_later">1 周后</string>
+    <string name="user_mute_specify_time_1_month_later">1 个月后</string>
 </resources>

--- a/modules/features/user/src/main/res/values/strings.xml
+++ b/modules/features/user/src/main/res/values/strings.xml
@@ -4,4 +4,13 @@
     <string name="registration_date">Registered on the %s</string>
     <string name="confirm_user_block_title">Confirmation</string>
     <string name="confirm_user_block_description">Are you sure you want to block %s?</string>
+
+    <string name="user_mute_specify_time_15_minutes_later">15 minutes later</string>
+    <string name="user_mute_specify_time_30_minutes_later">30 minutes later</string>
+    <string name="user_mute_specify_time_1_hours_later">1 hour later</string>
+    <string name="user_mute_specify_time_1_day_later">1 day later</string>
+    <string name="user_mute_specify_time_1_week_later">1 week later</string>
+    <string name="user_mute_specify_time_1_month_later">1 month later</string>
+
+
 </resources>

--- a/modules/features/user/src/main/res/values/strings.xml
+++ b/modules/features/user/src/main/res/values/strings.xml
@@ -11,6 +11,5 @@
     <string name="user_mute_specify_time_1_day_later">1 day later</string>
     <string name="user_mute_specify_time_1_week_later">1 week later</string>
     <string name="user_mute_specify_time_1_month_later">1 month later</string>
-
-
+    <string name="user_mute_specify_time_indefinite_period">Indefinite perio</string>
 </resources>

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/UserRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/UserRepository.kt
@@ -1,5 +1,6 @@
 package net.pantasystem.milktea.model.user
 
+import net.pantasystem.milktea.model.user.mute.CreateMute
 import net.pantasystem.milktea.model.user.query.FindUsersQuery
 import net.pantasystem.milktea.model.user.report.Report
 
@@ -17,7 +18,7 @@ interface UserRepository {
 
     suspend fun unfollow(userId: User.Id): Boolean
 
-    suspend fun mute(userId: User.Id): Boolean
+    suspend fun mute(createMute: CreateMute): Boolean
 
     suspend fun unmute(userId: User.Id): Boolean
 

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/mute/CreateMute.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/mute/CreateMute.kt
@@ -1,0 +1,9 @@
+package net.pantasystem.milktea.model.user.mute
+
+import kotlinx.datetime.Instant
+import net.pantasystem.milktea.model.user.User
+
+data class CreateMute(
+    val userId: User.Id,
+    val expiresAt: Instant? = null,
+)


### PR DESCRIPTION
## やったこと
ユーザーミュート時にミュートの期限を指定できるようにしました。
そのためにダイアログを表示して、そこで時刻の指定をできるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #497 


