### PR TITLE
カスタム絵文字がフラッシュする不具合を修正

### DIFF
--- a/modules/common_android_ui/build.gradle
+++ b/modules/common_android_ui/build.gradle
@@ -69,5 +69,7 @@ dependencies {
     implementation libs.lifecycle.viewmodel
     implementation libs.fragment.ktx
     implementation libs.activity.ktx
+    implementation libs.animation.apng
+
 
 }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
@@ -1,13 +1,18 @@
 package net.pantasystem.milktea.common_android_ui
 
 import android.net.Uri
+import android.text.Spannable
 import android.text.method.LinkMovementMethod
 import android.text.util.Linkify
 import android.widget.TextView
+import androidx.core.text.getSpans
 import androidx.databinding.BindingAdapter
+import com.bumptech.glide.load.resource.gif.GifDrawable
+import com.github.penfeizhou.animation.apng.APNGDrawable
 import jp.panta.misskeyandroidclient.mfm.Root
 import net.pantasystem.milktea.common_android.mfm.MFMParser
 import net.pantasystem.milktea.common_android.ui.text.CustomEmojiDecorator
+import net.pantasystem.milktea.common_android.ui.text.DrawableEmojiSpan
 import net.pantasystem.milktea.model.emoji.Emoji
 import java.util.regex.Pattern
 
@@ -28,6 +33,7 @@ object DecorateTextHelper {
         text?: return
         val span = CustomEmojiDecorator()
             .decorate(emojis, text, this)
+        stopDrawableAnimations(this)
         this.text = span
         if(clickableLink == true){
             decorateLink(this)
@@ -61,7 +67,25 @@ object DecorateTextHelper {
     fun TextView.decorate(node: Root?){
         node?: return
         this.movementMethod = LinkMovementMethod.getInstance()
+        stopDrawableAnimations(this)
         this.text = MFMDecorator.decorate(this, node)
+    }
+
+    fun stopDrawableAnimations(textView: TextView) {
+        val beforeText = textView.text
+        if (beforeText is Spannable) {
+            val drawableEmojiSpans = beforeText.getSpans<DrawableEmojiSpan>()
+            drawableEmojiSpans.forEach {
+                when(val imageDrawable = it.imageDrawable) {
+                    is GifDrawable -> {
+                        imageDrawable.stop()
+                    }
+                    is APNGDrawable -> {
+                        imageDrawable.stop()
+                    }
+                }
+            }
+        }
     }
 
     @BindingAdapter("sourceText", "emojis")

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/user/UserTextHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/user/UserTextHelper.kt
@@ -5,6 +5,7 @@ import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import dagger.hilt.android.EntryPointAccessors
 import net.pantasystem.milktea.common_android.ui.text.CustomEmojiDecorator
+import net.pantasystem.milktea.common_android_ui.DecorateTextHelper
 import net.pantasystem.milktea.model.user.User
 
 
@@ -30,6 +31,7 @@ object UserTextHelper {
             userName = subNameView
         }
         name?.let {
+            DecorateTextHelper.stopDrawableAnimations(it)
             name.text = CustomEmojiDecorator().decorate(user.emojis, user.displayName, name)
         }
         userName?.let {


### PR DESCRIPTION
## やったこと
RecyclerViewのViewを使い回すという特性上、同じTextViewをアニメーションのハンドラーが持ち続け
なおかつ更新し続けるため、不用意な更新が走り絵文字が点滅するという問題が発生していました。
そこでTextViewのテキストを置き換える時は以前のリソースを解放するような実装に変更しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



