### PR TITLE
メンションを指定して投稿画面を開こうとするとクラッシュする問題を修正

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
@@ -516,11 +516,7 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
     private fun addMentionUserNames(userNames: List<String>) {
         val pos = binding.inputMain.selectionEnd
         noteEditorViewModel.addMentionUserNames(userNames, pos).let { newPos ->
-            Log.d(
-                "NoteEditorActivity",
-                "text:${noteEditorViewModel.uiState.value.formState.text}, stateText:${noteEditorViewModel.uiState.value.formState.text}"
-            )
-            binding.inputMain.setText(noteEditorViewModel.uiState.value.formState.text ?: "")
+            binding.inputMain.setText(noteEditorViewModel.text.value ?: "")
             binding.inputMain.setSelection(newPos)
         }
     }

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -209,6 +209,7 @@
                             app:media="@{note.media}"
                             android:layout_width="match_parent"
                             android:layout_height="200dp"
+                            android:layout_marginTop="2dp"
                             android:visibility="@{note.media.visibleMediaPreviewArea ? View.VISIBLE : View.GONE}"
                             tools:visibility="visible"
                             tools:layout_height="20dp" />


### PR DESCRIPTION
## やったこと
メンションを指定して投稿画面を開こうとするとクラッシュする問題を修正しました。
原因としては複数のFlowを束ねたFlowから値を取得して反映しようとしたため、
値の反映が遅くなってしまいそのずれによって発生したIndexのずれによってクラッシュが発生していました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1025 


