### PR TITLE
リノートが連続する場合はコンテンツを表示しないようにしました

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -42,7 +42,6 @@ open class PlaneNoteViewData(
             }
         }
 
-    val isMyNote = account.remoteId == toShowNote.user.id.id
 
     val isRenotedByMe = !note.note.hasContent() && note.user.id.id == account.remoteId
 
@@ -90,8 +89,6 @@ open class PlaneNoteViewData(
 
 
     val textNode = MFMParser.parse(toShowNote.note.text, toShowNote.note.emojis)
-    val urls = textNode?.getUrls()
-
 
     val translateState: LiveData<ResultState<Translation?>?> =
         this.noteTranslationStore.state(toShowNote.note.id).asLiveData()
@@ -109,6 +106,8 @@ open class PlaneNoteViewData(
         it.aboutMediaType == File.AboutMediaType.IMAGE || it.aboutMediaType == File.AboutMediaType.VIDEO
     } ?: emptyList()
     val media = MediaViewData(previewableFiles)
+
+    val isOnlyVisibleRenoteStatusMessage = MutableLiveData<Boolean>(false)
 
 
     val urlPreviewList = MutableLiveData<List<UrlPreview>>()

--- a/modules/features/note/src/main/res/layout/item_note.xml
+++ b/modules/features/note/src/main/res/layout/item_note.xml
@@ -44,6 +44,7 @@
                     layout="@layout/item_simple_note"
                     app:note="@{note}"
                     app:noteCardActionListener="@{noteCardActionListener}"
+                    android:visibility="@{note.isOnlyVisibleRenoteStatusMessage ? View.GONE : View.VISIBLE }"
                     />
 
         </LinearLayout>

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
@@ -66,11 +66,16 @@ data class Note(
         return renoteId != null
     }
 
+
+    fun isRenoteOnly(): Boolean {
+        return isRenote() && !hasContent()
+    }
+
     /**
      * ファイル、投票、テキストなどのコンテンツを持っているか
      */
     fun hasContent(): Boolean {
-        return !(text == null && fileIds.isNullOrEmpty() && poll == null)
+        return text != null || !fileIds.isNullOrEmpty() || poll != null
     }
 
     fun isOwnReaction(reaction: Reaction): Boolean {


### PR DESCRIPTION
## やったこと
同一のコンテンツがリノートされた場合は、そのコンテンツを表示しないようにしました。
コンテンツを表示しないようにする条件:
ひとつ前の投稿と現在の投稿がリノートで
一つ前（過去）の投稿がリノートかつリノートの対象が同一の場合

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1066 

