### PR TITLE
編集画面が起動時にクラッシュする問題を修正

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
@@ -158,7 +158,9 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
     @Inject
     lateinit var loggerFactory: Logger.Factory
 
-    val logger = loggerFactory.create("NoteEditorFragment")
+    val logger by lazy {
+        loggerFactory.create("NoteEditorFragment")
+    }
 
     internal lateinit var confirmViewModel: ConfirmViewModel
 
@@ -451,9 +453,9 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
             noteEditorViewModel.textCursorPos.collect {
                 try {
                     binding.inputMain.setText(
-                        noteEditorViewModel.text.value ?: ""
+                        it.text
                     )
-                    binding.inputMain.setSelection(it)
+                    binding.inputMain.setSelection(it.cursorPos)
                 } catch (e: Throwable) {
                     logger.error("setCursorPos error", e = e)
                 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
@@ -68,7 +68,7 @@ class NoteEditorViewModel @Inject constructor(
 
     val text = savedStateHandle.getStateFlow<String?>(NoteEditorSavedStateKey.Text.name, null)
 
-    val textCursorPos = MutableSharedFlow<Int>(extraBufferCapacity = 10)
+    val textCursorPos = MutableSharedFlow<TextWithCursorPos>(extraBufferCapacity = 10)
 
     val cw = savedStateHandle.getStateFlow<String?>(NoteEditorSavedStateKey.Cw.name, null)
     val hasCw = savedStateHandle.getStateFlow(NoteEditorSavedStateKey.HasCW.name, false)
@@ -294,7 +294,7 @@ class NoteEditorViewModel @Inject constructor(
                         users.map { it.displayUserName }, 0
                     )
                 savedStateHandle.setText(text)
-                textCursorPos.tryEmit(pos)
+                textCursorPos.tryEmit(TextWithCursorPos(text, pos))
             }
         }
     }
@@ -551,3 +551,5 @@ class NoteEditorViewModel @Inject constructor(
 
 
 }
+
+data class TextWithCursorPos(val text: String?, val cursorPos: Int)


### PR DESCRIPTION
## やったこと
lateinit varが初期化される前にアクセスしてしまっていたのが原因だったので修正

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



