### PR TITLE
メンションが状態に応じて最適な表示に変換されるようにしました

### DIFF
--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
@@ -7,7 +7,7 @@ import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 object MFMParser {
-    private val mentionPattern = Pattern.compile("""\A@([\w._\-]+)(@[\w._\-]+)?""")
+    internal val mentionPattern = Pattern.compile("""\A@([\w._\-]+)(@[\w._\-]+)?""")
     private val titlePattern = Pattern.compile("""\A[【\[]([^\n\[\]【】]+)[】\]](\n|\z)""")
 
     private val searchPattern =
@@ -412,7 +412,7 @@ object MFMParser {
                 position + matcher.start(),
                 position + matcher.end(),
                 text = "@${matcher.nullableGroup(1)}${getMentionHost(
-                    hostInMentionText = matcher.nullableGroup(1),
+                    hostInMentionText = matcher.nullableGroup(2),
                     accountHost = accountHost,
                     userHost = userHost,
                     

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
@@ -410,15 +410,15 @@ object MFMParser {
                 // NOTE: メンション中に含まれるHost部
                 val hostInMentionText = matcher.nullableGroup(2)
 
-                // NOTE: 投稿先インスタンスと現在のアカウントが異なり、
-                // かつホストの指定がない場合は投稿先のインスタンスのホストを付け足して表示する
+                // NOTE: 投稿先ユーザーのインスタンスとと現在のアカウントのインスタンスが異なり、
+                // かつホストの指定がない場合はメンション部に投稿先のインスタンスのホストを付け足して表示する
                 if (hostInMentionText.isNullOrBlank()) {
                     return userHost?.let {
                         "@$it"
                     } ?: ""
                 }
 
-                // NOTE: 投稿先インスタンスと現在のアカウントが異なり、
+                // NOTE: 投稿先インスタンスと現在のアカウントのインスタンスが異なり、
                 // かつテキスト中のメンションのホスト部の指定があり
                 // テキスト中のメンションのホスト部が現在のアカウントインスタンスと同一の場合は省略して表示する
                 if (hostInMentionText == accountHost) {

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
@@ -6,19 +6,25 @@ import java.net.URLDecoder
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-object MFMParser{
+object MFMParser {
 
-    fun parse(text: String?, emojis: List<Emoji>? = emptyList(), userHost: String? = null, isSameHost: Boolean? = null): Root?{
-        text?: return null
+    fun parse(
+        text: String?,
+        emojis: List<Emoji>? = emptyList(),
+        userHost: String? = null,
+        accountHost: String? = null
+    ): Root? {
+        text ?: return null
         //println("textSize:${text.length}")
         println("userHost:$userHost")
         val root = Root(text)
-        NodeParser(text, root,
+        NodeParser(
+            text, root,
             emojis?.associate {
                 it.name to it
             } ?: emptyMap(),
             userHost = userHost,
-            isSameHost = isSameHost
+            accountHost = accountHost,
         ).parse()
         return root
     }
@@ -39,8 +45,8 @@ object MFMParser{
         val start: Int = parent.insideStart,
         val end: Int = parent.insideEnd,
         val userHost: String?,
-        val isSameHost: Boolean?,
-    ){
+        val accountHost: String?,
+    ) {
         // タグ探索開始
         // タグ探索中
         // タグ探索完了
@@ -59,7 +65,7 @@ object MFMParser{
          * 第一段階としてタグの先頭の文字に該当するかを検証する
          * キャンセルされたときはここからやり直される
          */
-        private val parserMap: Map<Char, List<()-> Element?>> = mapOf(
+        private val parserMap: Map<Char, List<() -> Element?>> = mapOf(
             '<' to listOf(::parseBlock), //斜体、小文字、中央揃え、横伸縮、左右反転、回転、飛び跳ねる
             '~' to listOf(::parseStrike), //打消し線
             //'(' to ::parseExpansion, //横伸縮
@@ -82,28 +88,28 @@ object MFMParser{
          * @param tagStart 次に存在するNodeの始点
          * text<Node> この場合だと4になる
          */
-        private fun recoveryBeforeText(tagStart: Int){
+        private fun recoveryBeforeText(tagStart: Int) {
             // 文字数が０より多いとき
-            if((tagStart - finallyDetected) > 0){
+            if ((tagStart - finallyDetected) > 0) {
                 val text = sourceText.substring(finallyDetected, tagStart)
                 parent.childElements.add(Text(text, finallyDetected))
             }
         }
 
-        fun parse(){
-            while(position < end){
+        fun parse() {
+            while (position < end) {
                 val parser = parserMap[sourceText[position]]
 
-                if(parser == null){
+                if (parser == null) {
                     // 何にも該当しない場合は繰り上げる
-                    position ++
-                }else{
+                    position++
+                } else {
 
                     val node = parser.mapNotNull {
                         it.invoke()
                     }.firstOrNull()
                     // nodeが実際に存在したとき
-                    if(node != null){
+                    if (node != null) {
 
                         // positionは基本的にはNodeの開始地点のままなので発見したNodeの終了地点にする
                         position = node.end
@@ -116,20 +122,25 @@ object MFMParser{
                         finallyDetected = node.end
 
 
-
                         // 発見したNodeを追加する
                         parent.childElements.add(node)
 
 
                         // 新たに発見した子NodeのためにNodeParserを作成する
                         // 新たに発見した子Nodeの内側を捜索するのでparentは新たに発見した子Nodeになる
-                        if(node is Node){
-                            NodeParser(sourceText, parent = node, emojiNameMap = emojiNameMap, userHost = userHost, isSameHost = isSameHost).parse()
+                        if (node is Node) {
+                            NodeParser(
+                                sourceText,
+                                parent = node,
+                                emojiNameMap = emojiNameMap,
+                                userHost = userHost,
+                                accountHost = accountHost
+                            ).parse()
                         }
 
 
-                    }else{
-                        position ++
+                    } else {
+                        position++
                     }
                 }
             }
@@ -142,21 +153,21 @@ object MFMParser{
          * タグの開始位置や終了位置、内部要素の開始、終了位置は正規表現とMatcherを利用し現在のポジションと合わせ相対的に求める
          */
 
-        private fun parseTypeStar(): Node?{
+        private fun parseTypeStar(): Node? {
             val boldPattern = Pattern.compile("""\A\*\*(.+?)\*\*""", Pattern.DOTALL)
             val animationPattern = Pattern.compile("""\A\*\*\*(.+?)\*\*\*""", Pattern.DOTALL)
             val currentInside = sourceText.substring(position, parent.insideEnd)
 
-            if(animationPattern.matcher(currentInside).find()){
+            if (animationPattern.matcher(currentInside).find()) {
                 // アニメーションはサポートしていないため終了
                 return null
             }
 
             val matcher = boldPattern.matcher(currentInside)
-            if(!matcher.find()){
+            if (!matcher.find()) {
                 return null
             }
-            if(parent.elementType.elementClass.weight < ElementType.BOLD.elementClass.weight || parent.elementType == ElementType.BOLD){
+            if (parent.elementType.elementClass.weight < ElementType.BOLD.elementClass.weight || parent.elementType == ElementType.BOLD) {
                 return null
             }
 
@@ -170,18 +181,18 @@ object MFMParser{
             )
         }
 
-        private fun parseBlock(): Node?{
+        private fun parseBlock(): Node? {
             val pattern = Pattern.compile("""\A<([a-z]+)>(.+?)</\1>""", Pattern.DOTALL)
             val matcher = pattern.matcher(sourceText.substring(position, parent.insideEnd))
-            if(!matcher.find()){
+            if (!matcher.find()) {
                 return null
-            }else{
-                val tagName = matcher.group(1)?: return null
+            } else {
+                val tagName = matcher.group(1) ?: return null
 
-                val tag = MFMContract.blockTypeTagNameMap[tagName]?: return null
+                val tag = MFMContract.blockTypeTagNameMap[tagName] ?: return null
 
                 // Parentより自分のほうが重い又は同じタグの場合無効
-                if(parent.elementType.elementClass.weight < tag.elementClass.weight || parent.elementType == tag){
+                if (parent.elementType.elementClass.weight < tag.elementClass.weight || parent.elementType == tag) {
                     return null
                 }
 
@@ -197,13 +208,13 @@ object MFMParser{
             }
         }
 
-        private fun parseStrike(): Node?{
+        private fun parseStrike(): Node? {
             val pattern = Pattern.compile("""\A~~(.+?)~~""", Pattern.DOTALL)
             val matcher = pattern.matcher(sourceText.substring(position, parent.insideEnd))
-            if(!matcher.find()){
+            if (!matcher.find()) {
                 return null
             }
-            if(parent.elementType.elementClass.weight < ElementType.STRIKE.elementClass.weight || parent.elementType == ElementType.STRIKE){
+            if (parent.elementType.elementClass.weight < ElementType.STRIKE.elementClass.weight || parent.elementType == ElementType.STRIKE) {
                 return null
             }
             val child = matcher.group(1)
@@ -218,14 +229,13 @@ object MFMParser{
         }
 
 
-
-        private fun parseCode(): Node?{
+        private fun parseCode(): Node? {
             val pattern = Pattern.compile("""\A```(.*)```""", Pattern.DOTALL)
             val matcher = pattern.matcher(sourceText.substring(position, parent.insideEnd))
-            if(!matcher.find()){
+            if (!matcher.find()) {
                 return null
             }
-            if(parent.elementType != ElementType.ROOT){
+            if (parent.elementType != ElementType.ROOT) {
                 return null
             }
             return Node(
@@ -237,16 +247,16 @@ object MFMParser{
             )
         }
 
-        private fun parseQuote(): Node?{
+        private fun parseQuote(): Node? {
 
-            if(position > 0){
-                val c = sourceText[ position - 1 ]
+            if (position > 0) {
+                val c = sourceText[position - 1]
                 // 直前の文字が改行コードではないかつ、親が引用コードではない
-                if( (c != '\r' && c != '\n') && parent.elementType != ElementType.QUOTE){
+                if ((c != '\r' && c != '\n') && parent.elementType != ElementType.QUOTE) {
 //                    println("直前の文字が改行コードではないかつ、親が引用コードではない")
                     return null
                 }
-                if( parent.elementType.elementClass.weight < ElementType.QUOTE.elementClass.weight && parent.elementType != ElementType.ROOT){
+                if (parent.elementType.elementClass.weight < ElementType.QUOTE.elementClass.weight && parent.elementType != ElementType.ROOT) {
 //                    println("親ノードのほうが小さい")
                     return null
                 }
@@ -255,7 +265,7 @@ object MFMParser{
             val matcher = quotePattern.matcher(sourceText.substring(position, parent.insideEnd))
 
 
-            if(!matcher.find()){
+            if (!matcher.find()) {
                 return null
             }
             val nodeEnd = matcher.end()
@@ -263,7 +273,7 @@ object MFMParser{
 
 
             // > の後に何もない場合キャンセルする
-            if(nodeEnd + position <= position){
+            if (nodeEnd + position <= position) {
                 return null
             }
             ///println("inside:$inside")
@@ -279,25 +289,27 @@ object MFMParser{
 
         private val titlePattern = Pattern.compile("""\A[【\[]([^\n\[\]【】]+)[】\]](\n|\z)""")
 
-        private val searchPattern = Pattern.compile("""^(.+?)[ |　]((?i)Search|検索|\[検索]|\[Search])$""", Pattern.MULTILINE)
-        private val linkPattern = Pattern.compile("""\??\[(.+?)]\((https?|ftp)(://[-_.!~*'()a-zA-Z0-9;/?:@&=+${'$'},%#]+)\)""")
+        private val searchPattern =
+            Pattern.compile("""^(.+?)[ |　]((?i)Search|検索|\[検索]|\[Search])$""", Pattern.MULTILINE)
+        private val linkPattern =
+            Pattern.compile("""\??\[(.+?)]\((https?|ftp)(://[-_.!~*'()a-zA-Z0-9;/?:@&=+${'$'},%#]+)\)""")
 
-        private fun parseTitle(): Node?{
-            if(position > 0){
-                val c = sourceText[ position - 1 ]
+        private fun parseTitle(): Node? {
+            if (position > 0) {
+                val c = sourceText[position - 1]
                 // 直前の文字が改行コードではないかつ、親が引用コードではない
-                if( (c != '\r' && c != '\n') ){
+                if ((c != '\r' && c != '\n')) {
                     return null
                 }
-                if( parent.elementType != ElementType.ROOT){
+                if (parent.elementType != ElementType.ROOT) {
                     return null
                 }
             }
             val matcher = titlePattern.matcher(sourceText.substring(position, parent.insideEnd))
-            if(!matcher.find()){
+            if (!matcher.find()) {
                 return null
             }
-            if(parent.elementType != ElementType.ROOT){
+            if (parent.elementType != ElementType.ROOT) {
                 return null
             }
             return Node(
@@ -314,15 +326,15 @@ object MFMParser{
          * 要素が見つかれば他の要素のルールと同じく要素の末端が次のポジションになる
          * 戻るポイントは基本的には検索済みであるが要素は発見されなかった場所なので無視してしまうリスクは限りなくゼロに近い。
          */
-        private fun parseSearch(): Search?{
+        private fun parseSearch(): Search? {
 
             val targetText = sourceText.substring(finallyDetected, parent.insideEnd)
             val matcher = searchPattern.matcher(targetText)
-            if(!matcher.find() || parent.elementType != ElementType.ROOT){
+            if (!matcher.find() || parent.elementType != ElementType.ROOT) {
                 return null
             }
 
-            val text = matcher.group(1)?: return null
+            val text = matcher.group(1) ?: return null
             return Search(
                 text = text,
                 start = finallyDetected + matcher.start(),
@@ -333,20 +345,20 @@ object MFMParser{
         }
 
 
-        private fun parseLink(): Link?{
+        private fun parseLink(): Link? {
 
             val targetText = sourceText.substring(position, parent.insideEnd)
             val matcher = linkPattern.matcher(targetText)
-            if(!matcher.find()){
+            if (!matcher.find()) {
                 return null
             }
 
-            if(parent.elementType.elementClass.weight <= ElementClass.LINK.weight){
+            if (parent.elementType.elementClass.weight <= ElementClass.LINK.weight) {
                 return null
             }
 
-            val text = matcher.group(1)?: return null
-            val url = matcher.group(2)?: return null
+            val text = matcher.group(1) ?: return null
+            val url = matcher.group(2) ?: return null
             return Link(
                 text = text,
                 start = position + matcher.start(),
@@ -358,12 +370,12 @@ object MFMParser{
         }
 
         private val emojiPattern = Pattern.compile("""\A:([a-zA-Z0-9+\-_]+):""")
-        private fun parseEmoji(): EmojiElement?{
+        private fun parseEmoji(): EmojiElement? {
             val matcher = emojiPattern.matcher(sourceText.substring(position, parent.insideEnd))
-            if(!matcher.find() || parent.elementType.elementClass.weight <= ElementType.EMOJI.elementClass.weight){
+            if (!matcher.find() || parent.elementType.elementClass.weight <= ElementType.EMOJI.elementClass.weight) {
                 return null
             }
-            val tagName = matcher.group(1)?: return null
+            val tagName = matcher.group(1) ?: return null
             val emoji: Emoji = emojiNameMap[tagName]
                 ?: return null
 
@@ -378,43 +390,62 @@ object MFMParser{
         }
 
         private val mentionPattern = Pattern.compile("""\A@([\w._\-]+)(@[\w._\-]+)?""")
-        private fun parseMention(): Mention?{
-            if(!beforeSpaceCheck()){
+        private fun parseMention(): Mention? {
+            if (!beforeSpaceCheck()) {
                 return null
             }
             val matcher = mentionPattern.matcher(sourceText.substring(position, parent.insideEnd))
-            if(!matcher.find() || parent.elementType.elementClass.weight <= ElementType.MENTION.elementClass.weight){
+            if (!matcher.find() || parent.elementType.elementClass.weight <= ElementType.MENTION.elementClass.weight) {
                 return null
             }
-            val host = if (isSameHost == true) {
-                ""
-            } else matcher.nullableGroup(2).let { host ->
-                if (host.isNullOrBlank()) {
-                    userHost?.let {
-                        "@$it"
-                    }
-                } else {
-                    host
+            fun getHost(): String {
+                if (accountHost == null) {
+                    return ""
                 }
-            } ?: ""
+                // NOTE: 投稿主とアカウントの所有者が同一のアカウントである時
+                if (userHost == accountHost) {
+                    return ""
+                }
+
+                // NOTE: メンション中に含まれるHost部
+                val hostInMentionText = matcher.nullableGroup(2)
+
+                // NOTE: 投稿先インスタンスと現在のアカウントが異なり、
+                // かつホストの指定がない場合は投稿先のインスタンスのホストを付け足して表示する
+                if (hostInMentionText.isNullOrBlank()) {
+                    return userHost?.let {
+                        "@$it"
+                    } ?: ""
+                }
+
+                // NOTE: 投稿先インスタンスと現在のアカウントが異なり、
+                // かつテキスト中のメンションのホスト部の指定があり
+                // テキスト中のメンションのホスト部が現在のアカウントインスタンスと同一の場合は省略して表示する
+                if (hostInMentionText == accountHost) {
+                    return ""
+                }
+
+                return ""
+            }
+
 
             return Mention(
                 position + matcher.start(),
                 position + matcher.end(),
                 position + matcher.start(),
                 position + matcher.end(),
-                text = "@${matcher.nullableGroup(1)}$host",
+                text = "@${matcher.nullableGroup(1)}${getHost()}",
                 host = matcher.nullableGroup(2)
             )
         }
 
         private val hashTagPattern = Pattern.compile("""#[^\s.,!?'"#:/\[\]【】@]+""")
-        private fun parseHashTag(): HashTag?{
-            if(!beforeSpaceCheck()){
+        private fun parseHashTag(): HashTag? {
+            if (!beforeSpaceCheck()) {
                 return null
             }
             val matcher = hashTagPattern.matcher(sourceText.substring(position, parent.insideEnd))
-            if(!matcher.find() || parent.elementType.elementClass.weight <= ElementType.MENTION.elementClass.weight){
+            if (!matcher.find() || parent.elementType.elementClass.weight <= ElementType.MENTION.elementClass.weight) {
                 return null
             }
 
@@ -428,16 +459,18 @@ object MFMParser{
 
         }
 
-        private val urlPattern = Pattern.compile("""(https?)(://)([-_.!~*'()\[\]a-zA-Z0-9;/?:@&=+${'$'},%#]+)""")
-        private fun parseUrl(): Link?{
+        private val urlPattern =
+            Pattern.compile("""(https?)(://)([-_.!~*'()\[\]a-zA-Z0-9;/?:@&=+${'$'},%#]+)""")
+
+        private fun parseUrl(): Link? {
             val matcher = urlPattern.matcher(sourceText.substring(position, parent.insideEnd))
-            if(!matcher.find()){
+            if (!matcher.find()) {
                 return null
             }
-            fun decodeUrl(url: String): String{
+            fun decodeUrl(url: String): String {
                 return URLDecoder.decode(url.replace("%20", "+"), "UTF-8")
             }
-            return if(matcher.nullableGroup(1) == "http"){
+            return if (matcher.nullableGroup(1) == "http") {
                 Link(
                     decodeUrl(matcher.group()),
                     position + matcher.start(),
@@ -446,46 +479,47 @@ object MFMParser{
                     position + matcher.end(),
                     matcher.group()
                 )
-            }else {
+            } else {
                 Link(
-                    decodeUrl(matcher.nullableGroup(3)?: matcher.group()),
+                    decodeUrl(matcher.nullableGroup(3) ?: matcher.group()),
                     position + matcher.start(),
                     position + matcher.end(),
-                    position + (matcher.nullableStart(3)?: matcher.start()),
-                    position + (matcher.nullableEnd(3)?: matcher.end()),
+                    position + (matcher.nullableStart(3) ?: matcher.start()),
+                    position + (matcher.nullableEnd(3) ?: matcher.end()),
                     url = matcher.group()
                 )
             }
         }
 
         private val spaceCRLFPattern = Pattern.compile("""\s""")
-        private fun beforeSpaceCheck(): Boolean{
-            return position <= parent.insideStart || spaceCRLFPattern.matcher(sourceText[ position - 1].toString()).find()
+        private fun beforeSpaceCheck(): Boolean {
+            return position <= parent.insideStart || spaceCRLFPattern.matcher(sourceText[position - 1].toString())
+                .find()
 
         }
 
     }
 
-    private fun Matcher.nullableGroup(group: Int): String?{
-        return try{
+    private fun Matcher.nullableGroup(group: Int): String? {
+        return try {
             this.group(group)
-        }catch(e: Exception){
+        } catch (e: Exception) {
             null
         }
     }
 
-    private fun Matcher.nullableStart(group: Int): Int?{
-        return try{
+    private fun Matcher.nullableStart(group: Int): Int? {
+        return try {
             this.start(group)
-        }catch(e: Exception){
+        } catch (e: Exception) {
             null
         }
     }
 
-    private fun Matcher.nullableEnd(group: Int): Int?{
-        return try{
+    private fun Matcher.nullableEnd(group: Int): Int? {
+        return try {
             this.end(group)
-        }catch(e: Exception){
+        } catch (e: Exception) {
             null
         }
     }

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
@@ -402,7 +402,7 @@ object MFMParser {
                 if (accountHost == null) {
                     return ""
                 }
-                // NOTE: 投稿主とアカウントの所有者が同一のアカウントである時
+                // NOTE: 投稿主とアカウントの所有者が同一のホスト(インスタンス)である時
                 if (userHost == accountHost) {
                     return ""
                 }

--- a/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
+++ b/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
@@ -56,5 +56,21 @@ class MFMParserTest {
     }
 
 
+    @Test
+    fun getMentionHost_Pattern1() {
+        val host = MFMParser.getMentionHost(
+            hostInMentionText = "@pokemon.mastportal.info",
+            accountHost = "misskey.io",
+            userHost = "mstdn.jp"
+        )
+        Assert.assertEquals("@pokemon.mastportal.info", host)
+    }
+
+    @Test
+    fun mentionPattern() {
+        val matcher = MFMParser.mentionPattern.matcher("@Panta@pokemon.mastportal.info")
+        Assert.assertTrue(matcher.find())
+        Assert.assertEquals("@pokemon.mastportal.info", matcher.group(2))
+    }
 
 }

--- a/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
+++ b/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
@@ -1,0 +1,60 @@
+package net.pantasystem.milktea.common_android.mfm
+
+import org.junit.Assert
+import org.junit.Test
+
+class MFMParserTest {
+
+    @Test
+    fun getMentionHost_SameMentionHostAndUserOtherHost() {
+        val host = MFMParser.getMentionHost(
+            hostInMentionText = "@misskey.io",
+            accountHost = "misskey.io",
+            userHost = "misskey.io"
+        )
+        Assert.assertEquals("", host)
+    }
+
+    @Test
+    fun getMentionHost_GiveOtherHost() {
+        val host = MFMParser.getMentionHost(
+            hostInMentionText = "@misskey.pantasystem.com",
+            accountHost = "misskey.io",
+            userHost = "misskey.pantasystem.com"
+        )
+        Assert.assertEquals("@misskey.pantasystem.com", host)
+    }
+
+    @Test
+    fun getMentionHost_GiveOtherUserHost() {
+        val host = MFMParser.getMentionHost(
+            hostInMentionText = null,
+            accountHost = "misskey.io",
+            userHost = "misskey.pantasystem.com"
+        )
+        Assert.assertEquals("@misskey.pantasystem.com", host)
+    }
+
+    @Test
+    fun getMentionHost_GiveSameAccountAndUserAndMention() {
+        val host = MFMParser.getMentionHost(
+            hostInMentionText = "@misskey.io",
+            accountHost = "misskey.io",
+            userHost = "misskey.io"
+        )
+        Assert.assertEquals("", host)
+    }
+
+    @Test
+    fun getMentionHost_GiveNullMentionHostAndSameAccountAndUserHost() {
+        val host = MFMParser.getMentionHost(
+            hostInMentionText = null,
+            accountHost = "misskey.io",
+            userHost = "misskey.io"
+        )
+        Assert.assertEquals("", host)
+    }
+
+
+
+}

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -77,7 +77,12 @@ open class PlaneNoteViewData(
     val avatarUrl = toShowNote.user.avatarUrl
 
     val cw = toShowNote.note.cw
-    val cwNode = MFMParser.parse(toShowNote.note.cw, toShowNote.note.emojis)
+    val cwNode = MFMParser.parse(
+        toShowNote.note.cw, toShowNote.note.emojis,
+        userHost = toShowNote.user
+            .host,
+        isSameHost = toShowNote.user.isSameHost
+    )
 
     //true　折り畳み
     val text = toShowNote.note.text
@@ -88,7 +93,10 @@ open class PlaneNoteViewData(
     }
 
 
-    val textNode = MFMParser.parse(toShowNote.note.text, toShowNote.note.emojis)
+    val textNode = MFMParser.parse(
+        toShowNote.note.text, toShowNote.note.emojis, userHost = toShowNote.user
+            .host, isSameHost = toShowNote.user.isSameHost
+    )
 
     val translateState: LiveData<ResultState<Translation?>?> =
         this.noteTranslationStore.state(toShowNote.note.id).asLiveData()
@@ -160,10 +168,20 @@ open class PlaneNoteViewData(
 
     val subNoteAvatarUrl = subNote?.user?.avatarUrl
     private val subNoteText = subNote?.note?.text
-    val subNoteTextNode = MFMParser.parse(subNote?.note?.text, subNote?.note?.emojis)
+    val subNoteTextNode = MFMParser.parse(
+        subNote?.note?.text,
+        subNote?.note?.emojis,
+        isSameHost = subNote?.user?.isSameHost,
+        userHost = subNote?.user?.host
+    )
 
     val subCw = subNote?.note?.cw
-    val subCwNode = MFMParser.parse(subNote?.note?.cw, subNote?.note?.emojis)
+    val subCwNode = MFMParser.parse(
+        subNote?.note?.cw,
+        subNote?.note?.emojis,
+        isSameHost = subNote?.user?.isSameHost,
+        userHost = subNote?.user?.host
+    )
 
     //true　折り畳み
     val subContentFolding = MutableLiveData(subCw != null)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -81,7 +81,7 @@ open class PlaneNoteViewData(
         toShowNote.note.cw, toShowNote.note.emojis,
         userHost = toShowNote.user
             .host,
-        isSameHost = toShowNote.user.isSameHost
+        accountHost = account.getHost()
     )
 
     //true　折り畳み
@@ -94,8 +94,10 @@ open class PlaneNoteViewData(
 
 
     val textNode = MFMParser.parse(
-        toShowNote.note.text, toShowNote.note.emojis, userHost = toShowNote.user
-            .host, isSameHost = toShowNote.user.isSameHost
+        toShowNote.note.text, toShowNote.note.emojis,
+        userHost = toShowNote.user
+            .host,
+        accountHost = account.getHost()
     )
 
     val translateState: LiveData<ResultState<Translation?>?> =
@@ -171,7 +173,7 @@ open class PlaneNoteViewData(
     val subNoteTextNode = MFMParser.parse(
         subNote?.note?.text,
         subNote?.note?.emojis,
-        isSameHost = subNote?.user?.isSameHost,
+        accountHost = account.getHost(),
         userHost = subNote?.user?.host
     )
 
@@ -179,7 +181,7 @@ open class PlaneNoteViewData(
     val subCwNode = MFMParser.parse(
         subNote?.note?.cw,
         subNote?.note?.emojis,
-        isSameHost = subNote?.user?.isSameHost,
+        accountHost = account.getHost(),
         userHost = subNote?.user?.host
     )
 


### PR DESCRIPTION

## やったこと
メンションが現在のアカウントのインスタンス、投稿先のインスタンス、メンションの表示状態に応じて最適な形式で表示するように変換するようにしました。
ParserにそのMFM作成主（投稿主）と現在のアカウントのホストが同一であるのか？を判定したフラグ(isSameHost)と
その投稿主が所属するインスタンスのホストを渡すようにしました。
そしてそのパラメーターを利用して判定を行いメンション部の変換を行うようにしました。

## 動作確認
エミュレーターで動作確認済み


## スクリーンショット(任意)


## 備考


## Issue番号

Closed #1082


