### PR TITLE
ViewModelでAssistedInjectで値を受け渡していたのを辞める

### DIFF
--- a/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/GalleryPostsFragment.kt
+++ b/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/GalleryPostsFragment.kt
@@ -20,7 +20,6 @@ import net.pantasystem.milktea.common.APIError
 import net.pantasystem.milktea.common_navigation.*
 import net.pantasystem.milktea.common_viewmodel.CurrentPageableTimelineViewModel
 import net.pantasystem.milktea.gallery.viewmodel.GalleryPostsViewModel
-import net.pantasystem.milktea.gallery.viewmodel.provideFactory
 import net.pantasystem.milktea.model.account.page.Pageable
 import javax.inject.Inject
 
@@ -28,16 +27,13 @@ import javax.inject.Inject
 class GalleryPostsFragment : Fragment() {
 
     companion object {
-        private const val EXTRA_ACCOUNT_ID = "jp.panta.misskeyandroidclient.view.gallery.ACCOUNT_ID"
-        private const val EXTRA_PAGEABLE =
-            "jp.panta.misskeyandroidclient.view.gallery.EXTRA_PAGEABLE"
 
         fun newInstance(pageable: Pageable.Gallery, accountId: Long?): GalleryPostsFragment {
             return GalleryPostsFragment().apply {
                 arguments = Bundle().also {
-                    it.putSerializable(EXTRA_PAGEABLE, pageable)
+                    it.putSerializable(GalleryPostsViewModel.EXTRA_PAGEABLE, pageable)
                     if (accountId != null) {
-                        it.putLong(EXTRA_ACCOUNT_ID, accountId)
+                        it.putLong(GalleryPostsViewModel.EXTRA_ACCOUNT_ID, accountId)
                     }
                 }
             }
@@ -45,14 +41,9 @@ class GalleryPostsFragment : Fragment() {
     }
 
 
-    val pageable: Pageable.Gallery by lazy {
-        arguments?.getSerializable(EXTRA_PAGEABLE) as Pageable.Gallery
-    }
 
     private val currentTimelineViewModel: CurrentPageableTimelineViewModel by activityViewModels()
 
-    @Inject
-    lateinit var viewModelFactory: GalleryPostsViewModel.ViewModelAssistedFactory
 
     @Inject
     lateinit var userDetailNavigation: UserDetailNavigation
@@ -64,15 +55,7 @@ class GalleryPostsFragment : Fragment() {
     @Inject
     lateinit var authorizationNavigation: AuthorizationNavigation
 
-    val viewModel: GalleryPostsViewModel by viewModels {
-        val pageable = arguments?.getSerializable(EXTRA_PAGEABLE) as Pageable.Gallery
-        var accountId = arguments?.getLong(EXTRA_ACCOUNT_ID, -1)
-        if (accountId == -1L) {
-            accountId = null
-        }
-
-        GalleryPostsViewModel.provideFactory(viewModelFactory, pageable, accountId)
-    }
+    val viewModel: GalleryPostsViewModel by viewModels()
 
 
     override fun onCreateView(
@@ -138,7 +121,7 @@ class GalleryPostsFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        currentTimelineViewModel.setCurrentPageable(pageable)
+        currentTimelineViewModel.setCurrentPageable(viewModel.pageable)
     }
 
 }

--- a/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/viewmodel/GalleryPostsViewModel.kt
+++ b/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/viewmodel/GalleryPostsViewModel.kt
@@ -42,8 +42,8 @@ class GalleryPostsViewModel @Inject constructor(
         const val EXTRA_ACCOUNT_ID = "GalleryPostsViewModel.EXTRA_ACCOUNT_ID"
     }
 
-    val pageable: Pageable.Gallery = savedStateHandle[EXTRA_PAGEABLE]
-        ?: throw IllegalArgumentException()
+    val pageable: Pageable.Gallery = requireNotNull(savedStateHandle[EXTRA_PAGEABLE])
+
     val accountId: Long? = savedStateHandle.get<Long?>(EXTRA_ACCOUNT_ID).takeIf {
         it != -1L
     }

--- a/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/viewmodel/GalleryPostsViewModel.kt
+++ b/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/viewmodel/GalleryPostsViewModel.kt
@@ -3,7 +3,7 @@ package net.pantasystem.milktea.gallery.viewmodel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.*
@@ -24,9 +24,10 @@ import net.pantasystem.milktea.model.gallery.GalleryPost
 import net.pantasystem.milktea.model.gallery.GalleryPostRelation
 import net.pantasystem.milktea.model.gallery.GalleryRepository
 import net.pantasystem.milktea.model.user.UserRepository
+import javax.inject.Inject
 
-class GalleryPostsViewModel @AssistedInject constructor(
-
+@HiltViewModel
+class GalleryPostsViewModel @Inject constructor(
     private val galleryDataSource: GalleryDataSource,
     galleryRepository: GalleryRepository,
     private val filePropertyDataSource: FilePropertyDataSource,

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/NoteDetailFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/NoteDetailFragment.kt
@@ -26,10 +26,9 @@ import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.FragmentNoteDetailBinding
+import net.pantasystem.milktea.note.detail.viewmodel.NoteDetailViewModel
 import net.pantasystem.milktea.note.view.NoteCardActionHandler
 import net.pantasystem.milktea.note.viewmodel.NotesViewModel
-import net.pantasystem.milktea.note.detail.viewmodel.NoteDetailViewModel
-import net.pantasystem.milktea.note.detail.viewmodel.provideFactory
 import javax.inject.Inject
 
 
@@ -37,17 +36,12 @@ import javax.inject.Inject
 class NoteDetailFragment : Fragment(R.layout.fragment_note_detail) {
 
     companion object {
-        private const val EXTRA_NOTE_ID =
-            "jp.panta.misskeyandroidclinet.view.notes.detail.EXTRA_NOTE_ID"
-        private const val EXTRA_PAGE = "jp.panta.misskeyandroidclinet.view.notes.detail.EXTRA_PAGE"
-        private const val EXTRA_ACCOUNT_ID =
-            "jp.panta.misskeyandroidclient.view.notes.detail.EXTRA_ACCOUNT_ID"
 
         fun newInstance(noteId: String, accountId: Long? = null): NoteDetailFragment {
             return NoteDetailFragment().apply {
                 arguments = Bundle().apply {
-                    putString(EXTRA_NOTE_ID, noteId)
-                    putLong(EXTRA_ACCOUNT_ID, accountId ?: -1)
+                    putString(NoteDetailViewModel.EXTRA_NOTE_ID, noteId)
+                    putLong(NoteDetailViewModel.EXTRA_ACCOUNT_ID, accountId ?: -1)
                 }
             }
         }
@@ -55,13 +49,9 @@ class NoteDetailFragment : Fragment(R.layout.fragment_note_detail) {
         fun newInstance(
             page: Page
         ): NoteDetailFragment {
-            page.pageable() as? Pageable.Show ?: throw IllegalArgumentException("Not Pageable.Show")
-            return NoteDetailFragment().apply {
-                arguments = Bundle().apply {
-                    putSerializable(EXTRA_PAGE, page)
-                    putLong(EXTRA_ACCOUNT_ID, page.accountId)
-                }
-            }
+            val pageable = page.pageable() as? Pageable.Show
+                ?: throw IllegalArgumentException("Not Pageable.Show")
+            return newInstance(pageable.noteId)
         }
 
         fun newInstance(noteId: Note.Id): NoteDetailFragment {
@@ -74,8 +64,6 @@ class NoteDetailFragment : Fragment(R.layout.fragment_note_detail) {
 
     private val currentPageableTimelineViewModel: CurrentPageableTimelineViewModel by activityViewModels()
 
-    @Inject
-    lateinit var noteDetailViewModelAssistedFactory: NoteDetailViewModel.ViewModelAssistedFactory
 
     @Inject
     internal lateinit var settingStore: SettingStore
@@ -83,20 +71,8 @@ class NoteDetailFragment : Fragment(R.layout.fragment_note_detail) {
     @Inject
     lateinit var userDetailNavigation: UserDetailNavigation
 
-    val page: Pageable.Show by lazy {
-        (arguments?.getSerializable(EXTRA_PAGE) as? Page)?.pageable() as? Pageable.Show
-            ?: Pageable.Show(arguments?.getString(EXTRA_NOTE_ID)!!)
-    }
-    private val noteDetailViewModel: NoteDetailViewModel by viewModels {
-        val accountId = arguments?.getLong(EXTRA_ACCOUNT_ID, -1)?.let {
-            if (it == -1L) null else it
-        }
-        NoteDetailViewModel.provideFactory(
-            noteDetailViewModelAssistedFactory,
-            page,
-            accountId
-        )
-    }
+
+    private val noteDetailViewModel: NoteDetailViewModel by viewModels()
 
     val binding: FragmentNoteDetailBinding by dataBinding()
 
@@ -141,8 +117,7 @@ class NoteDetailFragment : Fragment(R.layout.fragment_note_detail) {
 
     override fun onResume() {
         super.onResume()
-
-        currentPageableTimelineViewModel.setCurrentPageable(page)
+        currentPageableTimelineViewModel.setCurrentPageable(Pageable.Show(noteDetailViewModel.noteId))
     }
 
     @MainThread

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewModel.kt
@@ -1,12 +1,10 @@
 package net.pantasystem.milktea.note.detail.viewmodel
 
 import android.util.Log
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import net.pantasystem.milktea.app_store.notes.NoteTranslationStore
@@ -14,12 +12,13 @@ import net.pantasystem.milktea.data.gettters.NoteRelationGetter
 import net.pantasystem.milktea.data.infrastructure.url.UrlPreviewStoreProvider
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.account.CurrentAccountWatcher
-import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.model.notes.*
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewDataCache
+import javax.inject.Inject
 
-class NoteDetailViewModel @AssistedInject constructor(
+@HiltViewModel
+class NoteDetailViewModel @Inject constructor(
     accountRepository: AccountRepository,
     private val noteCaptureAdapter: NoteCaptureAPIAdapter,
     private val noteRelationGetter: NoteRelationGetter,
@@ -27,16 +26,19 @@ class NoteDetailViewModel @AssistedInject constructor(
     private val noteTranslationStore: NoteTranslationStore,
     private val urlPreviewStoreProvider: UrlPreviewStoreProvider,
     private val noteDataSource: NoteDataSource,
-    @Assisted val show: Pageable.Show,
-    @Assisted val accountId: Long? = null,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    @AssistedFactory
-    interface ViewModelAssistedFactory {
-        fun create(show: Pageable.Show, accountId: Long?): NoteDetailViewModel
+    companion object {
+        const val EXTRA_NOTE_ID = "NoteDetailViewModel.NOTE_ID"
+        const val EXTRA_ACCOUNT_ID = "NoteDetailViewModel.ACCOUNT_ID"
     }
 
-    companion object;
+    val accountId: Long? = savedStateHandle.get<Long?>(EXTRA_ACCOUNT_ID).takeIf {
+        it != -1L
+    }
+
+    val noteId: String = savedStateHandle[EXTRA_NOTE_ID] ?: throw IllegalArgumentException()
 
     private val currentAccountWatcher: CurrentAccountWatcher = CurrentAccountWatcher(accountId, accountRepository)
 
@@ -53,7 +55,7 @@ class NoteDetailViewModel @AssistedInject constructor(
     private val note = suspend {
         currentAccountWatcher.getAccount()
     }.asFlow().flatMapLatest {
-        noteDataSource.observeOne(Note.Id(it.accountId, show.noteId))
+        noteDataSource.observeOne(Note.Id(it.accountId, noteId))
     }.onStart {
         emit(null)
     }
@@ -159,7 +161,7 @@ class NoteDetailViewModel @AssistedInject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val account = currentAccountWatcher.getAccount()
-                val note = noteRepository.find(Note.Id(account.accountId, show.noteId))
+                val note = noteRepository.find(Note.Id(account.accountId, noteId))
                     .getOrThrow()
                 noteRepository.syncConversation(note.id).getOrThrow()
                 recursiveSync(note.id).getOrThrow()
@@ -188,7 +190,7 @@ class NoteDetailViewModel @AssistedInject constructor(
 
     suspend fun getUrl(): String {
         val account = currentAccountWatcher.getAccount()
-        return "${account.instanceDomain}/notes/${show.noteId}"
+        return "${account.instanceDomain}/notes/${noteId}"
     }
 
 
@@ -204,16 +206,6 @@ class NoteDetailViewModel @AssistedInject constructor(
 
 }
 
-@Suppress("UNCHECKED_CAST")
-fun NoteDetailViewModel.Companion.provideFactory(
-    factory: NoteDetailViewModel.ViewModelAssistedFactory,
-    show: Pageable.Show,
-    accountId: Long? = null,
-) = object : ViewModelProvider.Factory {
-    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        return factory.create(show, accountId) as T
-    }
-}
 
 sealed interface NoteType {
     data class Detail(val note: NoteRelation) : NoteType

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewModel.kt
@@ -38,7 +38,7 @@ class NoteDetailViewModel @Inject constructor(
         it != -1L
     }
 
-    val noteId: String = savedStateHandle[EXTRA_NOTE_ID] ?: throw IllegalArgumentException()
+    val noteId: String = requireNotNull(savedStateHandle[EXTRA_NOTE_ID])
 
     private val currentAccountWatcher: CurrentAccountWatcher = CurrentAccountWatcher(accountId, accountRepository)
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/history/ReactionHistoryListFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/history/ReactionHistoryListFragment.kt
@@ -2,74 +2,44 @@ package net.pantasystem.milktea.note.reaction.history
 
 import android.os.Bundle
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.wada811.databinding.dataBinding
 import dagger.hilt.android.AndroidEntryPoint
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.FragmentReactionHistoryListBinding
 import net.pantasystem.milktea.note.reaction.viewmodel.ReactionHistoryViewModel
-import net.pantasystem.milktea.note.reaction.viewmodel.provideViewModel
-import javax.inject.Inject
 
 @AndroidEntryPoint
-class ReactionHistoryListFragment : Fragment() {
+class ReactionHistoryListFragment : Fragment(R.layout.fragment_reaction_history_list) {
 
     companion object {
-        private const val EXTRA_NOTE_ID = "NOTE_ID"
-        private const val EXTRA_ACCOUNT_ID = "EXTRA_ACCOUNT_ID"
-        private const val EXTRA_TYPE = "EXTRA_TYPE"
-
         fun newInstance(noteId: Note.Id, type: String? = null) : ReactionHistoryListFragment {
             return ReactionHistoryListFragment().also {
                 it.arguments = Bundle().also { bundle ->
-                    bundle.putString(EXTRA_NOTE_ID, noteId.noteId)
-                    bundle.putLong(EXTRA_ACCOUNT_ID, noteId.accountId)
+                    bundle.putSerializable(ReactionHistoryViewModel.EXTRA_NOTE_ID, noteId)
                     type?.let{
-                        bundle.putString(EXTRA_TYPE, type)
+                        bundle.putString(ReactionHistoryViewModel.EXTRA_TYPE, type)
                     }
                 }
             }
         }
     }
 
-    lateinit var binding: FragmentReactionHistoryListBinding
+    val binding: FragmentReactionHistoryListBinding by dataBinding()
     lateinit var mLinearLayoutManager: LinearLayoutManager
 
-    @Inject
-    lateinit var assistedFactory: ReactionHistoryViewModel.ViewModelAssistedFactory
-    private val viewModel: ReactionHistoryViewModel by viewModels {
-        val aId = requireArguments().getLong(EXTRA_ACCOUNT_ID, -1)
-        val nId = requireArguments().getString(EXTRA_NOTE_ID)
-        val type = requireArguments().getString(EXTRA_TYPE)
-        requireNotNull(nId)
-        require(aId != -1L)
-        val noteId = Note.Id(aId, nId)
-        ReactionHistoryViewModel.provideViewModel(assistedFactory, noteId, type)
-    }
+    private val viewModel: ReactionHistoryViewModel by viewModels()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_reaction_history_list, container, false)
-        return binding.root
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val aId = requireArguments().getLong(EXTRA_ACCOUNT_ID, -1)
-        val nId = requireArguments().getString(EXTRA_NOTE_ID)
-        requireNotNull(nId)
-        require(aId != -1L)
+
         viewModel.isLoading.observe(viewLifecycleOwner) {
             if(it == true && viewModel.histories.value.isNullOrEmpty()) {
                 // 初期読み込み

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/ReactionHistoryViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/ReactionHistoryViewModel.kt
@@ -1,12 +1,10 @@
 package net.pantasystem.milktea.note.reaction.viewmodel
 
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
@@ -19,22 +17,24 @@ import net.pantasystem.milktea.model.notes.reaction.ReactionHistory
 import net.pantasystem.milktea.model.notes.reaction.ReactionHistoryDataSource
 import net.pantasystem.milktea.model.notes.reaction.ReactionHistoryPaginator
 import net.pantasystem.milktea.model.notes.reaction.ReactionHistoryRequest
+import javax.inject.Inject
 
 
-class ReactionHistoryViewModel @AssistedInject constructor(
+@HiltViewModel
+class ReactionHistoryViewModel @Inject constructor(
     reactionHistoryDataSource: ReactionHistoryDataSource,
     paginatorFactory: ReactionHistoryPaginator.Factory,
     val loggerFactory: Logger.Factory,
-    @Assisted val noteId: Note.Id,
-    @Assisted val type: String?
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    @AssistedFactory
-    interface ViewModelAssistedFactory {
-        fun create(noteId: Note.Id, type: String?): ReactionHistoryViewModel
+    companion object {
+        const val EXTRA_NOTE_ID = "ReactionHistoryViewModel.EXTRA_NOTE_ID"
+        const val EXTRA_TYPE = "ReactionHistoryViewModel.TYPE"
     }
 
-    companion object
+    val noteId: Note.Id = requireNotNull(savedStateHandle[EXTRA_NOTE_ID])
+    val type: String? = savedStateHandle[EXTRA_TYPE]
 
     val logger = loggerFactory.create("ReactionHistoryVM")
 
@@ -66,15 +66,4 @@ class ReactionHistoryViewModel @AssistedInject constructor(
         }
     }
 
-}
-
-@Suppress("UNCHECKED_CAST")
-fun ReactionHistoryViewModel.Companion.provideViewModel(
-    factory: ReactionHistoryViewModel.ViewModelAssistedFactory,
-    noteId: Note.Id,
-    type: String?
-) = object : ViewModelProvider.Factory {
-    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        return factory.create(noteId, type) as T
-    }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenotesBottomSheetDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenotesBottomSheetDialog.kt
@@ -21,38 +21,22 @@ import net.pantasystem.milktea.note.view.RenoteUsersScreen
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class RenotesBottomSheetDialog : BottomSheetDialogFragment(){
+class RenotesBottomSheetDialog : BottomSheetDialogFragment() {
 
     @Inject
     lateinit var userDetailNavigation: UserDetailNavigation
 
     companion object {
-        private const val EXTRA_ACCOUNT_ID = "ACCOUNT_ID"
-        private const val EXTRA_NOTE_ID = "NOTE_ID"
-
-        fun newInstance(noteId: Note.Id) : RenotesBottomSheetDialog {
+        fun newInstance(noteId: Note.Id): RenotesBottomSheetDialog {
             return RenotesBottomSheetDialog().also {
                 it.arguments = Bundle().also { bundle ->
-                    bundle.putLong(EXTRA_ACCOUNT_ID, noteId.accountId)
-                    bundle.putString(EXTRA_NOTE_ID, noteId.noteId)
+                    bundle.putSerializable(RenotesViewModel.EXTRA_NOTE_ID, noteId)
                 }
             }
         }
     }
 
-    @Inject
-    lateinit var renotesViewModelAssistedFactory: RenotesViewModel.ViewModelAssistedFactory
-
-
-
-    private val viewModel by viewModels<RenotesViewModel> {
-        val noteId = arguments?.let {
-            val aId = it.getLong(EXTRA_ACCOUNT_ID)
-            val nId = it.getString(EXTRA_NOTE_ID)!!
-            Note.Id(aId, nId)
-        }!!
-        RenotesViewModel.provideViewModel(renotesViewModelAssistedFactory, noteId)
-    }
+    private val viewModel by viewModels<RenotesViewModel>()
 
 
     private val bottomSheetDialogBehavior: BottomSheetBehavior<FrameLayout>?
@@ -75,9 +59,11 @@ class RenotesBottomSheetDialog : BottomSheetDialogFragment(){
                         renotesViewModel = viewModel,
                         onSelected = { nr ->
                             dismiss()
-                            val intent = userDetailNavigation.newIntent(UserDetailNavigationArgs.UserId(
-                                nr.user.id
-                            ))
+                            val intent = userDetailNavigation.newIntent(
+                                UserDetailNavigationArgs.UserId(
+                                    nr.user.id
+                                )
+                            )
                             startActivity(intent)
                         },
                         onScrollState = { state ->

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenotesViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenotesViewModel.kt
@@ -1,11 +1,9 @@
 package net.pantasystem.milktea.note.renote
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -21,28 +19,29 @@ import net.pantasystem.milktea.model.notes.NoteRelation
 import net.pantasystem.milktea.model.notes.NoteRepository
 import net.pantasystem.milktea.model.notes.renote.Renote
 import net.pantasystem.milktea.model.user.User
+import javax.inject.Inject
 
-class RenotesViewModel @AssistedInject constructor(
+@HiltViewModel
+class RenotesViewModel @Inject constructor(
     private val renotesPagingServiceFactory: RenotesPagingService.Factory,
     private val noteGetter: NoteRelationGetter,
     private val noteRepository: NoteRepository,
     private val noteCaptureAPIAdapter: NoteCaptureAPIAdapter,
     accountStore: AccountStore,
     loggerFactory: Logger.Factory,
-    @Assisted val noteId: Note.Id,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    @AssistedFactory
-    interface ViewModelAssistedFactory {
-        fun create(noteId: Note.Id): RenotesViewModel
-    }
 
-    companion object;
+    companion object {
+        const val EXTRA_NOTE_ID = "RenotesViewModel.EXTRA_NOTE_ID"
+    }
+    val noteId: Note.Id = savedStateHandle[EXTRA_NOTE_ID]
+        ?: throw IllegalArgumentException()
 
     private val renotesPagingService by lazy {
         renotesPagingServiceFactory.create(noteId)
     }
-
 
     private val logger = loggerFactory.create("RenotesVM")
 
@@ -116,15 +115,5 @@ class RenotesViewModel @AssistedInject constructor(
                 }
             }
         }
-    }
-}
-
-fun RenotesViewModel.Companion.provideViewModel(
-    factory: RenotesViewModel.ViewModelAssistedFactory,
-    noteId: Note.Id
-) = object : ViewModelProvider.Factory {
-    @Suppress("UNCHECKED_CAST")
-    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        return factory.create(noteId) as T
     }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -56,7 +56,7 @@ class TimelineViewModel @Inject constructor(
         const val EXTRA_PAGEABLE = "TimelineViewModel.EXTRA_PAGEABLE"
     }
 
-    val pageable: Pageable = savedStateHandle[EXTRA_PAGEABLE] ?: throw IllegalArgumentException()
+    val pageable: Pageable = requireNotNull(savedStateHandle[EXTRA_PAGEABLE])
     val accountId: Long? = savedStateHandle[EXTRA_ACCOUNT_ID]
 
     val tag = "TimelineViewModel"

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -1,12 +1,10 @@
 package net.pantasystem.milktea.note.timeline.viewmodel
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
@@ -23,7 +21,6 @@ import net.pantasystem.milktea.common.StateContent
 import net.pantasystem.milktea.common_android.resource.StringSource
 import net.pantasystem.milktea.data.gettters.NoteRelationGetter
 import net.pantasystem.milktea.data.infrastructure.url.UrlPreviewStoreProvider
-import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.account.CurrentAccountWatcher
 import net.pantasystem.milktea.model.account.UnauthorizedException
@@ -36,9 +33,11 @@ import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewDataCache
 import java.io.IOException
 import java.net.SocketTimeoutException
+import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class TimelineViewModel @AssistedInject constructor(
+@HiltViewModel
+class TimelineViewModel @Inject constructor(
     timelineStoreFactory: TimelineStore.Factory,
     noteStreaming: NoteStreaming,
     accountRepository: AccountRepository,
@@ -49,21 +48,16 @@ class TimelineViewModel @AssistedInject constructor(
     private val urlPreviewStoreProvider: UrlPreviewStoreProvider,
     private val accountStore: AccountStore,
     private val wordFilterConfigRepository: WordFilterConfigRepository,
-    @Assisted val account: Account?,
-    @Assisted val accountId: Long? = account?.accountId,
-    @Assisted val pageable: Pageable,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    @AssistedFactory
-    interface ViewModelAssistedFactory {
-        fun create(
-            account: Account?,
-            accountId: Long?,
-            pageable: Pageable,
-        ): TimelineViewModel
+    companion object {
+        const val EXTRA_ACCOUNT_ID = "TimelineViewModel.EXTRA_ACCOUNT_ID"
+        const val EXTRA_PAGEABLE = "TimelineViewModel.EXTRA_PAGEABLE"
     }
 
-    companion object
+    val pageable: Pageable = savedStateHandle[EXTRA_PAGEABLE] ?: throw IllegalArgumentException()
+    val accountId: Long? = savedStateHandle[EXTRA_ACCOUNT_ID]
 
     val tag = "TimelineViewModel"
 
@@ -169,18 +163,6 @@ class TimelineViewModel @AssistedInject constructor(
 
 }
 
-@Suppress("UNCHECKED_CAST")
-fun TimelineViewModel.Companion.provideViewModel(
-    assistedFactory: TimelineViewModel.ViewModelAssistedFactory,
-    account: Account?,
-    accountId: Long? = account?.accountId,
-    pageable: Pageable,
-
-    ) = object : ViewModelProvider.Factory {
-    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        return assistedFactory.create(account, accountId, pageable) as T
-    }
-}
 
 sealed interface TimelineListItem {
     object Loading : TimelineListItem

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/FollowFollowerActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/FollowFollowerActivity.kt
@@ -17,15 +17,13 @@ import net.pantasystem.milktea.user.compose.screen.FollowFollowerRoute
 import net.pantasystem.milktea.user.viewmodel.FollowFollowerViewModel
 import net.pantasystem.milktea.user.viewmodel.ToggleFollowViewModel
 import net.pantasystem.milktea.user.viewmodel.UserDetailViewModel
-import net.pantasystem.milktea.user.viewmodel.provideFactory
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class FollowFollowerActivity : AppCompatActivity() {
 
     companion object {
-        private const val EXTRA_USER_ID =
-            "net.pantasystem.milktea.user.activity.FollowFollowerActivity.EXTRA_USER_ID"
+
         private const val EXTRA_VIEW_CURRENT =
             "net.pantasystem.milktea.user.activity.FollowFollowerActivity.EXTRA_VIEW_CURRENT"
         private const val FOLLOWING_VIEW_MODE = 0
@@ -33,7 +31,7 @@ class FollowFollowerActivity : AppCompatActivity() {
 
         fun newIntent(context: Context, userId: User.Id, isFollowing: Boolean): Intent {
             return Intent(context, FollowFollowerActivity::class.java).apply {
-                putExtra(EXTRA_USER_ID, userId)
+                putExtra(FollowFollowerViewModel.EXTRA_USER_ID, userId)
                 putExtra(
                     EXTRA_VIEW_CURRENT,
                     if (isFollowing) FOLLOWING_VIEW_MODE else FOLLOWER_VIEW_MODE
@@ -50,12 +48,8 @@ class FollowFollowerActivity : AppCompatActivity() {
 
     private val toggleFollowFollowerViewModel: ToggleFollowViewModel by viewModels()
 
-    @Inject
-    lateinit var viewModelFactory: FollowFollowerViewModel.ViewModelAssistedFactory
-    private val followFollowerViewModel by viewModels<FollowFollowerViewModel> {
-        val userId = intent.getSerializableExtra(EXTRA_USER_ID) as User.Id
-        FollowFollowerViewModel.provideFactory(viewModelFactory, userId)
-    }
+
+    private val followFollowerViewModel by viewModels<FollowFollowerViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/FollowFollowerViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/FollowFollowerViewModel.kt
@@ -1,11 +1,9 @@
 package net.pantasystem.milktea.user.viewmodel
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -16,21 +14,22 @@ import net.pantasystem.milktea.common.PageableState
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.model.user.UserRepository
+import javax.inject.Inject
 
-class FollowFollowerViewModel @AssistedInject constructor(
+@HiltViewModel
+class FollowFollowerViewModel @Inject constructor(
     followFollowerPagingStoreFactory: FollowFollowerPagingStore.Factory,
     private val userRepository: UserRepository,
-    private val userDataSource: UserDataSource,
-    private val loggerFactory: Logger.Factory,
-    @Assisted val userId: User.Id
+    userDataSource: UserDataSource,
+    loggerFactory: Logger.Factory,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    companion object
-
-    @AssistedFactory
-    interface ViewModelAssistedFactory {
-        fun create(userId: User.Id): FollowFollowerViewModel
+    companion object {
+        const val EXTRA_USER_ID = "FollowFollowerViewModel.EXTRA_USER_ID"
     }
+
+    val userId: User.Id = requireNotNull(savedStateHandle.get<User.Id>(EXTRA_USER_ID))
 
     val logger = loggerFactory.create("FollowFollowerVM")
 
@@ -123,13 +122,3 @@ data class FollowFollowerUiState(
     val followerUsersState: PageableState<List<User.Id>> = PageableState.Loading.Init(),
     val followUsersState: PageableState<List<User.Id>> = PageableState.Loading.Init()
 )
-
-fun FollowFollowerViewModel.Companion.provideFactory(
-    factory: FollowFollowerViewModel.ViewModelAssistedFactory,
-    userId: User.Id,
-) = object : ViewModelProvider.Factory {
-    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        @Suppress("UNCHECKED_CAST")
-        return factory.create(userId) as T
-    }
-}


### PR DESCRIPTION
## やったこと
user.idやnote.idなどの値をAssistedInjectを用いて受け渡していましたが、
SavedStateHandleで受け渡す方法に置き換えました

## 動作確認


## スクリーンショット(任意)


## 備考
UserDetailActivityはActivity側の実装に依存していた形だったので今回のPRでは移行を見送りました

## Issue番号
Closed #1037 


