### PR TITLE
リアクションイベント処理周りの実装のリファクタリングとテストケースの追加

### DIFF
--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteEventReducer.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteEventReducer.kt
@@ -47,7 +47,7 @@ fun Note.onReacted(account: Account, e: NoteUpdated.Body.Reacted): Note {
     return this.copy(
         reactionCounts = list,
         myReaction = if(e.body.userId == account.remoteId) e.body.reaction else this.myReaction,
-        emojis = emojis
+        emojis = emojis?.distinct()
     )
 }
 

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/notes/NoteEventReducerKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/notes/NoteEventReducerKtTest.kt
@@ -1,0 +1,224 @@
+package net.pantasystem.milktea.data.infrastructure.notes
+
+import net.pantasystem.milktea.api_streaming.NoteUpdated
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.emoji.Emoji
+import net.pantasystem.milktea.model.notes.Note
+import net.pantasystem.milktea.model.notes.make
+import net.pantasystem.milktea.model.notes.reaction.ReactionCount
+import net.pantasystem.milktea.model.user.User
+import org.junit.Assert
+import org.junit.Test
+
+class NoteEventReducerKtTest {
+    private val account = Account("test", "misskey.io", "Panta", Account.InstanceType.MISSKEY, "")
+
+    @Test
+    fun onReacted_GiveOtherUserReaction() {
+        val note = Note.make(
+            id = Note.Id(0L, "1"),
+            text = "",
+            userId = User.Id(0L, "2")
+        )
+
+        val result = note.onReacted(
+            account,
+            NoteUpdated.Body.Reacted(
+                id = "1",
+                body = NoteUpdated.Body.Reacted.Body(
+                    reaction = ":kawaii:",
+                    userId = "other"
+                )
+            )
+        )
+
+        Assert.assertEquals(listOf(ReactionCount(":kawaii:", 1)), result.reactionCounts)
+        Assert.assertNull(result.myReaction)
+    }
+
+    @Test
+    fun onReacted_GiveMyReaction() {
+        val note = Note.make(
+            id = Note.Id(0L, "1"),
+            text = "",
+            userId = User.Id(0L, "2")
+        )
+
+        val result = note.onReacted(
+            account,
+            NoteUpdated.Body.Reacted(
+                id = "1",
+                body = NoteUpdated.Body.Reacted.Body(
+                    reaction = ":kawaii:",
+                    userId = account.remoteId
+                )
+            )
+        )
+
+        Assert.assertEquals(listOf(ReactionCount(":kawaii:", 1)), result.reactionCounts)
+        Assert.assertEquals(":kawaii:", result.myReaction)
+    }
+
+    @Test
+    fun onReacted_GiveMyReactionAndHasReactions() {
+        val note = Note.make(
+            id = Note.Id(0L, "1"),
+            text = "",
+            userId = User.Id(0L, "2"),
+            reactionCounts = listOf(
+                ReactionCount(":watasimo:", 1),
+                ReactionCount(":kawaii:", 1)
+            )
+        )
+
+        val result = note.onReacted(
+            account, NoteUpdated.Body.Reacted(
+                id = "1",
+                body = NoteUpdated.Body.Reacted.Body(
+                    reaction = ":kawaii:",
+                    userId = account.remoteId
+                )
+            )
+        )
+
+        Assert.assertEquals(
+            listOf(ReactionCount(":watasimo:", 1), ReactionCount(":kawaii:", 2)),
+            result.reactionCounts
+        )
+        Assert.assertEquals(":kawaii:", result.myReaction)
+    }
+
+    @Test
+    fun onReacted_GiveMyReactionAndHasOtherReactions() {
+        val note = Note.make(
+            id = Note.Id(0L, "1"),
+            text = "",
+            userId = User.Id(0L, "2"),
+            reactionCounts = listOf(
+                ReactionCount(":watasimo:", 1),
+            )
+        )
+
+        val result = note.onReacted(
+            account, NoteUpdated.Body.Reacted(
+                id = "1",
+                body = NoteUpdated.Body.Reacted.Body(
+                    reaction = ":kawaii:",
+                    userId = account.remoteId
+                )
+            )
+        )
+
+        Assert.assertEquals(
+            listOf(ReactionCount(":watasimo:", 1), ReactionCount(":kawaii:", 1)),
+            result.reactionCounts
+        )
+        Assert.assertEquals(":kawaii:", result.myReaction)
+    }
+
+    @Test
+    fun onUnReacted() {
+        val note = Note.make(
+            id = Note.Id(0L, "1"),
+            text = "",
+            userId = User.Id(0L, "2"),
+            reactionCounts = listOf(
+                ReactionCount(":watasimo:", 1),
+            )
+        )
+        val result = note.onUnReacted(
+            account, NoteUpdated.Body.Unreacted(
+                note.id.noteId, NoteUpdated.Body.Unreacted.Body(
+                    ":watasimo:",
+                    userId = "other"
+                )
+            )
+        )
+        Assert.assertNull(result.myReaction)
+        Assert.assertEquals(emptyList<ReactionCount>(), result.reactionCounts)
+    }
+
+    @Test
+    fun onUnReacted_GiveMyEvent() {
+        val note = Note.make(
+            id = Note.Id(0L, "1"),
+            text = "",
+            userId = User.Id(0L, "2"),
+            reactionCounts = listOf(
+                ReactionCount(":watasimo:", 1),
+            ),
+            myReaction = ":watasimo:"
+        )
+        val result = note.onUnReacted(
+            account, NoteUpdated.Body.Unreacted(
+                note.id.noteId, NoteUpdated.Body.Unreacted.Body(
+                    ":watasimo:",
+                    userId = account.remoteId
+                )
+            )
+        )
+        Assert.assertNull(result.myReaction)
+        Assert.assertEquals(emptyList<ReactionCount>(), result.reactionCounts)
+    }
+
+    @Test
+    fun onUnReacted_GiveOtherUserEvent() {
+        val note = Note.make(
+            id = Note.Id(0L, "1"),
+            text = "",
+            userId = User.Id(0L, "2"),
+            reactionCounts = listOf(
+                ReactionCount(":watasimo:", 2),
+            ),
+            myReaction = ":watasimo:"
+        )
+        val result = note.onUnReacted(
+            account, NoteUpdated.Body.Unreacted(
+                note.id.noteId, NoteUpdated.Body.Unreacted.Body(
+                    ":watasimo:",
+                    userId = "other"
+                )
+            )
+        )
+        Assert.assertEquals(":watasimo:", result.myReaction)
+        Assert.assertEquals(
+            listOf(
+                ReactionCount(":watasimo:", 1),
+            ), result.reactionCounts
+        )
+    }
+
+    @Test
+    fun onReacted_GiveNewEmoji() {
+        val note = Note.make(
+            id = Note.Id(0L, "1"),
+            text = "",
+            userId = User.Id(0L, "2"),
+            reactionCounts = listOf(
+                ReactionCount(":watasimo:", 2),
+            ),
+            myReaction = ":watasimo:"
+        )
+        val result = note.onReacted(
+            account,
+            NoteUpdated.Body.Reacted(
+                id = "1",
+                body = NoteUpdated.Body.Reacted.Body(
+                    reaction = ":kawaii:",
+                    userId = account.remoteId,
+                    emoji = Emoji(
+                        name = ":kawaii:"
+                    )
+                )
+            )
+        )
+        Assert.assertEquals(
+            listOf(
+                Emoji(
+                    name = ":kawaii:"
+                )
+            ), result.emojis
+        )
+    }
+
+}


### PR DESCRIPTION
## やったこと
リアクションのイベントを元にNoteのデータ構造を変更する実装部分に対しての
テストケースの追加とリファクタリングを行いました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



