### PR TITLE
タイムライン表示時に認証エラーが発生した時に、再認証用のボタンを表示するようにしました

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/MainActivityEventCollector.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/MainActivityEventCollector.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.common_android_ui.report.ReportViewModel
+import net.pantasystem.milktea.common_navigation.AuthorizationArgs
 import net.pantasystem.milktea.common_navigation.AuthorizationNavigation
 import net.pantasystem.milktea.model.CreateNoteTaskExecutor
 import net.pantasystem.milktea.model.TaskState
@@ -162,7 +163,7 @@ internal class MainActivityEventCollector (
                 accountStore.state.collect {
                     if (it.isUnauthorized) {
                         activity.startActivity(
-                            authorizationNavigation.newIntent(Unit)
+                            authorizationNavigation.newIntent(AuthorizationArgs.New)
                         )
                         activity.finish()
                     }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/AccountSwitchingDialog.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/AccountSwitchingDialog.kt
@@ -10,11 +10,12 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import net.pantasystem.milktea.common_viewmodel.viewmodel.AccountViewData
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import net.pantasystem.milktea.common_android_ui.R
+import net.pantasystem.milktea.common_navigation.AuthorizationArgs
 import net.pantasystem.milktea.common_navigation.AuthorizationNavigation
+import net.pantasystem.milktea.common_viewmodel.viewmodel.AccountViewData
 import net.pantasystem.milktea.common_viewmodel.viewmodel.AccountViewModel
 import javax.inject.Inject
 
@@ -38,7 +39,7 @@ class AccountSwitchingDialog : BottomSheetDialogFragment() {
         }
 
         view.findViewById<Button>(R.id.add_account).setOnClickListener {
-            startActivity(authorizationNavigation.newIntent(Unit))
+            startActivity(authorizationNavigation.newIntent(AuthorizationArgs.New))
             dismiss()
         }
         val accountsView = view.findViewById<RecyclerView>(R.id.accounts_view)

--- a/modules/common_navigation/src/main/java/net/pantasystem/milktea/common_navigation/AuthorizationNavigation.kt
+++ b/modules/common_navigation/src/main/java/net/pantasystem/milktea/common_navigation/AuthorizationNavigation.kt
@@ -1,4 +1,11 @@
 package net.pantasystem.milktea.common_navigation
 
+import net.pantasystem.milktea.model.account.Account
 
-interface AuthorizationNavigation : ActivityNavigation<Unit>
+
+interface AuthorizationNavigation : ActivityNavigation<AuthorizationArgs>
+
+sealed interface AuthorizationArgs {
+    object New : AuthorizationArgs
+    data class ReAuth(val account: Account?) : AuthorizationArgs
+}

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -303,11 +303,7 @@
     <string name="retry">リトライ</string>
     <string name="failed_to_get_the_note">ノートの取得に失敗しました</string>
 
-    <string name="timeout_error">タイムアウト</string>
-    <string name="server_error">サーバーエラー</string>
-    <string name="bot_error">ボットですか？</string>
-    <string name="auth_error">認証エラー</string>
-    <string name="parameter_error">パラメーターエラー</string>
+
     <string name="refresh">リフレッシュ</string>
 
     <string name="long_text">長すぎるため自動的に折りたたまれました(%d文字)</string>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -298,11 +298,7 @@
     <string name="retry">重试</string>
     <string name="failed_to_get_the_note">帖文获取失败</string>
 
-    <string name="timeout_error">超时</string>
-    <string name="server_error">服务器错误</string>
-    <string name="bot_error">你是人类吗？</string>
-    <string name="auth_error">用户身份验证错误</string>
-    <string name="parameter_error">参数错误</string>
+
     <string name="refresh">刷新</string>
 
     <string name="long_text">由于太长已为你自动折叠（文本量：%d）</string>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -299,11 +299,7 @@
     <string name="retry">Retry</string>
     <string name="failed_to_get_the_note">Failed to get note</string>
 
-    <string name="timeout_error">Timeout</string>
-    <string name="server_error">Server error</string>
-    <string name="bot_error">Are you human?</string>
-    <string name="auth_error">Authentication error</string>
-    <string name="parameter_error">Parameter error</string>
+
     <string name="refresh">Refresh</string>
 
     <string name="long_text">Collapsed automatically because it is too long(size:%d)</string>

--- a/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/GalleryPostsFragment.kt
+++ b/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/GalleryPostsFragment.kt
@@ -127,7 +127,7 @@ class GalleryPostsFragment : Fragment() {
                     if (it is APIError.ClientException && it.error?.error?.code == "PERMISSION_DENIED") {
                         Toast.makeText(requireContext(), "再認証が必要です。", Toast.LENGTH_LONG).show()
                         // 再認証をする
-                        startActivity(authorizationNavigation.newIntent(Unit))
+                        startActivity(authorizationNavigation.newIntent(AuthorizationArgs.New))
                     }
                 }
             }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
@@ -413,7 +413,7 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
                     if (it.isUnauthorized) {
                         requireActivity().finish()
                         startActivity(
-                            authorizationNavigation.newIntent(Unit)
+                            authorizationNavigation.newIntent(AuthorizationArgs.New)
                         )
                     }
                 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineErrorHandler.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineErrorHandler.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import android.widget.Toast
 import net.pantasystem.milktea.common.APIError
+import net.pantasystem.milktea.model.account.UnauthorizedException
 import net.pantasystem.milktea.note.R
 import java.io.IOException
 import java.net.SocketTimeoutException
@@ -15,13 +16,12 @@ class TimelineErrorHandler(
     operator fun invoke(error: Throwable) {
         Log.e("TimelineErrorHandler", "error", error)
         when (error) {
-            is IOException -> {
-                Toast.makeText(context, R.string.network_error, Toast.LENGTH_LONG)
-                    .show()
-
-            }
             is SocketTimeoutException -> {
                 Toast.makeText(context, R.string.timeout_error, Toast.LENGTH_LONG)
+                    .show()
+            }
+            is IOException -> {
+                Toast.makeText(context, R.string.network_error, Toast.LENGTH_LONG)
                     .show()
 
             }
@@ -41,6 +41,13 @@ class TimelineErrorHandler(
                 Toast.makeText(
                     context,
                     R.string.parameter_error,
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+            is UnauthorizedException -> {
+                Toast.makeText(
+                    context,
+                    R.string.timeline_unauthorized_error,
                     Toast.LENGTH_LONG
                 ).show()
             }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
@@ -21,6 +21,7 @@ import net.pantasystem.milktea.app_store.setting.SettingStore
 import net.pantasystem.milktea.common.ui.ApplyMenuTint
 import net.pantasystem.milktea.common.ui.PageableView
 import net.pantasystem.milktea.common.ui.ScrollableTop
+import net.pantasystem.milktea.common_navigation.AuthorizationArgs
 import net.pantasystem.milktea.common_navigation.AuthorizationNavigation
 import net.pantasystem.milktea.common_navigation.UserDetailNavigation
 import net.pantasystem.milktea.common_viewmodel.CurrentPageableTimelineViewModel
@@ -127,7 +128,7 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
                 mViewModel.loadInit()
             },
             onReauthenticateAction = {
-                startActivity(authorizationNavigation.newIntent(Unit))
+                startActivity(authorizationNavigation.newIntent(AuthorizationArgs.New))
             },
         ) {
             NoteCardActionHandler(

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
@@ -17,6 +17,7 @@ import com.wada811.databinding.dataBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
+import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.app_store.setting.SettingStore
 import net.pantasystem.milktea.common.ui.ApplyMenuTint
 import net.pantasystem.milktea.common.ui.PageableView
@@ -92,6 +93,9 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
     @Inject
     lateinit var authorizationNavigation: AuthorizationNavigation
 
+    @Inject
+    lateinit var accountStore: AccountStore
+
 
     private val mBinding: FragmentSwipeRefreshRecyclerViewBinding by dataBinding()
 
@@ -128,7 +132,13 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
                 mViewModel.loadInit()
             },
             onReauthenticateAction = {
-                startActivity(authorizationNavigation.newIntent(AuthorizationArgs.New))
+                startActivity(
+                    authorizationNavigation.newIntent(
+                        AuthorizationArgs.ReAuth(
+                            accountStore.currentAccount
+                        )
+                    )
+                )
             },
         ) {
             NoteCardActionHandler(
@@ -237,8 +247,6 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
         isShowing = false
         Log.d("TimelineFragment", "onPause")
     }
-
-
 
 
     @ExperimentalCoroutinesApi

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
@@ -21,6 +21,7 @@ import net.pantasystem.milktea.app_store.setting.SettingStore
 import net.pantasystem.milktea.common.ui.ApplyMenuTint
 import net.pantasystem.milktea.common.ui.PageableView
 import net.pantasystem.milktea.common.ui.ScrollableTop
+import net.pantasystem.milktea.common_navigation.AuthorizationNavigation
 import net.pantasystem.milktea.common_navigation.UserDetailNavigation
 import net.pantasystem.milktea.common_viewmodel.CurrentPageableTimelineViewModel
 import net.pantasystem.milktea.model.account.page.Page
@@ -87,6 +88,9 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
     @Inject
     lateinit var setMenuTint: ApplyMenuTint
 
+    @Inject
+    lateinit var authorizationNavigation: AuthorizationNavigation
+
 
     private val mBinding: FragmentSwipeRefreshRecyclerViewBinding by dataBinding()
 
@@ -117,9 +121,15 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
         super.onViewCreated(view, savedInstanceState)
 
         mLinearLayoutManager = LinearLayoutManager(this.requireContext())
-        val adapter = TimelineListAdapter(viewLifecycleOwner, {
-            mViewModel.loadInit()
-        }) {
+        val adapter = TimelineListAdapter(
+            viewLifecycleOwner,
+            onRefreshAction = {
+                mViewModel.loadInit()
+            },
+            onReauthenticateAction = {
+                startActivity(authorizationNavigation.newIntent(Unit))
+            },
+        ) {
             NoteCardActionHandler(
                 requireActivity() as AppCompatActivity,
                 notesViewModel,

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
@@ -22,7 +22,8 @@ import net.pantasystem.milktea.model.notes.reaction.ReactionCount
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.ItemHasReplyToNoteBinding
 import net.pantasystem.milktea.note.databinding.ItemNoteBinding
-import net.pantasystem.milktea.note.databinding.ItemTimelineEmptyOrErrorBinding
+import net.pantasystem.milktea.note.databinding.ItemTimelineEmptyBinding
+import net.pantasystem.milktea.note.databinding.ItemTimelineErrorBinding
 import net.pantasystem.milktea.note.poll.PollListAdapter
 import net.pantasystem.milktea.note.reaction.ReactionCountAdapter
 import net.pantasystem.milktea.note.timeline.viewmodel.TimelineListItem
@@ -155,23 +156,19 @@ class TimelineListAdapter(
 
     class LoadingViewHolder(view: View) : TimelineListItemViewHolderBase(view)
 
-    class ErrorViewHolder(val binding: ItemTimelineEmptyOrErrorBinding) : TimelineListItemViewHolderBase(binding.root) {
-        fun bind(throwable: Throwable) {
+    class ErrorViewHolder(val binding: ItemTimelineErrorBinding) : TimelineListItemViewHolderBase(binding.root) {
+        fun bind(item: TimelineListItem.Error) {
+            binding.errorItem = item
             binding.errorView.isVisible = false
             binding.showErrorMessageButton.isVisible = true
-            binding.errorView.text = throwable.toString()
+            binding.errorView.text = item.throwable.toString()
             binding.showErrorMessageButton.setOnClickListener {
                 binding.errorView.isVisible = true
             }
         }
     }
 
-    class EmptyViewHolder(val binding: ItemTimelineEmptyOrErrorBinding) : TimelineListItemViewHolderBase(binding.root) {
-        fun bind() {
-            binding.errorView.isVisible = false
-            binding.showErrorMessageButton.isVisible = false
-        }
-    }
+    class EmptyViewHolder(val binding: ItemTimelineEmptyBinding) : TimelineListItemViewHolderBase(binding.root)
 
     enum class ViewHolderType {
         NormalNote, HasReplyToNote, Loading, Empty, Error
@@ -259,13 +256,12 @@ class TimelineListAdapter(
                 p0.binding.retryLoadButton.setOnClickListener {
                     onRefreshAction()
                 }
-                p0.bind()
             }
             is ErrorViewHolder -> {
                 p0.binding.retryLoadButton.setOnClickListener {
                     onRefreshAction()
                 }
-                p0.bind((item as TimelineListItem.Error).throwable)
+                p0.bind((item as TimelineListItem.Error))
             }
         }
 
@@ -285,10 +281,10 @@ class TimelineListAdapter(
                 LoadingViewHolder(LayoutInflater.from(p0.context).inflate(R.layout.item_timeline_loading, p0, false))
             }
             ViewHolderType.Empty -> {
-                EmptyViewHolder(DataBindingUtil.inflate(LayoutInflater.from(p0.context), R.layout.item_timeline_empty_or_error, p0, false))
+                EmptyViewHolder(DataBindingUtil.inflate(LayoutInflater.from(p0.context), R.layout.item_timeline_empty, p0, false))
             }
             ViewHolderType.Error -> {
-                ErrorViewHolder(DataBindingUtil.inflate(LayoutInflater.from(p0.context), R.layout.item_timeline_empty_or_error, p0, false))
+                ErrorViewHolder(DataBindingUtil.inflate(LayoutInflater.from(p0.context), R.layout.item_timeline_error, p0, false))
             }
         }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
@@ -35,6 +35,7 @@ import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
 class TimelineListAdapter(
     private val lifecycleOwner: LifecycleOwner,
     val onRefreshAction: () -> Unit,
+    val onReauthenticateAction: () -> Unit,
     val onAction: (NoteCardAction) -> Unit,
 ) : ListAdapter<TimelineListItem, TimelineListAdapter.TimelineListItemViewHolderBase>(object : DiffUtil.ItemCallback<TimelineListItem>() {
     override fun areContentsTheSame(
@@ -260,6 +261,9 @@ class TimelineListAdapter(
             is ErrorViewHolder -> {
                 p0.binding.retryLoadButton.setOnClickListener {
                     onRefreshAction()
+                }
+                p0.binding.reauthenticateButton.setOnClickListener {
+                    onReauthenticateAction()
                 }
                 p0.bind((item as TimelineListItem.Error))
             }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -16,20 +16,26 @@ import kotlinx.datetime.Instant
 import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.app_store.notes.NoteTranslationStore
 import net.pantasystem.milktea.app_store.notes.TimelineStore
+import net.pantasystem.milktea.common.APIError
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common.PageableState
 import net.pantasystem.milktea.common.StateContent
+import net.pantasystem.milktea.common_android.resource.StringSource
 import net.pantasystem.milktea.data.gettters.NoteRelationGetter
 import net.pantasystem.milktea.data.infrastructure.url.UrlPreviewStoreProvider
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.account.CurrentAccountWatcher
+import net.pantasystem.milktea.model.account.UnauthorizedException
 import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.model.notes.NoteCaptureAPIAdapter
 import net.pantasystem.milktea.model.notes.NoteStreaming
 import net.pantasystem.milktea.model.notes.muteword.WordFilterConfigRepository
+import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewDataCache
+import java.io.IOException
+import java.net.SocketTimeoutException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TimelineViewModel @AssistedInject constructor(
@@ -179,7 +185,36 @@ fun TimelineViewModel.Companion.provideViewModel(
 sealed interface TimelineListItem {
     object Loading : TimelineListItem
     data class Note(val note: PlaneNoteViewData) : TimelineListItem
-    data class Error(val throwable: Throwable) : TimelineListItem
+    data class Error(val throwable: Throwable) : TimelineListItem {
+        fun getErrorMessage(): StringSource {
+            return when(throwable) {
+                is SocketTimeoutException -> {
+                    StringSource(R.string.timeout_error)
+                }
+                is IOException -> {
+                    StringSource(R.string.timeout_error)
+                }
+                is APIError.AuthenticationException -> {
+                    StringSource(R.string.auth_error)
+                }
+                is APIError.IAmAIException -> {
+                    StringSource(R.string.bot_error)
+                }
+                is APIError.InternalServerException -> {
+                    StringSource(R.string.server_error)
+                }
+                is APIError.ClientException -> {
+                    StringSource(R.string.parameter_error)
+                }
+                is UnauthorizedException -> {
+                    StringSource(R.string.timeline_unauthorized_error)
+                }
+                else -> {
+                    StringSource("error:$throwable")
+                }
+            }
+        }
+    }
     object Empty : TimelineListItem
 }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -214,6 +214,11 @@ sealed interface TimelineListItem {
                 }
             }
         }
+
+        fun isUnauthorizedError(): Boolean {
+            return throwable is APIError.AuthenticationException
+                    || throwable is UnauthorizedException
+        }
     }
     object Empty : TimelineListItem
 }

--- a/modules/features/note/src/main/res/layout/item_timeline_empty.xml
+++ b/modules/features/note/src/main/res/layout/item_timeline_empty.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <LinearLayout android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center_vertical"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="16dp"
+            xmlns:android="http://schemas.android.com/apk/res/android">
+        <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/failed_to_get_the_note"
+                />
+        <Button
+                android:id="@+id/retryLoadButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/retry"/>
+
+    </LinearLayout>
+</layout>

--- a/modules/features/note/src/main/res/layout/item_timeline_error.xml
+++ b/modules/features/note/src/main/res/layout/item_timeline_error.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout>
     <data>
+        <import type="android.view.View" />
         <variable
                 name="errorItem"
                 type="net.pantasystem.milktea.note.timeline.viewmodel.TimelineListItem.Error" />
@@ -25,11 +26,21 @@
                 android:layout_height="wrap_content"
                 android:text="@string/retry"/>
 
-        <TextView
+        <Button
+                android:id="@+id/reauthenticateButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/reauthenticate"
+                android:visibility="@{errorItem.unauthorizedError ? View.VISIBLE : View.GONE }"
+                />
+
+        <Button
                 android:id="@+id/showErrorMessageButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/show_error"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+
                 />
         <TextView
                 android:id="@+id/errorView"

--- a/modules/features/note/src/main/res/layout/item_timeline_error.xml
+++ b/modules/features/note/src/main/res/layout/item_timeline_error.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout>
+    <data>
+        <variable
+                name="errorItem"
+                type="net.pantasystem.milktea.note.timeline.viewmodel.TimelineListItem.Error" />
+    </data>
     <LinearLayout android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_gravity="center_vertical"
@@ -12,6 +17,7 @@
                 android:layout_height="wrap_content"
                 android:gravity="center"
                 android:text="@string/failed_to_get_the_note"
+                stringSource="@{errorItem.errorMessage}"
                 />
         <Button
                 android:id="@+id/retryLoadButton"

--- a/modules/features/note/src/main/res/values-ja/strings.xml
+++ b/modules/features/note/src/main/res/values-ja/strings.xml
@@ -3,4 +3,11 @@
     <string name="time_machine">タイムマシーン</string>
     <string name="dialog_timemachine_message">表示したいタイムラインの時間を指定してください</string>
     <string name="show_error">Show Error</string>
+
+    <string name="timeout_error">タイムアウト</string>
+    <string name="server_error">サーバーエラー</string>
+    <string name="bot_error">ボットですか？</string>
+    <string name="auth_error">認証エラー</string>
+    <string name="parameter_error">パラメーターエラー</string>
+    <string name="timeline_unauthorized_error">未認証エラー</string>
 </resources>

--- a/modules/features/note/src/main/res/values-ja/strings.xml
+++ b/modules/features/note/src/main/res/values-ja/strings.xml
@@ -10,4 +10,5 @@
     <string name="auth_error">認証エラー</string>
     <string name="parameter_error">パラメーターエラー</string>
     <string name="timeline_unauthorized_error">未認証エラー</string>
+    <string name="reauthenticate">再認証する</string>
 </resources>

--- a/modules/features/note/src/main/res/values-zh/strings.xml
+++ b/modules/features/note/src/main/res/values-zh/strings.xml
@@ -3,4 +3,11 @@
     <string name="time_machine">回到未来</string>
     <string name="dialog_timemachine_message">请指定您要显示的时间线的时间</string>
     <string name="show_error">Show Error</string>
+
+    <string name="timeout_error">超时</string>
+    <string name="server_error">服务器错误</string>
+    <string name="bot_error">你是人类吗？</string>
+    <string name="auth_error">用户身份验证错误</string>
+    <string name="parameter_error">参数错误</string>
+    <string name="timeline_unauthorized_error">未認証エラー</string>
 </resources>

--- a/modules/features/note/src/main/res/values-zh/strings.xml
+++ b/modules/features/note/src/main/res/values-zh/strings.xml
@@ -10,4 +10,5 @@
     <string name="auth_error">用户身份验证错误</string>
     <string name="parameter_error">参数错误</string>
     <string name="timeline_unauthorized_error">未認証エラー</string>
+    <string name="reauthenticate">重新认证</string>
 </resources>

--- a/modules/features/note/src/main/res/values/strings.xml
+++ b/modules/features/note/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="auth_error">Authentication error</string>
     <string name="parameter_error">Parameter error</string>
     <string name="timeline_unauthorized_error">Unauthorized error</string>
+    <string name="reauthenticate">Reauthenticate</string>
 </resources>

--- a/modules/features/note/src/main/res/values/strings.xml
+++ b/modules/features/note/src/main/res/values/strings.xml
@@ -2,4 +2,11 @@
     <string name="time_machine">Back to the future</string>
     <string name="dialog_timemachine_message">Please specify the time of the timeline you want to display</string>
     <string name="show_error">Show Error</string>
+
+    <string name="timeout_error">Timeout</string>
+    <string name="server_error">Server error</string>
+    <string name="bot_error">Are you human?</string>
+    <string name="auth_error">Authentication error</string>
+    <string name="parameter_error">Parameter error</string>
+    <string name="timeline_unauthorized_error">Unauthorized error</string>
 </resources>

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/PinNoteFragment.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/PinNoteFragment.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import net.pantasystem.milktea.app_store.setting.SettingStore
+import net.pantasystem.milktea.common_navigation.AuthorizationNavigation
 import net.pantasystem.milktea.common_navigation.UserDetailNavigation
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.note.timeline.TimelineListAdapter
@@ -60,6 +61,9 @@ class PinNoteFragment : Fragment(R.layout.fragment_pin_note) {
     @Inject
     lateinit var userDetailNavigation: UserDetailNavigation
 
+    @Inject
+    lateinit var authorizationNavigation: AuthorizationNavigation
+
     @ExperimentalCoroutinesApi
     val userViewModel: UserDetailViewModel by activityViewModels {
 
@@ -82,6 +86,8 @@ class PinNoteFragment : Fragment(R.layout.fragment_pin_note) {
         val notesViewModel = ViewModelProvider(requireActivity())[NotesViewModel::class.java]
         val adapter = TimelineListAdapter(viewLifecycleOwner, {
             userViewModel.sync()
+        }, {
+            authorizationNavigation.newIntent(Unit)
         }) {
             NoteCardActionHandler(
                 requireActivity() as AppCompatActivity,

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/PinNoteFragment.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/PinNoteFragment.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import net.pantasystem.milktea.app_store.setting.SettingStore
+import net.pantasystem.milktea.common_navigation.AuthorizationArgs
 import net.pantasystem.milktea.common_navigation.AuthorizationNavigation
 import net.pantasystem.milktea.common_navigation.UserDetailNavigation
 import net.pantasystem.milktea.model.user.User
@@ -87,7 +88,7 @@ class PinNoteFragment : Fragment(R.layout.fragment_pin_note) {
         val adapter = TimelineListAdapter(viewLifecycleOwner, {
             userViewModel.sync()
         }, {
-            authorizationNavigation.newIntent(Unit)
+            authorizationNavigation.newIntent(AuthorizationArgs.New)
         }) {
             NoteCardActionHandler(
                 requireActivity() as AppCompatActivity,


### PR DESCRIPTION
## やったこと
タイムライン表示時のローディング時に、認証エラーが発生した時は、
再認証用のボタンを表示するようにしました。
また再認証用のボタンを押した時に、ログインしているアカウントがあれば、
認証画面のホスト部の初期値にそのアカウントのホストを入れるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #911 


