### PR TITLE
apngのライブラリのバージョンを応急的にダウングレード

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -46,7 +46,7 @@ dependencyResolutionManagement {
             library('glide-glide', 'com.github.bumptech.glide:glide:4.12.0')
             library('glide-compiler', 'com.github.bumptech.glide:compiler:4.13.2')
             library('accompanist-glide', 'com.google.accompanist:accompanist-glide:0.14.0')
-            library('animation-apng', 'com.github.penfeizhou.android.animation:apng:2.24.0')
+            library('animation-apng', 'com.github.penfeizhou.android.animation:apng:2.23.0')
 
             library('wada811-databinding', 'com.github.wada811:DataBinding-ktx:5.0.2')
 


### PR DESCRIPTION
## やったこと
ライブラリのバージョンを上げるとapngを描画できなくなる不具合が発生したのでダウングレード

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



