### PR TITLE
プロフィール画面から直接リモートユーザーのWebページに遷移できるようにしました

### DIFF
--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
@@ -387,8 +387,11 @@ class UserDetailActivity : AppCompatActivity() {
                 }
             }
             R.id.share -> {
-                val url = mViewModel.profileUrl.value
-                    ?: return false
+                val account = accountStore.currentAccount
+                val url = account?.let {
+                    mViewModel.user.value?.getRemoteProfileUrl(it)
+                } ?: return false
+
 
                 val intent = Intent().apply {
                     action = Intent.ACTION_SEND

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
@@ -263,6 +263,19 @@ class UserDetailActivity : AppCompatActivity() {
                 }
             }
 
+            binding.showRemoteUserInRemotePage.setOnClickListener {
+                val account = accountStore.currentAccount
+                if (account != null) {
+
+                    mViewModel.user.value?.getRemoteProfileUrl(account)?.let {
+                        val uri = Uri.parse(it)
+                        startActivity(
+                            Intent(Intent.ACTION_VIEW, uri)
+                        )
+                    }
+                }
+            }
+
             binding.createMention.setOnClickListener {
                 mViewModel.user.value?.displayUserName?.let {
                     val intent = NoteEditorActivity.newBundle(this, mentions = listOf(it))

--- a/modules/features/user/src/main/res/layout/activity_user_detail.xml
+++ b/modules/features/user/src/main/res/layout/activity_user_detail.xml
@@ -36,7 +36,7 @@
                     <LinearLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="vertical"
+                            android:orientation="horizontal"
                             android:id="@+id/remoteUserState"
                             android:paddingStart="16dp"
                             android:paddingEnd="16dp"
@@ -52,6 +52,16 @@
                                 android:layout_height="wrap_content"
                                 android:text="@string/view_in_browser"
                                 style="@style/Widget.MaterialComponents.Button.TextButton"
+                                android:layout_weight="1"
+                                />
+                        <Button
+                                android:id="@+id/showRemoteUserInRemotePage"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="@string/view_remotely"
+                                style="@style/Widget.MaterialComponents.Button.TextButton"
+                                android:layout_weight="1"
+                                android:visibility="@{userViewModel.user.remoteUser ? View.VISIBLE : View.GONE}"
                                 />
                     </LinearLayout>
                     <ImageView

--- a/modules/features/user/src/main/res/values-ja/strings.xml
+++ b/modules/features/user/src/main/res/values-ja/strings.xml
@@ -13,5 +13,6 @@
     <string name="user_mute_specify_time_1_week_later">1週間後</string>
     <string name="user_mute_specify_time_1_month_later">1ヶ月後</string>
     <string name="user_mute_specify_time_indefinite_period">無期限</string>
+    <string name="view_remotely">リモートで表示</string>
 
 </resources>

--- a/modules/features/user/src/main/res/values-zh/strings.xml
+++ b/modules/features/user/src/main/res/values-zh/strings.xml
@@ -13,5 +13,6 @@
     <string name="user_mute_specify_time_1_week_later">1 周后</string>
     <string name="user_mute_specify_time_1_month_later">1 个月后</string>
     <string name="user_mute_specify_time_indefinite_period">无限期</string>
+    <string name="view_remotely">远程查看</string>
 
 </resources>

--- a/modules/features/user/src/main/res/values/strings.xml
+++ b/modules/features/user/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="user_mute_specify_time_1_week_later">1 week later</string>
     <string name="user_mute_specify_time_1_month_later">1 month later</string>
     <string name="user_mute_specify_time_indefinite_period">Indefinite perio</string>
+    <string name="view_remotely">View remotely</string>
 </resources>

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/User.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/User.kt
@@ -83,6 +83,9 @@ sealed interface User : Entity {
         val updatedAt: Instant?,
     ) : User {
         companion object
+
+        val isRemoteUser: Boolean = !isSameHost
+
         val followState: FollowState
             get() {
                 if (isFollowing) {
@@ -99,6 +102,9 @@ sealed interface User : Entity {
 
                 return FollowState.UNFOLLOWING
             }
+        fun getRemoteProfileUrl(account: Account): String {
+            return url ?: getProfileUrl(account)
+        }
     }
 
     data class InstanceInfo(


### PR DESCRIPTION
## やったこと
現状は現在使用しているインスタンスのWebページでリモートユーザーを表示するページに遷移するようにしていたが、
直接リモートユーザーの所属しているインスタンスのプロフィールページを表示できるようにしました。
また共有を選択したとき、そのユーザーがリモートのユーザーであるときは、リモートのユーザーのインスタンスのプロフィールのURLを添付するようにしました。
## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #922


