### PR TITLE
引用先のテキストがからの場合に他のノートのテキストが憑依してしまう問題を修正しました

### DIFF
--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -328,14 +328,10 @@
                                 android:visibility='@{note.subCw == null ? View.GONE : View.VISIBLE }'
                                 android:textColor="?attr/colorAccent"
                                 android:text="@{SafeUnbox.unboxString(note.subContentFoldingStatusMessage)}"
-                                android:onClick="@{()-> note.changeSubContentFolding() }"
                                 app:layout_constraintTop_toBottomOf="@id/subCw"
                                 app:layout_constraintStart_toStartOf="parent"
-                                noteId="@{ note.subNote.note.id }"
-                                onToggleCw="@{ note::changeSubContentFolding }"
-                                targetView="@{ subNoteText }"
-                                isVisible="@{ note.subContentFolding }"
-                                app:emojiCompatEnabled="false"
+
+                                android:onClick="@{ () -> note.changeSubContentFolding() }"
                                 />
 
                         <TextView
@@ -346,9 +342,9 @@
                                 android:id="@+id/subNoteText"
                                 tools:text="aowjfoiwajehofijawioefjioawejfiowajeiofhawoifahwoiefwaioe"
                                 app:textNode="@{note.subNoteTextNode}"
-                                android:visibility="@{SafeUnbox.unbox(note.subContentFolding)? View.GONE : View.VISIBLE }"
                                 app:layout_constraintTop_toBottomOf="@id/subContentFoldingButton"
-                                app:layout_constraintStart_toStartOf="parent"/>
+                                app:layout_constraintStart_toStartOf="parent"
+                                android:visibility="@{ note.subContentFolding || note.subNote.note.text == null ? View.GONE : View.VISIBLE }"/>
 
                         <include
                                 layout="@layout/media_preview"
@@ -357,11 +353,13 @@
                                 android:layout_width="match_parent"
                                 android:layout_height="200dp"
                                 android:layout_below="@id/subNoteText"
-                                android:visibility="@{note.subNoteFiles.empty || note.subNoteMedia.isOver4Files ? View.GONE : View.VISIBLE}"
+                                android:visibility="@{note.subContentFolding || note.subNoteFiles.empty || note.subNoteMedia.isOver4Files ? View.GONE : View.VISIBLE}"
                                 tools:layout_height="20dp"
                                 app:layout_constraintStart_toStartOf="parent"
                                 app:layout_constraintEnd_toEndOf="parent"
-                                app:layout_constraintTop_toBottomOf="@id/subNoteText"/>
+                                app:layout_constraintTop_toBottomOf="@id/subNoteText"
+                                android:layout_marginTop="2dp"
+                                />
 
 
                     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## やったこと
原因としては表示状態の制御に問題があり、
特にRecyclerViewではViewが使いまわされ、
使いまわされた時に他のViewの状態が残ったままかつ表示状態が残ってしまった時に発生する問題でした。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



