### PR TITLE
ファイル種別が画像の共有インテントからノートを作成できるようにしました

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -175,16 +175,17 @@
                 android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
-
                 <category android:name="android.intent.category.DEFAULT" />
-
                 <data android:mimeType="text/*" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
-
                 <category android:name="android.intent.category.DEFAULT" />
-
+                <data android:mimeType="image/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
             </intent-filter>
         </activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -180,6 +180,13 @@
 
                 <data android:mimeType="text/*" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="image/*" />
+            </intent-filter>
         </activity>
         <activity
                 android:name=".MainActivity"

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/NoteEditorActivity.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/NoteEditorActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.os.Parcelable
 import android.util.Log
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -95,6 +96,9 @@ class NoteEditorActivity : AppCompatActivity() {
                     handleSendImage(intent)
                 }
             }
+            intent.action == Intent.ACTION_SEND_MULTIPLE && intent.type?.startsWith("image/") == true -> {
+                handleSendImages(intent)
+            }
             else -> Unit
         }
 
@@ -141,12 +145,23 @@ class NoteEditorActivity : AppCompatActivity() {
     @Suppress("DEPRECATION")
     private fun handleSendImage(intent: Intent) {
         (intent.getParcelableExtra(Intent.EXTRA_STREAM) as? Uri)?.let { uri ->
-            val size = mViewModel.fileTotal()
-            if (size > mViewModel.maxFileCount.value) {
-                Log.d("NoteEditorActivity", "失敗しました")
-            } else {
-                mViewModel.add(uri.toAppFile(this))
-            }
+            addFileFromUri(uri)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun handleSendImages(intent: Intent) {
+        intent.getParcelableArrayListExtra<Parcelable>(Intent.EXTRA_STREAM)?.mapNotNull {
+                it as? Uri
+            }?.map(::addFileFromUri)
+    }
+
+    private fun addFileFromUri(uri: Uri) {
+        val size = mViewModel.fileTotal()
+        if (size > mViewModel.maxFileCount.value) {
+            Log.d("NoteEditorActivity", "失敗しました")
+        } else {
+            mViewModel.add(uri.toAppFile(this))
         }
     }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/NoteEditorActivity.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/NoteEditorActivity.kt
@@ -2,13 +2,16 @@ package net.pantasystem.milktea.note
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.wada811.databinding.dataBinding
 import dagger.hilt.android.AndroidEntryPoint
 import net.pantasystem.milktea.common.ui.ApplyTheme
 import net.pantasystem.milktea.model.channel.Channel
+import net.pantasystem.milktea.model.file.toAppFile
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.note.databinding.ActivityNoteEditorBinding
 import net.pantasystem.milktea.note.editor.NoteEditorFragment
@@ -82,8 +85,17 @@ class NoteEditorActivity : AppCompatActivity() {
         binding.lifecycleOwner = this
 
         var text: String? = null
-        if (intent?.action == Intent.ACTION_SEND && intent.type?.startsWith("text/") == true) {
-            text = intent.getStringExtra(Intent.EXTRA_TEXT)
+
+        when {
+            intent?.action == Intent.ACTION_SEND -> {
+                if (intent.type?.startsWith("text/") == true) {
+                    text = intent.getStringExtra(Intent.EXTRA_TEXT)
+                }
+                if (intent.type?.startsWith("image/") == true) {
+                    handleSendImage(intent)
+                }
+            }
+            else -> Unit
         }
 
         val accountId: Long? =
@@ -126,5 +138,16 @@ class NoteEditorActivity : AppCompatActivity() {
 
     }
 
+    @Suppress("DEPRECATION")
+    private fun handleSendImage(intent: Intent) {
+        (intent.getParcelableExtra(Intent.EXTRA_STREAM) as? Uri)?.let { uri ->
+            val size = mViewModel.fileTotal()
+            if (size > mViewModel.maxFileCount.value) {
+                Log.d("NoteEditorActivity", "失敗しました")
+            } else {
+                mViewModel.add(uri.toAppFile(this))
+            }
+        }
+    }
 
 }


### PR DESCRIPTION
## やったこと
ファイル種別がimage/で始まる画像を含んだ共有インテントから、
ノートの作成画面を開きファイルを添付できるようにしました。
これによりGoogle Photoなどの共有からMilkteaにファイルを添付できるようになりました。

## 動作確認
エミュレーターで動作確認済み。
またGoogle Photoからファイルを共有＆添付できることを確認しました。

## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1026


