### PR TITLE
シンプル投稿フォームから投稿できない問題を修正

### DIFF
--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -56,7 +56,7 @@ class NoteRepositoryImpl @Inject constructor(
                 uploader.get(createNote.author)
             ) ?: throw IllegalStateException("ファイルのアップロードに失敗しました")
         }.mapCatching {
-            misskeyAPIProvider.get(createNote.author).create(it).body()?.createdNote
+            misskeyAPIProvider.get(createNote.author).create(it).throwIfHasError().body()?.createdNote
         }.onFailure {
             logger.error("create note error", it)
         }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
@@ -223,6 +223,11 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
             finishOrConfirmSaveAsDraftOrDelete()
         }
         noteEditorToolbar.lifecycleOwner = viewLifecycleOwner
+        noteEditorToolbar.noteVisibility.setOnClickListener {
+            Log.d("NoteEditorActivity", "公開範囲を設定しようとしています")
+            val dialog = VisibilitySelectionDialogV2()
+            dialog.show(childFragmentManager, "NoteEditor")
+        }
 
 
         confirmViewModel = ViewModelProvider(requireActivity())[ConfirmViewModel::class.java]
@@ -340,11 +345,6 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
             }
         }
 
-        noteEditorViewModel.showVisibilitySelectionEvent.observe(viewLifecycleOwner) {
-            Log.d("NoteEditorActivity", "公開範囲を設定しようとしています")
-            val dialog = VisibilitySelectionDialogV2()
-            dialog.show(childFragmentManager, "NoteEditor")
-        }
 
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/SimpleEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/SimpleEditorFragment.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.withContext
 import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.common_android.ui.listview.applyFlexBoxLayout
 import net.pantasystem.milktea.common_android.ui.text.CustomEmojiTokenizer
-import net.pantasystem.milktea.common_android_ui.account.AccountSwitchingDialog
 import net.pantasystem.milktea.common_compose.FilePreviewTarget
 import net.pantasystem.milktea.common_navigation.*
 import net.pantasystem.milktea.common_viewmodel.viewmodel.AccountViewModel
@@ -113,9 +112,7 @@ class SimpleEditorFragment : Fragment(R.layout.fragment_simple_editor), SimpleEd
 
 
         mBinding.accountViewModel = accountViewModel
-        accountViewModel.switchAccount.observe(this) {
-            AccountSwitchingDialog().show(childFragmentManager, "tag")
-        }
+
         accountViewModel.showProfile.observe(this) {
             val intent = userDetailNavigation.newIntent(
                 UserDetailNavigationArgs.UserId(

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/SimpleEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/SimpleEditorFragment.kt
@@ -196,8 +196,7 @@ class SimpleEditorFragment : Fragment(R.layout.fragment_simple_editor), SimpleEd
             viewModel.clear()
         }
 
-        viewModel.showVisibilitySelectionEvent.observe(viewLifecycleOwner) {
-            Log.d("NoteEditorActivity", "公開範囲を設定しようとしています")
+        mBinding.noteVisibility.setOnClickListener {
             val dialog = VisibilitySelectionDialogV2()
             dialog.show(childFragmentManager, "NoteEditor")
         }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/SimpleEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/SimpleEditorFragment.kt
@@ -103,7 +103,7 @@ class SimpleEditorFragment : Fragment(R.layout.fragment_simple_editor), SimpleEd
 
         mBinding.simpleEditor = this
 
-        mBinding.lifecycleOwner = this
+        mBinding.lifecycleOwner = viewLifecycleOwner
         mBinding.noteEditorViewModel = mViewModel
 
         val userChipAdapter =
@@ -183,7 +183,8 @@ class SimpleEditorFragment : Fragment(R.layout.fragment_simple_editor), SimpleEd
 
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                viewModel.poll.collect { poll ->
+                viewModel.uiState.collect { uiState ->
+                    val poll = uiState.poll
                     if (poll == null) {
                         removePollFragment()
                     } else {
@@ -378,6 +379,7 @@ class SimpleEditorFragment : Fragment(R.layout.fragment_simple_editor), SimpleEd
 
     }
 
+    @Suppress("DEPRECATION")
     private val registerForOpenDriveActivityResult =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == RESULT_OK) {
@@ -414,6 +416,7 @@ class SimpleEditorFragment : Fragment(R.layout.fragment_simple_editor), SimpleEd
             }
         }
 
+    @Suppress("DEPRECATION")
     private val selectUserResult =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == RESULT_OK && result.data != null) {
@@ -425,6 +428,7 @@ class SimpleEditorFragment : Fragment(R.layout.fragment_simple_editor), SimpleEd
             }
         }
 
+    @Suppress("DEPRECATION")
     private val selectMentionToUserResult =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == RESULT_OK && result.data != null) {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/note_file_preview.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/note_file_preview.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,14 +25,14 @@ fun NoteFilePreview(
     dataSource: FilePropertyDataSource,
     onShow: (FilePreviewTarget)->Unit
 ) {
-    val files = noteEditorViewModel.files.collectAsState()
+    val uiState by noteEditorViewModel.uiState.collectAsState()
     val maxFileCount = noteEditorViewModel.maxFileCount.asLiveData().observeAsState()
 
     Row (
         verticalAlignment = Alignment.CenterVertically,
     ){
         HorizontalFilePreviewList(
-            files = files.value,
+            files = uiState.files,
             repository = fileRepository,
             modifier = Modifier.weight(1f),
             dataSource = dataSource,
@@ -49,9 +50,9 @@ fun NoteFilePreview(
                 }
             }
         )
-        if (files.value.isNotEmpty())
+        if (uiState.files.isNotEmpty())
             Text(
-                "${files.value.size}/${maxFileCount.value}"
+                "${uiState.files.size}/${maxFileCount.value}"
             )
     }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorSavedHandlerHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorSavedHandlerHelper.kt
@@ -1,6 +1,8 @@
 package net.pantasystem.milktea.note.editor.viewmodel
 
 import androidx.lifecycle.SavedStateHandle
+import kotlinx.datetime.Instant
+import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.channel.Channel
 import net.pantasystem.milktea.model.file.AppFile
 import net.pantasystem.milktea.model.notes.Note
@@ -21,6 +23,10 @@ fun SavedStateHandle.getText(): String? {
     return this[NoteEditorSavedStateKey.Text.name]
 }
 
+fun SavedStateHandle.getCw(): String? {
+    return this[NoteEditorSavedStateKey.Cw.name]
+}
+
 fun SavedStateHandle.setCw(text: String?) {
     this[NoteEditorSavedStateKey.Cw.name] = text
 }
@@ -37,6 +43,10 @@ fun SavedStateHandle.setChannelId(channelId: Channel.Id?) {
     this[NoteEditorSavedStateKey.ChannelId.name] = channelId
 }
 
+fun SavedStateHandle.getChannelId(): Channel.Id? {
+    return this[NoteEditorSavedStateKey.ChannelId.name]
+}
+
 
 fun SavedStateHandle.setReplyId(noteId: Note.Id?) {
     this[NoteEditorSavedStateKey.ReplyId.name] = noteId
@@ -46,9 +56,20 @@ fun SavedStateHandle.setRenoteId(noteId: Note.Id?) {
     this[NoteEditorSavedStateKey.RenoteId.name] = noteId
 }
 
+fun SavedStateHandle.getRenoteId(): Note.Id? {
+    return this[NoteEditorSavedStateKey.RenoteId.name]
+}
+
+fun SavedStateHandle.getReplyId(): Note.Id? {
+    return this[NoteEditorSavedStateKey.ReplyId.name]
+}
 
 fun SavedStateHandle.setScheduleAt(date: Date?) {
     this[NoteEditorSavedStateKey.ScheduleAt.name] = date
+}
+
+fun SavedStateHandle.getScheduleAt(): Date? {
+    return this[NoteEditorSavedStateKey.ScheduleAt.name]
 }
 
 fun SavedStateHandle.setHasCw(hasCw: Boolean) {
@@ -79,6 +100,10 @@ fun SavedStateHandle.setDraftNoteId(id: Long?) {
     this[NoteEditorSavedStateKey.DraftNoteId.name] = id
 }
 
+fun SavedStateHandle.getDraftNoteId(): Long? {
+    return this[NoteEditorSavedStateKey.DraftNoteId.name]
+}
+
 fun SavedStateHandle.applyBy(note: NoteEditorUiState) {
     setVisibility(note.sendToState.visibility)
     setText(note.formState.text)
@@ -94,5 +119,28 @@ fun SavedStateHandle.applyBy(note: NoteEditorUiState) {
         note.sendToState.schedulePostAt?.let {
             Date(it.toEpochMilliseconds())
         }
+    )
+}
+
+fun SavedStateHandle.getNoteEditingUiState(account: Account?): NoteEditorUiState {
+    return NoteEditorUiState(
+        formState = NoteEditorFormState(
+            text = getText(),
+            cw = getCw(),
+            hasCw = getHasCw(),
+        ),
+        sendToState = NoteEditorSendToState(
+            visibility = getVisibility(),
+            channelId = getChannelId(),
+            renoteId = getRenoteId(),
+            replyId = getReplyId(),
+            schedulePostAt = getScheduleAt()?.let {
+                Instant.fromEpochMilliseconds(it.time)
+            },
+            draftNoteId = getDraftNoteId()
+        ),
+        poll = getPoll(),
+        files = getFiles(),
+        currentAccount = account,
     )
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
@@ -145,9 +145,6 @@ class NoteEditorViewModel @Inject constructor(
         savedStateHandle.getStateFlow<Date?>(NoteEditorSavedStateKey.ScheduleAt.name, null)
 
 
-    val showVisibilitySelectionEvent = EventBus<Unit>()
-
-
     val address = visibility.map {
         it as? Visibility.Specified
     }.map {
@@ -434,10 +431,6 @@ class NoteEditorViewModel @Inject constructor(
 
     fun disablePoll() {
         savedStateHandle.setPoll(null)
-    }
-
-    fun showVisibilitySelection() {
-        showVisibilitySelectionEvent.event = Unit
     }
 
     fun setText(text: String) {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
@@ -146,7 +146,6 @@ class NoteEditorViewModel @Inject constructor(
 
 
     val showVisibilitySelectionEvent = EventBus<Unit>()
-    private val visibilitySelectedEvent = EventBus<Unit>()
 
 
     val address = visibility.map {
@@ -453,7 +452,6 @@ class NoteEditorViewModel @Inject constructor(
         logger.debug("公開範囲がセットされた:$visibility")
         savedStateHandle.setChannelId(null)
         savedStateHandle.setVisibility(visibility)
-        this.visibilitySelectedEvent.event = Unit
     }
 
     fun setChannelId(channelId: Channel.Id?) {

--- a/modules/features/note/src/main/res/layout/fragment_simple_editor.xml
+++ b/modules/features/note/src/main/res/layout/fragment_simple_editor.xml
@@ -90,7 +90,7 @@
                     app:circleIcon="@{noteEditorViewModel.currentUser.user.avatarUrl}"
 
                     tools:ignore="ContentDescription"
-                    tools:src="@mipmap/ic_launcher" />
+                     />
 
             <ImageButton
                     android:id="@+id/selectFileFromLocal"
@@ -167,7 +167,6 @@
                     android:layout_margin="4dp"
                     android:layout_weight="1"
                     android:adjustViewBounds="true"
-                    android:onClick="@{()-> noteEditorViewModel.showVisibilitySelection()}"
                     app:noteVisibility="@{noteEditorViewModel.visibility}"
                     tools:ignore="ContentDescription"
                     tools:src="@drawable/ic_language_black_24dp"

--- a/modules/features/note/src/main/res/layout/view_note_editor_toolbar.xml
+++ b/modules/features/note/src/main/res/layout/view_note_editor_toolbar.xml
@@ -46,7 +46,6 @@
 
                 app:circleIcon="@{viewModel.currentUser.user.avatarUrl}"
                 tools:ignore="ContentDescription"
-                tools:src="@mipmap/ic_launcher"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 android:layout_marginStart="8dp"
@@ -72,7 +71,6 @@
                 tools:src="@drawable/ic_language_black_24dp"
                 tools:ignore="ContentDescription"
                 app:noteVisibility="@{viewModel.visibility}"
-                android:onClick="@{()-> viewModel.showVisibilitySelection()}"
                 android:layout_marginEnd="4dp"
                 android:layout_centerVertical="true"
                 android:layout_toStartOf="@id/textCounter"


### PR DESCRIPTION
## やったこと
シンプル投稿フォームから投稿できない問題を修正しました。
原因としてはシンプル投稿フォームの場合UiStateを出力しているFlowをcollectしていないため
UiStateから状態を読み取ろうとして初期値を取ってしまいAPIが400を返してしまうという問題でした。
そこでFlowに依存しないようにするためにSavedStateHandleから取得できるようにし解決しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1033


