### PR TITLE
improve English localization of compose view / 作成ビューの英語ローカライズを改善します

### DIFF
--- a/modules/common_compose/src/main/res/values/strings.xml
+++ b/modules/common_compose/src/main/res/values/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="show">show</string>
-    <string name="undo_nsfw">Undo nsfw</string>
+    <string name="show">Show</string>
+    <string name="undo_nsfw">Undo NSFW</string>
     <string name="mark_as_nsfw">Mark as NSFW</string>
-    <string name="remove_attachment">Remote attachment</string>
+    <string name="remove_attachment">Remove attachment</string>
 
 
     <string name="future">Future</string>


### PR DESCRIPTION
申し訳ありませんが、私は日本語を話せないので、Google 翻訳を使用しています。 話すときの間違いを許してください。/ I am sorry, I don't speak Japanese, so I'm using Google Translate. Please forgive any mistakes I make when speaking.

## やったこと

このコミットにより、作成ビューのいくつかの英語ローカライズ文字列が改善されます。/ This commit improves a couple of English language localization strings for the compose view.

## 動作確認

この変更は、いくつかの文字列にのみ影響します。 CIでテストするだけで十分です。/ This change only affects a few strings. It should be sufficient to test it with CI. 

## スクリーンショット(任意)

None

## 備考

None

## Issue番号

None

このソフトウェアを作成していただきありがとうございます。/ Thank you for making this software.
