### PR TITLE
通知のユーザー名部分にカスタム絵文字のデコレーションがされない問題を修正

### DIFF
--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationTitleHelper.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationTitleHelper.kt
@@ -3,6 +3,7 @@ package net.pantasystem.milktea.notification
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import dagger.hilt.android.EntryPointAccessors
+import net.pantasystem.milktea.common_android.ui.text.CustomEmojiDecorator
 import net.pantasystem.milktea.common_android_ui.BindingProvider
 import net.pantasystem.milktea.model.notification.NotificationRelation
 import net.pantasystem.milktea.model.notification.PollEndedNotification
@@ -23,9 +24,14 @@ object NotificationTitleHelper {
                 context.getString(R.string.poll_ended)
             }
             else -> if (isUserNameDefault) {
-                notification.user?.displayUserName?: ""
+                notification.user?.displayUserName ?: ""
             } else {
-                notification.user?.displayName?: ""
+                CustomEmojiDecorator().decorate(
+                    notification.user?.emojis ?: emptyList(),
+                    notification.user?.displayName ?: "",
+                    this,
+                )
+
             }
         }
     }


### PR DESCRIPTION
## やったこと
通知のユーザー名部分にカスタム絵文字のデコレーションがされず:カスタム絵文字名:のような表示になっていた問題を修正しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1023 


