### PR TITLE
OGPを表示することができなくなった不具合を修正

### DIFF
--- a/modules/model/src/main/java/net/pantasystem/milktea/model/url/UrlPreview.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/url/UrlPreview.kt
@@ -1,5 +1,6 @@
 package net.pantasystem.milktea.model.url
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 
@@ -10,7 +11,7 @@ data class UrlPreview(
     val icon: String?,
     val description: String?,
     val thumbnail: String?,
-    val siteName: String?
+    @SerialName("sitename") val siteName: String?
     //val sensitive: Boolean
     //val player,
 )


### PR DESCRIPTION
## やったこと
JSONをパースする時のキー名の指定が誤っていたため
上手くJSONをデコードすることができずエラーが発生していました。
正しいキー名を指定することにより解決しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



