### PR TITLE
WebView経由でリアクションピッカーの設定状態を取り込めるようにしました

### DIFF
--- a/modules/features/setting/build.gradle
+++ b/modules/features/setting/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation libs.appcompat.appcompat
     implementation libs.android.material.material
     implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/modules/features/setting/build.gradle
+++ b/modules/features/setting/build.gradle
@@ -105,6 +105,8 @@ dependencies {
     implementation libs.flexbox
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation "com.squareup.retrofit2:retrofit:$retrofit"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0"
+
 
 
 }

--- a/modules/features/setting/src/main/AndroidManifest.xml
+++ b/modules/features/setting/src/main/AndroidManifest.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="net.pantasystem.milktea.setting">
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application>
         <activity
-                android:name="net.pantasystem.milktea.setting.activities.ClientWordFilterSettingActivity"
+                android:name=".activities.ImportReactionFromWebViewActivity"
+                android:exported="false">
+            <meta-data
+                    android:name="android.app.lib_name"
+                    android:value="" />
+        </activity>
+        <activity
+                android:name=".activities.ClientWordFilterSettingActivity"
                 android:exported="false" />
     </application>
 

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ImportReactionFromWebViewActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ImportReactionFromWebViewActivity.kt
@@ -3,19 +3,35 @@ package net.pantasystem.milktea.setting.activities
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.util.Log
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.MenuProvider
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.whenResumed
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.wada811.databinding.dataBinding
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import net.pantasystem.milktea.app_store.account.AccountStore
+import net.pantasystem.milktea.common.ui.ApplyTheme
+import net.pantasystem.milktea.common_android_ui.reaction.ReactionChoicesAdapter
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.setting.R
 import net.pantasystem.milktea.setting.databinding.ActivityImportReactionFromWebViewBinding
 import net.pantasystem.milktea.setting.viewmodel.ImportReactionFromWebViewViewModel
-import java.util.*
 import javax.inject.Inject
 
 const val EXTRA_ACCOUNT_HOST = "EXTRA_ACCOUNT_HOST"
@@ -31,26 +47,75 @@ class ImportReactionFromWebViewActivity : AppCompatActivity() {
     }
 
     private val jsInterfaceName by lazy {
-        UUID.randomUUID().toString()
+        "milktea"
     }
 
     private val binding: ActivityImportReactionFromWebViewBinding by dataBinding()
 
     private val importReactionFromWebViewViewModel: ImportReactionFromWebViewViewModel by viewModels()
 
+    @Inject
+    lateinit var applyTheme: ApplyTheme
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @SuppressLint("SetJavaScriptEnabled", "JavascriptInterface")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        applyTheme()
         setContentView(R.layout.activity_import_reaction_from_web_view)
 
         setupWebView()
+        setSupportActionBar(binding.topToolbar)
+
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                when(menuItem.itemId) {
+                    android.R.id.home -> {
+                        finish()
+                    }
+                }
+                return true
+            }
+        })
 
         binding.webView.loadUrl("https://$host/settings/reaction")
 
 
         binding.importButton.setOnClickListener {
             executeImportReactionsScript(accountStore.currentAccount)
+        }
+
+        val adapter = ReactionChoicesAdapter {}
+
+        binding.reactionsAdapter.adapter = adapter
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                importReactionFromWebViewViewModel.reactions.collect {
+                    adapter.submitList(it)
+                }
+            }
+        }
+        binding.reactionsAdapter.layoutManager =
+            LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false)
+
+        binding.overrideSaveButton.setOnClickListener {
+            importReactionFromWebViewViewModel.onOverwriteButtonClicked()
+        }
+
+        lifecycleScope.launch {
+            whenResumed {
+                (0..Int.MAX_VALUE).asFlow().map {
+                    delay(500)
+                }.flatMapLatest {
+                    accountStore.observeCurrentAccount
+                }.collect {
+                    executeImportReactionsScript(it)
+                }
+            }
         }
     }
 
@@ -76,15 +141,17 @@ class ImportReactionFromWebViewActivity : AppCompatActivity() {
     }
 
     fun executeImportReactionsScript(current: Account?) {
-        binding.webView.evaluateJavascript(
-            """
-                $jsInterfaceName.setLocalStorageCache(
-                    window.localStorage
-                        .getItem(
-                            'pizzax::base::cache::${current?.remoteId}'
-                        )
+        val script = """
+        $jsInterfaceName.setLocalStorageCache(
+            window.localStorage
+                .getItem(
+                    'pizzax::base::cache::${current?.remoteId}'
                 )
-                """.trimIndent()
+            )
+        """.trimIndent()
+        Log.d("ImportReactionFrom", "script:$script")
+        binding.webView.evaluateJavascript(
+            script
         ) {
             Log.d("ImportReactionFrom", "result:$it")
         }

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ImportReactionFromWebViewActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ImportReactionFromWebViewActivity.kt
@@ -15,7 +15,6 @@ import androidx.core.view.MenuProvider
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.lifecycle.whenResumed
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.wada811.databinding.dataBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -66,6 +65,7 @@ class ImportReactionFromWebViewActivity : AppCompatActivity() {
 
         setupWebView()
         setSupportActionBar(binding.topToolbar)
+        supportActionBar?.setTitle(R.string.import_reactions_from_the_web)
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         addMenuProvider(object : MenuProvider {
@@ -107,7 +107,7 @@ class ImportReactionFromWebViewActivity : AppCompatActivity() {
         }
 
         lifecycleScope.launch {
-            whenResumed {
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 (0..Int.MAX_VALUE).asFlow().map {
                     delay(500)
                 }.flatMapLatest {

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ImportReactionFromWebViewActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ImportReactionFromWebViewActivity.kt
@@ -124,9 +124,7 @@ class ImportReactionFromWebViewActivity : AppCompatActivity() {
         binding.webView.settings.javaScriptEnabled = true
         binding.webView.settings.domStorageEnabled = true
         binding.webView.addJavascriptInterface(
-            LocalStorageResultJSInterface(
-                importReactionFromWebViewViewModel
-            ), jsInterfaceName
+            jsInterface, jsInterfaceName
         )
 
         val current = accountStore.currentAccount
@@ -155,6 +153,15 @@ class ImportReactionFromWebViewActivity : AppCompatActivity() {
         ) {
             Log.d("ImportReactionFrom", "result:$it")
         }
+    }
+
+    private val jsInterface: LocalStorageResultJSInterface by lazy {
+        LocalStorageResultJSInterface(importReactionFromWebViewViewModel)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        binding.webView.removeJavascriptInterface(jsInterfaceName)
     }
 }
 

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ImportReactionFromWebViewActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ImportReactionFromWebViewActivity.kt
@@ -1,12 +1,103 @@
 package net.pantasystem.milktea.setting.activities
 
-import androidx.appcompat.app.AppCompatActivity
+import android.annotation.SuppressLint
 import android.os.Bundle
+import android.util.Log
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import com.wada811.databinding.dataBinding
+import dagger.hilt.android.AndroidEntryPoint
+import net.pantasystem.milktea.app_store.account.AccountStore
+import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.setting.R
+import net.pantasystem.milktea.setting.databinding.ActivityImportReactionFromWebViewBinding
+import net.pantasystem.milktea.setting.viewmodel.ImportReactionFromWebViewViewModel
+import java.util.*
+import javax.inject.Inject
 
+const val EXTRA_ACCOUNT_HOST = "EXTRA_ACCOUNT_HOST"
+
+@AndroidEntryPoint
 class ImportReactionFromWebViewActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var accountStore: AccountStore
+
+    private val host by lazy {
+        intent.getStringExtra(EXTRA_ACCOUNT_HOST)
+    }
+
+    private val jsInterfaceName by lazy {
+        UUID.randomUUID().toString()
+    }
+
+    private val binding: ActivityImportReactionFromWebViewBinding by dataBinding()
+
+    private val importReactionFromWebViewViewModel: ImportReactionFromWebViewViewModel by viewModels()
+
+
+    @SuppressLint("SetJavaScriptEnabled", "JavascriptInterface")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_import_reaction_from_web_view)
+
+        setupWebView()
+
+        binding.webView.loadUrl("https://$host/settings/reaction")
+
+
+        binding.importButton.setOnClickListener {
+            executeImportReactionsScript(accountStore.currentAccount)
+        }
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    fun setupWebView() {
+        binding.webView.settings.javaScriptEnabled = true
+        binding.webView.settings.domStorageEnabled = true
+        binding.webView.addJavascriptInterface(
+            LocalStorageResultJSInterface(
+                importReactionFromWebViewViewModel
+            ), jsInterfaceName
+        )
+
+        val current = accountStore.currentAccount
+
+        binding.webView.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView?, url: String?) {
+                super.onPageFinished(view, url)
+                executeImportReactionsScript(current)
+            }
+
+        }
+    }
+
+    fun executeImportReactionsScript(current: Account?) {
+        binding.webView.evaluateJavascript(
+            """
+                $jsInterfaceName.setLocalStorageCache(
+                    window.localStorage
+                        .getItem(
+                            'pizzax::base::cache::${current?.remoteId}'
+                        )
+                )
+                """.trimIndent()
+        ) {
+            Log.d("ImportReactionFrom", "result:$it")
+        }
+    }
+}
+
+class LocalStorageResultJSInterface(
+    private val importReactionFromWebViewViewModel: ImportReactionFromWebViewViewModel
+) {
+
+    @JavascriptInterface
+    fun setLocalStorageCache(cache: String) {
+        Log.d("setLocalStorageCache", "cache:$cache")
+        importReactionFromWebViewViewModel.onLocalStorageCacheLoaded(cache)
     }
 }

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ImportReactionFromWebViewActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ImportReactionFromWebViewActivity.kt
@@ -1,0 +1,12 @@
+package net.pantasystem.milktea.setting.activities
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import net.pantasystem.milktea.setting.R
+
+class ImportReactionFromWebViewActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_import_reaction_from_web_view)
+    }
+}

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ReactionSettingActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ReactionSettingActivity.kt
@@ -134,9 +134,9 @@ class ReactionSettingActivity : AppCompatActivity() {
 
         binding.importReactionFromWebButton.setOnClickListener {
             val intent = Intent(this, ImportReactionFromWebViewActivity::class.java)
-
+            intent.putExtra(EXTRA_ACCOUNT_HOST, accountStore.currentAccount?.getHost())
             startActivity(intent)
-
+            finish()
         }
 
 

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ReactionSettingActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ReactionSettingActivity.kt
@@ -1,5 +1,6 @@
 package net.pantasystem.milktea.setting.activities
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.MenuItem
@@ -128,6 +129,14 @@ class ReactionSettingActivity : AppCompatActivity() {
             override fun onNothingSelected(p0: AdapterView<*>?) {
 
             }
+        }
+
+
+        binding.importReactionFromWebButton.setOnClickListener {
+            val intent = Intent(this, ImportReactionFromWebViewActivity::class.java)
+
+            startActivity(intent)
+
         }
 
 

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/ImportReactionFromWebViewViewModel.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/ImportReactionFromWebViewViewModel.kt
@@ -1,0 +1,34 @@
+package net.pantasystem.milktea.setting.viewmodel
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import net.pantasystem.milktea.app_store.account.AccountStore
+import net.pantasystem.milktea.model.setting.WebClientBaseCache
+import javax.inject.Inject
+
+@HiltViewModel
+class ImportReactionFromWebViewViewModel @Inject constructor(
+    val accountStore: AccountStore
+) : ViewModel() {
+
+
+    private val _reactions = MutableStateFlow(listOf<String>())
+    val reactions: StateFlow<List<String>> = _reactions
+
+    fun onLocalStorageCacheLoaded(result: String) {
+        val decoder = Json {
+            ignoreUnknownKeys = true
+        }
+        runCatching {
+            decoder.decodeFromString<WebClientBaseCache>(result)
+        }.onSuccess {
+            _reactions.value = it.reactions
+        }
+
+    }
+}
+

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/ImportReactionFromWebViewViewModel.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/ImportReactionFromWebViewViewModel.kt
@@ -1,20 +1,32 @@
 package net.pantasystem.milktea.setting.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import net.pantasystem.milktea.app_store.account.AccountStore
+import net.pantasystem.milktea.common.Logger
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.notes.reaction.usercustom.ReactionUserSetting
+import net.pantasystem.milktea.model.notes.reaction.usercustom.ReactionUserSettingDao
 import net.pantasystem.milktea.model.setting.WebClientBaseCache
 import javax.inject.Inject
 
 @HiltViewModel
 class ImportReactionFromWebViewViewModel @Inject constructor(
-    val accountStore: AccountStore
+    val accountStore: AccountStore,
+    loggerFactory: Logger.Factory,
+    private val reactionUserSettingDao: ReactionUserSettingDao,
+    private val accountRepository: AccountRepository
 ) : ViewModel() {
 
+    val logger = loggerFactory.create("IRFWVViewModel")
 
     private val _reactions = MutableStateFlow(listOf<String>())
     val reactions: StateFlow<List<String>> = _reactions
@@ -27,8 +39,30 @@ class ImportReactionFromWebViewViewModel @Inject constructor(
             decoder.decodeFromString<WebClientBaseCache>(result)
         }.onSuccess {
             _reactions.value = it.reactions
+        }.onFailure {
+            logger.error("onLocalStorageCacheLoaded decode json error", it)
         }
 
+    }
+
+    fun onOverwriteButtonClicked() {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+
+                val account = accountRepository.getCurrentAccount().getOrThrow()
+                reactionUserSettingDao.deleteAll(reactionUserSettingDao.findByInstanceDomain(account.instanceDomain) ?: emptyList())
+                val settings = reactions.value.mapIndexed { i, reaction ->
+                    ReactionUserSetting(
+                        reaction,
+                        account.instanceDomain,
+                        i
+                    )
+                }
+                reactionUserSettingDao.insertAll(settings)
+            } catch (e: Exception) {
+                Log.e("ReactionPickerSettingVM", "save error", e)
+            }
+        }
     }
 }
 

--- a/modules/features/setting/src/main/res/layout/activity_import_reaction_from_web_view.xml
+++ b/modules/features/setting/src/main/res/layout/activity_import_reaction_from_web_view.xml
@@ -6,10 +6,54 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             tools:context=".activities.ImportReactionFromWebViewActivity">
+        <androidx.appcompat.widget.Toolbar
+                android:id="@+id/topToolbar"
+                android:layout_width="match_parent"
+                android:layout_height="56dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"/>
 
         <WebView
                 android:id="@+id/webView"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintTop_toBottomOf="@id/topToolbar"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/bottomToolbar"/>
+        <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/bottomToolbar"
+
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="wrap_content"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:padding="8dp">
+            <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/reactionsAdapter"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toTopOf="@id/importButton"
+                    app:layout_constraintEnd_toEndOf="parent" />
+            <Button
+                    android:id="@+id/overrideSaveButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintEnd_toStartOf="@id/importButton"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    android:text="@string/overwrite_save"/>
+            <Button
+                    android:id="@+id/importButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    android:text="@string/import_reactions"/>
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/modules/features/setting/src/main/res/layout/activity_import_reaction_from_web_view.xml
+++ b/modules/features/setting/src/main/res/layout/activity_import_reaction_from_web_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:context=".activities.ImportReactionFromWebViewActivity">
+
+        <WebView
+                android:id="@+id/webView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/modules/features/setting/src/main/res/layout/activity_reaction_setting.xml
+++ b/modules/features/setting/src/main/res/layout/activity_reaction_setting.xml
@@ -83,6 +83,12 @@
                         android:layout_height="wrap_content"
                         android:text="@string/set_the_reaction_displayed_in_the_reaction_picker"/>
 
+                <Button
+                        android:id="@+id/importReactionFromWebButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/import_reactions_from_the_web"/>
+
 
             </LinearLayout>
         </ScrollView>

--- a/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
+++ b/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
@@ -2,5 +2,6 @@
 <resources>
     <string name="client_word_mute">クライアントワードミュート</string>
     <string name="client_word_mute_format_description">スペースで区切るとAND指定になり、改行で区切るとOR指定になります。\nキーワードをスラッシュで囲むと正規表現になります。</string>
+    <string name="import_reactions_from_the_web">Import reactions from the web</string>
 
 </resources>

--- a/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
+++ b/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
@@ -2,8 +2,8 @@
 <resources>
     <string name="client_word_mute">クライアントワードミュート</string>
     <string name="client_word_mute_format_description">スペースで区切るとAND指定になり、改行で区切るとOR指定になります。\nキーワードをスラッシュで囲むと正規表現になります。</string>
-    <string name="import_reactions_from_the_web">Import reactions from the web</string>
-    <string name="import_reactions">Import reactions</string>
-    <string name="overwrite_save">Overwrite save</string>
+    <string name="import_reactions_from_the_web">リアクションをWebから取り込み</string>
+    <string name="import_reactions">取り込み</string>
+    <string name="overwrite_save">上書き保存</string>
 
 </resources>

--- a/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
+++ b/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
@@ -3,5 +3,7 @@
     <string name="client_word_mute">クライアントワードミュート</string>
     <string name="client_word_mute_format_description">スペースで区切るとAND指定になり、改行で区切るとOR指定になります。\nキーワードをスラッシュで囲むと正規表現になります。</string>
     <string name="import_reactions_from_the_web">Import reactions from the web</string>
+    <string name="import_reactions">Import reactions</string>
+    <string name="overwrite_save">Overwrite save</string>
 
 </resources>

--- a/modules/features/setting/src/main/res/values-zh/strings.xml
+++ b/modules/features/setting/src/main/res/values-zh/strings.xml
@@ -2,8 +2,8 @@
 <resources>
     <string name="client_word_mute">应用程序字静音</string>
     <string name="client_word_mute_format_description">用空格分隔会产生 AND 规范，用换行符分隔会产生 OR 规范。 \n关键字周围的斜线使其成为正则表达式。</string>
-    <string name="import_reactions_from_the_web">Import reactions from the web</string>
-    <string name="import_reactions">Import reactions</string>
-    <string name="overwrite_save">Overwrite save</string>
+    <string name="import_reactions_from_the_web">从网络导入反应</string>
+    <string name="import_reactions">进口反应</string>
+    <string name="overwrite_save">覆盖保存</string>
 
 </resources>

--- a/modules/features/setting/src/main/res/values-zh/strings.xml
+++ b/modules/features/setting/src/main/res/values-zh/strings.xml
@@ -2,5 +2,6 @@
 <resources>
     <string name="client_word_mute">应用程序字静音</string>
     <string name="client_word_mute_format_description">用空格分隔会产生 AND 规范，用换行符分隔会产生 OR 规范。 \n关键字周围的斜线使其成为正则表达式。</string>
+    <string name="import_reactions_from_the_web">Import reactions from the web</string>
 
 </resources>

--- a/modules/features/setting/src/main/res/values-zh/strings.xml
+++ b/modules/features/setting/src/main/res/values-zh/strings.xml
@@ -3,5 +3,7 @@
     <string name="client_word_mute">应用程序字静音</string>
     <string name="client_word_mute_format_description">用空格分隔会产生 AND 规范，用换行符分隔会产生 OR 规范。 \n关键字周围的斜线使其成为正则表达式。</string>
     <string name="import_reactions_from_the_web">Import reactions from the web</string>
+    <string name="import_reactions">Import reactions</string>
+    <string name="overwrite_save">Overwrite save</string>
 
 </resources>

--- a/modules/features/setting/src/main/res/values/strings.xml
+++ b/modules/features/setting/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="client_word_mute">Client Word mute</string>
     <string name="client_word_mute_format_description">Delimiting with a space results in an AND specification, and delimiting with a line break results in an OR specification. \nSlashes around the keyword make it a regular expression.</string>
+    <string name="import_reactions_from_the_web">Import reactions from the web</string>
 </resources>

--- a/modules/features/setting/src/main/res/values/strings.xml
+++ b/modules/features/setting/src/main/res/values/strings.xml
@@ -3,4 +3,6 @@
     <string name="client_word_mute">Client Word mute</string>
     <string name="client_word_mute_format_description">Delimiting with a space results in an AND specification, and delimiting with a line break results in an OR specification. \nSlashes around the keyword make it a regular expression.</string>
     <string name="import_reactions_from_the_web">Import reactions from the web</string>
+    <string name="import_reactions">Import reactions</string>
+    <string name="overwrite_save">Overwrite save</string>
 </resources>

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/WebClientBaseCache.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/WebClientBaseCache.kt
@@ -1,0 +1,6 @@
+package net.pantasystem.milktea.model.setting
+
+@kotlinx.serialization.Serializable
+data class WebClientBaseCache(
+    val reactions: List<String>
+)


### PR DESCRIPTION
## やったこと
LocalStorageにリアクションピッカーの設定状態が保存されている仕組みを使用して、
WebViewを使用して、一連のリアクションを取得するようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考
わざわざWebViewで取得している理由としては、通常のTokenでは個人のリアクションの設定状態を取得することができないことと、
Id,Passで取得したTokenをサードパーティアプリが使用することは推奨されていないからです。


## Issue番号
Closed #878 


