### PR TITLE
Accountテーブルに記録したインスタンスのURLの表記揺れ問題を修正

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/viewmodel/MainViewModel.kt
@@ -128,7 +128,7 @@ class MainViewModel @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     fun getCurrentAccountMisskeyAPI(): Flow<MisskeyAPI?> {
         return accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
-            metaRepository.observe(it.instanceDomain)
+            metaRepository.observe(it.normalizedInstanceDomain)
         }.map {
             it?.let {
                 misskeyAPIProvider.get(it.uri, it.getVersion())

--- a/modules/app_store/src/main/java/net/pantasystem/milktea/app_store/account/AccountStore.kt
+++ b/modules/app_store/src/main/java/net/pantasystem/milktea/app_store/account/AccountStore.kt
@@ -146,7 +146,7 @@ class AccountStore @Inject constructor(
             return
         }
         try {
-            val meta = metaRepository.find(account.instanceDomain).getOrNull()
+            val meta = metaRepository.find(account.normalizedInstanceDomain).getOrNull()
             val pages = makeDefaultPagesUseCase(account, meta)
             accountRepository.add(account.copy(pages = pages), true)
         } catch (e: Exception) {

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/ReactionViewHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/ReactionViewHelper.kt
@@ -78,8 +78,8 @@ object ReactionViewHelper {
         //Log.d("ReactionViewHelper", "reaction $reaction")
         if (reaction.startsWith(":") && reaction.endsWith(":")) {
             val account = accountStore.currentAccount
-            val emojis = if (account?.instanceDomain != null) {
-                cache.get(account.instanceDomain)?.emojis ?: emptyList()
+            val emojis = if (account?.normalizedInstanceDomain != null) {
+                cache.get(account.normalizedInstanceDomain)?.emojis ?: emptyList()
             } else {
                 emptyList()
             }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/viewmodel/AccountViewModel.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/viewmodel/AccountViewModel.kt
@@ -73,7 +73,7 @@ class AccountViewModel @Inject constructor(
             AccountInfo(
                 it,
                 userMap[it.accountId],
-                metaMap[it.instanceDomain],
+                metaMap[it.normalizedInstanceDomain],
                 current?.accountId == it.accountId
             )
         }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/viewmodel/AccountViewModel.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/viewmodel/AccountViewModel.kt
@@ -50,7 +50,7 @@ class AccountViewModel @Inject constructor(
 
     private val metaList = accountStore.observeAccounts.flatMapLatest { accounts ->
         val flows = accounts.map {
-            metaRepository.observe(it.instanceDomain).flowOn(Dispatchers.IO)
+            metaRepository.observe(it.normalizedInstanceDomain).flowOn(Dispatchers.IO)
         }
         combine(flows) {
             it.toList()

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/api/mastodon/MastodonAPIProvider.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/api/mastodon/MastodonAPIProvider.kt
@@ -35,7 +35,7 @@ class MastodonAPIProvider @Inject constructor(
         if (account.instanceType == Account.InstanceType.MISSKEY) {
             throw IllegalArgumentException("アカウント種別Misskeyは受け入れていません")
         }
-        return get(account.instanceDomain, account.token)
+        return get(account.normalizedInstanceDomain, account.token)
 
     }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/api/misskey/MisskeyAPIProvider.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/api/misskey/MisskeyAPIProvider.kt
@@ -39,7 +39,7 @@ class MisskeyAPIProvider @Inject constructor(
     }
 
     fun get(account: Account, version: Version? = null): MisskeyAPI {
-        return get(account.instanceDomain, version)
+        return get(account.normalizedInstanceDomain, version)
     }
 
     fun applyVersion(baseURL: String, version: Version) {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/DriveFileRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/DriveFileRepositoryImpl.kt
@@ -28,7 +28,7 @@ class DriveFileRepositoryImpl @Inject constructor(
             return file
         }
         val account = getAccount.get(id.accountId)
-        val api = misskeyAPIProvider.get(account.instanceDomain)
+        val api = misskeyAPIProvider.get(account.normalizedInstanceDomain)
         val response = api.showFile(ShowFile(fileId = id.fileId, i = account.token))
             .throwIfHasError()
         val fp = response.body()!!.toFileProperty(account)
@@ -38,7 +38,7 @@ class DriveFileRepositoryImpl @Inject constructor(
 
     override suspend fun toggleNsfw(id: FileProperty.Id) {
         val account = getAccount.get(id.accountId)
-        val api = misskeyAPIProvider.get(account.instanceDomain)
+        val api = misskeyAPIProvider.get(account.normalizedInstanceDomain)
         val fileProperty = find(id)
         val result = api.updateFile(
             UpdateFileDTO(

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/OkHttpDriveFileUploader.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/OkHttpDriveFileUploader.kt
@@ -67,7 +67,7 @@ class OkHttpDriveFileUploader(
             val requestBody = requestBodyBuilder.build()
 
             val request =
-                Request.Builder().url(URL("${account.instanceDomain}/api/drive/files/create"))
+                Request.Builder().url(URL("${account.normalizedInstanceDomain}/api/drive/files/create"))
                     .post(requestBody).build()
             val response = client.newCall(request).execute()
             if (response.isSuccessful) {
@@ -122,7 +122,7 @@ class OkHttpDriveFileUploader(
             val requestBody = requestBodyBuilder.build()
 
             val request =
-                Request.Builder().url(URL("${account.instanceDomain}/api/drive/files/create"))
+                Request.Builder().url(URL("${account.normalizedInstanceDomain}/api/drive/files/create"))
                     .post(requestBody).build()
             val response = client.newCall(request).execute()
             val code = response.code

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/file_paginator.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/file_paginator.kt
@@ -128,7 +128,7 @@ class FilePropertyPagingImpl(
 
     override suspend fun loadPrevious(): Result<List<FilePropertyDTO>> {
         return runCatching {
-            misskeyAPIProvider.get(getAccount.invoke().instanceDomain).getFiles(
+            misskeyAPIProvider.get(getAccount.invoke().normalizedInstanceDomain).getFiles(
                 RequestFile(
                     folderId = getCurrentFolderId.invoke(),
                     untilId = this.getUntilId(),

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/entity_converters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/entity_converters.kt
@@ -36,8 +36,8 @@ fun FilePropertyDTO.toFileProperty(account: Account): FileProperty {
         folderId = folderId,
         comment = comment,
         isSensitive = isSensitive ?: false,
-        url = getUrl(account.instanceDomain),
-        thumbnailUrl = getThumbnailUrl(account.instanceDomain),
+        url = getUrl(account.normalizedInstanceDomain),
+        thumbnailUrl = getThumbnailUrl(account.normalizedInstanceDomain),
         blurhash = blurhash,
         properties = properties?.let {
             FileProperty.Properties(it.width, it.height)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/GalleryRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/GalleryRepositoryImpl.kt
@@ -163,7 +163,7 @@ class GalleryRepositoryImpl @Inject constructor(
     }
 
     private fun getMisskeyAPI(account: Account): MisskeyAPIV1275 {
-        return misskeyAPIProvider.get(account.instanceDomain) as? MisskeyAPIV1275
+        return misskeyAPIProvider.get(account.normalizedInstanceDomain) as? MisskeyAPIV1275
             ?: throw IllegalVersionException()
     }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/gallery_posts_paginators.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/gallery_posts_paginators.kt
@@ -104,7 +104,7 @@ class GalleryPostsLoader (
 
     suspend fun api(sinceId: String? = null, untilId: String? = null) : suspend ()-> Response<List<GalleryPostDTO>>{
         val i = getAccount.invoke().token
-        val api = apiProvider.get(getAccount.invoke().instanceDomain) as? MisskeyAPIV1275
+        val api = apiProvider.get(getAccount.invoke().normalizedInstanceDomain) as? MisskeyAPIV1275
             ?: throw IllegalVersionException()
         when(pageable) {
             is Pageable.Gallery.MyPosts -> {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/liked_gallery_posts_paginator.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/liked_gallery_posts_paginator.kt
@@ -92,7 +92,7 @@ class LikedGalleryPostsLoader(
 
     override suspend fun loadFuture(): Result<List<LikedGalleryPost>> {
         return runCatching {
-            val api = misskeyAPIProvider.get(getAccount.invoke().instanceDomain) as? MisskeyAPIV1275
+            val api = misskeyAPIProvider.get(getAccount.invoke().normalizedInstanceDomain) as? MisskeyAPIV1275
                 ?: throw IllegalVersionException()
             api.likedGalleryPosts(
                 GetPosts(
@@ -106,7 +106,7 @@ class LikedGalleryPostsLoader(
 
     override suspend fun loadPrevious(): Result<List<LikedGalleryPost>> {
         return runCatching {
-            val api = misskeyAPIProvider.get(getAccount.invoke().instanceDomain) as? MisskeyAPIV1275
+            val api = misskeyAPIProvider.get(getAccount.invoke().normalizedInstanceDomain) as? MisskeyAPIV1275
                 ?: throw IllegalVersionException()
             api.likedGalleryPosts(
                 GetPosts(

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/group/GroupRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/group/GroupRepositoryImpl.kt
@@ -208,7 +208,7 @@ class GroupRepositoryImpl @Inject constructor(
     }
 
     private fun getMisskeyAPI(account: Account): MisskeyAPIV11 {
-        return misskeyAPIProvider.get(account.instanceDomain) as? MisskeyAPIV11
+        return misskeyAPIProvider.get(account.normalizedInstanceDomain) as? MisskeyAPIV11
             ?: throw IllegalVersionException()
     }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/MetaRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/MetaRepositoryImpl.kt
@@ -20,7 +20,7 @@ class MetaRepositoryImpl @Inject constructor(
 
     override suspend fun sync(instanceDomain: String): Result<Unit> = runCatching {
         withContext(Dispatchers.IO) {
-            val meta = fetch(instanceDomain)
+            val meta = fetch(instanceDomain).copy(uri = instanceDomain)
             metaDataSource.add(meta)
             metaCache.put(instanceDomain, meta)
             misskeyAPIProvider.applyVersion(instanceDomain, meta.getVersion())
@@ -35,7 +35,7 @@ class MetaRepositoryImpl @Inject constructor(
             }
             val localMeta = metaDataSource.get(instanceDomain)
             if (localMeta == null) {
-                val meta = fetch(instanceDomain)
+                val meta = fetch(instanceDomain).copy(uri = instanceDomain)
                 metaDataSource.add(meta)
             } else {
                 localMeta

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/MetaRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/MetaRepositoryImpl.kt
@@ -20,7 +20,7 @@ class MetaRepositoryImpl @Inject constructor(
 
     override suspend fun sync(instanceDomain: String): Result<Unit> = runCatching {
         withContext(Dispatchers.IO) {
-            val meta = fetch(instanceDomain).copy(uri = instanceDomain)
+            val meta = fetch(instanceDomain)
             metaDataSource.add(meta)
             metaCache.put(instanceDomain, meta)
             misskeyAPIProvider.applyVersion(instanceDomain, meta.getVersion())
@@ -35,7 +35,7 @@ class MetaRepositoryImpl @Inject constructor(
             }
             val localMeta = metaDataSource.get(instanceDomain)
             if (localMeta == null) {
-                val meta = fetch(instanceDomain).copy(uri = instanceDomain)
+                val meta = fetch(instanceDomain)
                 metaDataSource.add(meta)
             } else {
                 localMeta

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/MetaRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/MetaRepositoryImpl.kt
@@ -22,7 +22,7 @@ class MetaRepositoryImpl @Inject constructor(
         withContext(Dispatchers.IO) {
             val meta = fetch(instanceDomain)
             metaDataSource.add(meta)
-            metaCache.put(instanceDomain, meta)
+            metaCache.put(meta.uri, meta)
             misskeyAPIProvider.applyVersion(instanceDomain, meta.getVersion())
         }
     }
@@ -40,7 +40,7 @@ class MetaRepositoryImpl @Inject constructor(
             } else {
                 localMeta
             }.also { meta ->
-                metaCache.put(instanceDomain, meta)
+                metaCache.put(meta.uri, meta)
                 misskeyAPIProvider.applyVersion(instanceDomain, meta.getVersion())
             }
         }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteTranslationStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteTranslationStoreImpl.kt
@@ -46,7 +46,7 @@ class NoteTranslationStoreImpl @Inject constructor(
 
         runCatching {
             val account = accountRepository.get(noteId.accountId).getOrThrow()
-            val api = misskeyAPIProvider.get(account.instanceDomain)
+            val api = misskeyAPIProvider.get(account.normalizedInstanceDomain)
             val req = Translate(
                 i = account.token,
                 targetLang = Locale.getDefault().language,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/ReactionHistoryPaginatorImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/ReactionHistoryPaginatorImpl.kt
@@ -49,7 +49,7 @@ class ReactionHistoryPaginatorImpl(
     override suspend fun next(): Boolean {
         lock.withLock {
             val account = accountRepository.get(reactionHistoryRequest.noteId.accountId).getOrThrow()
-            val misskeyAPI = misskeyAPIProvider.get(account.instanceDomain)
+            val misskeyAPI = misskeyAPIProvider.get(account.normalizedInstanceDomain)
             val res = misskeyAPI.reactions(
                 RequestReactionHistoryDTO(
                     i = account.token,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/renote/RenotesPagingService.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/renote/RenotesPagingService.kt
@@ -102,7 +102,7 @@ class RenotesPagingImpl(
             val account = accountRepository.get(targetNoteId.accountId).getOrThrow()
             val i = account.token
 
-            misskeyAPIProvider.get(account.instanceDomain)
+            misskeyAPIProvider.get(account.normalizedInstanceDomain)
                 .renotes(FindRenotes(i = i, noteId = targetNoteId.noteId, untilId = getUntilId()))
                 .throwIfHasError().body()!!
         }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/sw/register/SubscriptionRegistrationImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/sw/register/SubscriptionRegistrationImpl.kt
@@ -41,7 +41,7 @@ class SubscriptionRegistrationImpl(
         ).build()
         logger.debug("endpoint:${endpoint}")
 
-        val api = misskeyAPIProvider.get(account.instanceDomain)
+        val api = misskeyAPIProvider.get(account.normalizedInstanceDomain)
         val res = api.swRegister(
             Subscription(
                 i = account.token,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/url/UrlPreviewStoreFactory.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/url/UrlPreviewStoreFactory.kt
@@ -20,7 +20,7 @@ class UrlPreviewStoreFactory(
 
 
     fun create(): UrlPreviewStore {
-        val url = account?.instanceDomain
+        val url = account?.normalizedInstanceDomain
             ?: summalyUrl
         return UrlPreviewMediatorStore(urlPreviewDAO, createUrlPreviewStore(url))
     }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/url/UrlPreviewStoreProvider.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/url/UrlPreviewStoreProvider.kt
@@ -29,7 +29,7 @@ class UrlPreviewStoreProvider @Inject constructor(
         account: Account,
         isReplace: Boolean
     ): UrlPreviewStore {
-        return account.instanceDomain.let { accountUrl ->
+        return account.normalizedInstanceDomain.let { accountUrl ->
 
             var store = mUrlPreviewStoreInstanceBaseUrlMap[accountUrl]
             if (store == null || isReplace) {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserRepositoryImpl.kt
@@ -97,7 +97,7 @@ class UserRepositoryImpl @Inject constructor(
             return@withContext local
         }
         val account = accountRepository.get(accountId).getOrThrow()
-        val misskeyAPI = misskeyAPIProvider.get(account.instanceDomain)
+        val misskeyAPI = misskeyAPIProvider.get(account.normalizedInstanceDomain)
         val res = misskeyAPI.showUser(
             RequestUser(
                 i = account.token,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/streaming/impl/SocketWithAccountProviderImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/streaming/impl/SocketWithAccountProviderImpl.kt
@@ -38,9 +38,9 @@ class SocketWithAccountProviderImpl @Inject constructor(
             }
 
 
-            var uri = account.instanceDomain
+            var uri = account.normalizedInstanceDomain
             if(uri.startsWith("https")) {
-                uri = "wss" + uri.substring(5, uri.length) + "/streaming"
+                uri = "wss://" + account.getHost() + "/streaming"
             }
             try {
                 val i = account.token

--- a/modules/features/auth/src/main/java/net/pantasystem/milktea/auth/viewmodel/app/AppAuthViewModel.kt
+++ b/modules/features/auth/src/main/java/net/pantasystem/milktea/auth/viewmodel/app/AppAuthViewModel.kt
@@ -99,15 +99,21 @@ class AppAuthViewModel @Inject constructor(
         it.inputState.isIdPassword
     }.flatMapLatest {
         suspend {
-            when (val meta = it.meta.content) {
-                is StateContent.Exist -> authService.createWaiting4Approval(
-                    it.inputState.instanceDomain,
-                    authService.createApp(
-                        it.inputState.instanceDomain,
-                        instanceType = meta.rawContent,
-                        appName = it.inputState.appName
+                when (val meta = it.meta.content) {
+                is StateContent.Exist -> {
+                    val instanceBase = when(val info = meta.rawContent) {
+                        is InstanceType.Mastodon -> info.instance.uri
+                        is InstanceType.Misskey -> info.instance.uri
+                    }
+                    authService.createWaiting4Approval(
+                        instanceBase,
+                        authService.createApp(
+                            instanceBase,
+                            instanceType = meta.rawContent,
+                            appName = it.inputState.appName
+                        )
                     )
-                )
+                }
 
                 is StateContent.NotExist -> throw IllegalStateException()
             }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewModel.kt
@@ -188,7 +188,7 @@ class NoteDetailViewModel @AssistedInject constructor(
 
     suspend fun getUrl(): String {
         val account = currentAccountWatcher.getAccount()
-        return "${account.instanceDomain}/notes/${show.noteId}"
+        return "${account.normalizedInstanceDomain}/notes/${show.noteId}"
     }
 
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
@@ -263,7 +263,7 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
         }
 
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
-            metaRepository.observe(it.instanceDomain)
+            metaRepository.observe(it.normalizedInstanceDomain)
         }.mapNotNull {
             it?.emojis
         }.distinctUntilChanged().onEach { emojis ->

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/SimpleEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/SimpleEditorFragment.kt
@@ -124,7 +124,7 @@ class SimpleEditorFragment : Fragment(R.layout.fragment_simple_editor), SimpleEd
         }
 
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
-            metaRepository.observe(it.instanceDomain)
+            metaRepository.observe(it.normalizedInstanceDomain)
         }.mapNotNull {
             it?.emojis
         }.distinctUntilChanged().onEach { emojis ->

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorSwitchAccountExecutor.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorSwitchAccountExecutor.kt
@@ -79,7 +79,7 @@ class NoteEditorSwitchAccountExecutor @Inject constructor(
     ): Result<NoteEditorSwitchAccountExecutorResult> = runCatching {
         if (noteEditingState.renoteId != null) {
             val renote = noteRepository.find(noteEditingState.renoteId).getOrThrow()
-            val url = "${fromAccount?.instanceDomain}/notes/${renote.id.noteId}"
+            val url = "${fromAccount?.normalizedInstanceDomain}/notes/${renote.id.noteId}"
             val toRenoteNote = resolverRepository.resolve(account.accountId, url)
                 .getOrThrow() as ApResolver.TypeNote
             noteEditingState.copy(renoteId = toRenoteNote.note.id)
@@ -95,7 +95,7 @@ class NoteEditorSwitchAccountExecutor @Inject constructor(
     ): Result<NoteEditorSwitchAccountExecutorResult> = runCatching {
         if (noteEditingState.replyId != null) {
             val reply = noteRepository.find(noteEditingState.replyId).getOrThrow()
-            val url = "${fromAccount?.instanceDomain}/notes/${reply.id.noteId}"
+            val url = "${fromAccount?.normalizedInstanceDomain}/notes/${reply.id.noteId}"
             val toReplyNote = resolverRepository.resolve(account.accountId, url)
                 .getOrThrow() as ApResolver.TypeNote
             noteEditingState.copy(replyId = toReplyNote.note.id)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
@@ -93,7 +93,7 @@ class NoteEditorViewModel @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     val maxTextLength =
         currentAccount.filterNotNull().flatMapLatest { account ->
-            metaRepository.observe(account.instanceDomain).filterNotNull().map { meta ->
+            metaRepository.observe(account.normalizedInstanceDomain).filterNotNull().map { meta ->
                 meta.maxNoteTextLength ?: 1500
             }
         }.stateIn(
@@ -104,7 +104,7 @@ class NoteEditorViewModel @Inject constructor(
 
 
     val maxFileCount = currentAccount.filterNotNull().mapNotNull {
-        metaRepository.get(it.instanceDomain)?.getVersion()
+        metaRepository.get(it.normalizedInstanceDomain)?.getVersion()
     }.map {
         if (it >= Version("12.100.2")) {
             16

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/emojis/CustomEmojiPickerDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/emojis/CustomEmojiPickerDialog.kt
@@ -61,7 +61,7 @@ class CustomEmojiPickerDialog : BottomSheetDialogFragment(){
             Log.d("PickerDialog", "アダプターをセットアップしました")
 
             accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
-                metaRepository.observe(it.instanceDomain)
+                metaRepository.observe(it.normalizedInstanceDomain)
             }.map {
                 it?.emojis?: emptyList()
             }.onEach {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialog.kt
@@ -68,7 +68,7 @@ class NoteOptionDialog : BottomSheetDialogFragment() {
                             }
                         },
                         onShareButtonClicked = {
-                            val baseUrl = uiState.currentAccount?.instanceDomain
+                            val baseUrl = uiState.currentAccount?.normalizedInstanceDomain
                             val url = "$baseUrl/notes/${it?.id?.noteId}"
                             val intent = Intent().apply {
                                 action = ACTION_SEND
@@ -104,7 +104,7 @@ class NoteOptionDialog : BottomSheetDialogFragment() {
                             dismiss()
                         },
                         onReportButtonClicked ={
-                            val baseUrl = uiState.currentAccount?.instanceDomain
+                            val baseUrl = uiState.currentAccount?.normalizedInstanceDomain
                             val report = it?.toReport(baseUrl!!)
                             notesViewModel.confirmReportEvent.event = report
                             dismiss()

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionViewModel.kt
@@ -90,7 +90,7 @@ class NoteOptionViewModel @Inject constructor(
     private suspend fun loadNoteState(id: Note.Id): Result<NoteState> = runCatching {
         withContext(Dispatchers.IO) {
             val account = accountRepository.get(id.accountId).getOrThrow()
-            misskeyAPIProvider.get(account.instanceDomain).noteState(
+            misskeyAPIProvider.get(account.normalizedInstanceDomain).noteState(
                 NoteRequest(
                     i = account.token,
                     noteId = id.noteId

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
@@ -40,7 +40,7 @@ object NoteReactionViewHelper {
         val cache = entryPoint.metaRepository()
 
         val textReaction = LegacyReaction.reactionMap[reaction] ?: reaction
-        val metaEmojis = cache.get(note.account.instanceDomain)?.emojis ?: emptyList()
+        val metaEmojis = cache.get(note.account.normalizedInstanceDomain)?.emojis ?: emptyList()
         val emoji = note.emojiMap[textReaction.replace(":", "")] ?: metaEmojis.firstOrNull {
             textReaction.replace(":", "") == it.name
         }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/picker/ReactionPickerDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/picker/ReactionPickerDialog.kt
@@ -20,9 +20,9 @@ import kotlinx.coroutines.launch
 import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.common_android_ui.reaction.ReactionAutoCompleteArrayAdapter
 import net.pantasystem.milktea.common_android_ui.reaction.ReactionChoicesAdapter
+import net.pantasystem.milktea.data.infrastructure.notes.reaction.impl.usercustom.ReactionUserSettingDao
 import net.pantasystem.milktea.model.instance.MetaRepository
 import net.pantasystem.milktea.model.notes.Note
-import net.pantasystem.milktea.data.infrastructure.notes.reaction.impl.usercustom.ReactionUserSettingDao
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.DialogReactionPickerBinding
 import net.pantasystem.milktea.note.viewmodel.NotesViewModel
@@ -89,7 +89,7 @@ class ReactionPickerDialog : AppCompatDialogFragment(){
         }
 
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
-            metaRepository.observe(it.instanceDomain)
+            metaRepository.observe(it.normalizedInstanceDomain)
         }.mapNotNull {
             it?.emojis
         }.onEach { emojis ->

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/picker/ReactionPickerDialogViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/picker/ReactionPickerDialogViewModel.kt
@@ -7,10 +7,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import net.pantasystem.milktea.data.infrastructure.notes.reaction.impl.usercustom.ReactionUserSettingDao
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.notes.reaction.LegacyReaction
-import net.pantasystem.milktea.data.infrastructure.notes.reaction.impl.usercustom.ReactionUserSettingDao
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,7 +22,7 @@ class ReactionPickerDialogViewModel @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val userConfigReactions = _currentAccount.filterNotNull().flatMapLatest { ac ->
-        reactionUserSettingDao.observeByInstanceDomain(ac.instanceDomain).map { list ->
+        reactionUserSettingDao.observeByInstanceDomain(ac.normalizedInstanceDomain).map { list ->
             list.sortedBy {
                 it.weight
             }.map {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/ReactionChoicesViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/ReactionChoicesViewModel.kt
@@ -33,12 +33,12 @@ class ReactionChoicesViewModel @Inject constructor(
     }.flowOn(Dispatchers.IO)
     @OptIn(ExperimentalCoroutinesApi::class)
     private val reactionCount = accountStore.observeCurrentAccount.filterNotNull().flatMapLatest { ac ->
-        reactionHistoryDao.observeSumReactions(ac.instanceDomain)
+        reactionHistoryDao.observeSumReactions(ac.normalizedInstanceDomain)
     }.flowOn(Dispatchers.IO)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val userSetting = accountStore.observeCurrentAccount.filterNotNull().flatMapLatest { ac ->
-        reactionUserSettingDao.observeByInstanceDomain(ac.instanceDomain)
+        reactionUserSettingDao.observeByInstanceDomain(ac.normalizedInstanceDomain)
     }
 
     // 検索時の候補

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/ReactionChoicesViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/ReactionChoicesViewModel.kt
@@ -29,7 +29,7 @@ class ReactionChoicesViewModel @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val meta = accountStore.observeCurrentAccount.filterNotNull().flatMapLatest { ac ->
-        metaRepository.observe(ac.instanceDomain)
+        metaRepository.observe(ac.normalizedInstanceDomain)
     }.flowOn(Dispatchers.IO)
     @OptIn(ExperimentalCoroutinesApi::class)
     private val reactionCount = accountStore.observeCurrentAccount.filterNotNull().flatMapLatest { ac ->

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/ReactionSelectionDialogViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/ReactionSelectionDialogViewModel.kt
@@ -26,7 +26,7 @@ class ReactionSelectionDialogViewModel @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val filteredEmojis = accountStore.observeCurrentAccount.filterNotNull().flatMapLatest { ac ->
-        metaRepository.observe(ac.instanceDomain)
+        metaRepository.observe(ac.normalizedInstanceDomain)
     }.filterNotNull().mapNotNull {
         it.emojis
     }.flatMapLatest { emojis ->
@@ -50,7 +50,7 @@ class ReactionSelectionDialogViewModel @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val categories = accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
-        metaRepository.observe(it.instanceDomain)
+        metaRepository.observe(it.normalizedInstanceDomain)
     }.mapNotNull {
         it?.emojis
     }.map { emojis ->

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/RemoteReactionEmojiSuggestionViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/RemoteReactionEmojiSuggestionViewModel.kt
@@ -49,7 +49,7 @@ class RemoteReactionEmojiSuggestionViewModel @Inject constructor(
         } else {
             suspend {
                 val account = accountRepository.get(remoteReaction.currentAccountId).getOrThrow()
-                metaRepository.find(account.instanceDomain).getOrThrow().emojis?.filter {
+                metaRepository.find(account.normalizedInstanceDomain).getOrThrow().emojis?.filter {
                     it.name == name
                 }
             }.asLoadingStateFlow()

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/viewmodel/NotificationViewModel.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/viewmodel/NotificationViewModel.kt
@@ -125,7 +125,7 @@ class NotificationViewModel @Inject constructor(
             logger.debug("in launch")
             val account = accountRepository.getCurrentAccount().getOrThrow()
             val request = NotificationRequest(i = account.token, limit = 20)
-            val misskeyAPI = misskeyAPIProvider.get(account.instanceDomain)
+            val misskeyAPI = misskeyAPIProvider.get(account.normalizedInstanceDomain)
 
             runCatching {
                 val notificationDTOList = misskeyAPI.notification(request).throwIfHasError().body()
@@ -165,7 +165,7 @@ class NotificationViewModel @Inject constructor(
 
         viewModelScope.launch(Dispatchers.IO) {
             val account = accountRepository.getCurrentAccount().getOrThrow()
-            val misskeyAPI = misskeyAPIProvider.get(account.instanceDomain)
+            val misskeyAPI = misskeyAPIProvider.get(account.normalizedInstanceDomain)
 
             val request = NotificationRequest(
                 i = account.token,

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ReactionSettingActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ReactionSettingActivity.kt
@@ -85,7 +85,7 @@ class ReactionSettingActivity : AppCompatActivity() {
 
 
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
-            metaRepository.observe(it.instanceDomain)
+            metaRepository.observe(it.normalizedInstanceDomain)
         }.distinctUntilChanged().mapNotNull {
             it?.emojis
         }.onEach { emojis ->

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/ImportReactionFromWebViewViewModel.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/ImportReactionFromWebViewViewModel.kt
@@ -12,9 +12,9 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.common.Logger
-import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.data.infrastructure.notes.reaction.impl.usercustom.ReactionUserSetting
 import net.pantasystem.milktea.data.infrastructure.notes.reaction.impl.usercustom.ReactionUserSettingDao
+import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.setting.WebClientBaseCache
 import javax.inject.Inject
 
@@ -50,11 +50,11 @@ class ImportReactionFromWebViewViewModel @Inject constructor(
             try {
 
                 val account = accountRepository.getCurrentAccount().getOrThrow()
-                reactionUserSettingDao.deleteAll(reactionUserSettingDao.findByInstanceDomain(account.instanceDomain) ?: emptyList())
+                reactionUserSettingDao.deleteAll(reactionUserSettingDao.findByInstanceDomain(account.normalizedInstanceDomain) ?: emptyList())
                 val settings = reactions.value.mapIndexed { i, reaction ->
                     ReactionUserSetting(
                         reaction,
-                        account.instanceDomain,
+                        account.normalizedInstanceDomain,
                         i
                     )
                 }

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/reaction/ReactionPickerSettingViewModel.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/reaction/ReactionPickerSettingViewModel.kt
@@ -50,7 +50,7 @@ class ReactionPickerSettingViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val rawSettings = reactionUserSettingDao
-                    .findByInstanceDomain(account.instanceDomain)
+                    .findByInstanceDomain(account.normalizedInstanceDomain)
                 mExistingSettingList = rawSettings ?: emptyList()
                 var settingReactions = rawSettings
                     ?: LegacyReaction.defaultReaction.mapIndexed { index, str ->
@@ -117,7 +117,7 @@ class ReactionPickerSettingViewModel @Inject constructor(
         mReactionSettingReactionNameMap[reaction] =
             ReactionUserSetting(
                 reaction,
-                account.instanceDomain,
+                account.normalizedInstanceDomain,
                 mReactionSettingReactionNameMap.size
             )
         reactionSettingsList.postValue(mReactionSettingReactionNameMap.values.toList())
@@ -143,7 +143,7 @@ class ReactionPickerSettingViewModel @Inject constructor(
     ): ReactionUserSetting {
         return ReactionUserSetting(
             reaction,
-            account.instanceDomain,
+            account.normalizedInstanceDomain,
             index
         )
     }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
@@ -132,7 +132,7 @@ class UserDetailViewModel @AssistedInject constructor(
     val tabTypes = combine(
         accountStore.observeCurrentAccount.filterNotNull(), userState.filterNotNull()
     ) { account, user ->
-        val api = misskeyAPIProvider.get(account.instanceDomain)
+        val api = misskeyAPIProvider.get(account.normalizedInstanceDomain)
         val isEnableGallery = api is MisskeyAPIV1275
         val isPublicReaction =
             api is MisskeyAPIV12 && (user.isPublicReactions || user.id == User.Id(

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/Account.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/Account.kt
@@ -38,8 +38,10 @@ data class Account(
     val normalizedInstanceDomain: String by lazy {
         val url = URL(instanceDomain)
         var str = "${url.protocol}://${url.host}"
-        if (url.port != 80 || url.port != 443) {
-            str += ":${url.port}"
+        if (url.port != -1) {
+            if (url.port != 80 || url.port != 443) {
+                str += ":${url.port}"
+            }
         }
         str
     }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/Account.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/Account.kt
@@ -3,6 +3,7 @@ package net.pantasystem.milktea.model.account
 
 import net.pantasystem.milktea.model.account.page.Page
 import java.io.Serializable
+import java.net.URL
 
 data class Account(
     val remoteId: String,
@@ -34,13 +35,21 @@ data class Account(
                 instanceType
             )
 
-
+    val normalizedInstanceDomain: String by lazy {
+        val url = URL(instanceDomain)
+        var str = "${url.protocol}://${url.host}"
+        if (url.port != 80 || url.port != 443) {
+            str += ":${url.port}"
+        }
+        str
+    }
 
     fun getHost(): String {
         if (instanceDomain.startsWith("https://")) {
-            return instanceDomain.substring("https://".length, instanceDomain.length)
+            return URL(instanceDomain).host
+
         } else if (instanceDomain.startsWith("http://")) {
-            return instanceDomain.substring("http://".length, instanceDomain.length)
+            return URL(instanceDomain).host
         }
         return instanceDomain
     }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/reaction/ToggleReactionUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/reaction/ToggleReactionUseCase.kt
@@ -31,7 +31,7 @@ class ToggleReactionUseCase @Inject constructor(
             val sendReaction =
                 if (
                     checkEmoji.checkEmoji(reaction)
-                    || metaRepository.find(account.instanceDomain).getOrThrow()
+                    || metaRepository.find(account.normalizedInstanceDomain).getOrThrow()
                         .isOwnEmojiBy(reactionObj)
                     || LegacyReaction.reactionMap.containsKey(reaction)
                 ) {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/reaction/ToggleReactionUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/reaction/ToggleReactionUseCase.kt
@@ -42,12 +42,12 @@ class ToggleReactionUseCase @Inject constructor(
             val note = noteRepository.find(noteId).getOrThrow()
             if (note.myReaction.isNullOrBlank()) {
                 if (noteRepository.reaction(CreateReaction(noteId, sendReaction)).getOrThrow()) {
-                    reactionHistoryRepository.create(ReactionHistory(sendReaction, account.instanceDomain))
+                    reactionHistoryRepository.create(ReactionHistory(sendReaction, account.normalizedInstanceDomain))
                 }
             } else if (note.myReaction != sendReaction) {
                 noteRepository.unreaction(noteId).getOrThrow()
                 if (noteRepository.reaction(CreateReaction(noteId, sendReaction)).getOrThrow()) {
-                    reactionHistoryRepository.create(ReactionHistory(sendReaction, account.instanceDomain))
+                    reactionHistoryRepository.create(ReactionHistory(sendReaction, account.normalizedInstanceDomain))
                 }
             } else {
                 noteRepository.unreaction(noteId).getOrThrow()

--- a/modules/model/src/test/java/net/pantasystem/milktea/model/account/AccountTest.kt
+++ b/modules/model/src/test/java/net/pantasystem/milktea/model/account/AccountTest.kt
@@ -1,0 +1,19 @@
+package net.pantasystem.milktea.model.account
+
+import org.junit.Assert
+import org.junit.Test
+
+class AccountTest {
+
+    @Test
+    fun getNormalizedInstanceDomain() {
+        val account = Account(
+            remoteId = "abc",
+            instanceDomain = "https://misskey.pantasystem.com",
+            instanceType = Account.InstanceType.MISSKEY,
+            token = "test",
+            userName = "Panta"
+        )
+        Assert.assertEquals("https://misskey.pantasystem.com", account.normalizedInstanceDomain)
+    }
+}

--- a/modules/model/src/test/java/net/pantasystem/milktea/model/notes/reaction/ToggleReactionUseCaseTest.kt
+++ b/modules/model/src/test/java/net/pantasystem/milktea/model/notes/reaction/ToggleReactionUseCaseTest.kt
@@ -45,7 +45,7 @@ class ToggleReactionUseCaseTest {
         val reactionHistoryDao = mock<ReactionHistoryRepository>()
         val account = Account(
             "testId",
-            "misskey.io",
+            "https://misskey.io",
             instanceType = Account.InstanceType.MISSKEY,
             token = "test",
             userName = "test",
@@ -59,7 +59,7 @@ class ToggleReactionUseCaseTest {
         }
         val fetchMeta = mock<MetaRepository> {
             onBlocking {
-                find(account.instanceDomain)
+                find(account.normalizedInstanceDomain)
             } doReturn Result.success(meta)
         }
 
@@ -107,7 +107,7 @@ class ToggleReactionUseCaseTest {
         }
 
         val meta = Meta(
-            uri = "misskey.io",
+            uri = "https://misskey.io",
             emojis = listOf(
                 Emoji(name = "kawaii"), Emoji(name = "wakaranai")
             )
@@ -115,7 +115,7 @@ class ToggleReactionUseCaseTest {
         val reactionHistoryDao = mock<ReactionHistoryRepository>()
         val account = Account(
             "testId",
-            "misskey.io",
+            "https://misskey.io",
             instanceType = Account.InstanceType.MISSKEY,
             token = "test",
             userName = "test",
@@ -129,7 +129,7 @@ class ToggleReactionUseCaseTest {
         }
         val fetchMeta = mock<MetaRepository> {
             onBlocking {
-                find(account.instanceDomain)
+                find(account.normalizedInstanceDomain)
             } doReturn Result.success(meta)
         }
 
@@ -156,7 +156,7 @@ class ToggleReactionUseCaseTest {
         }
 
         verifyBlocking(reactionHistoryDao) {
-            create(ReactionHistory(":wakaranai:", "misskey.io"))
+            create(ReactionHistory(":wakaranai:", "https://misskey.io"))
         }
     }
 
@@ -181,7 +181,7 @@ class ToggleReactionUseCaseTest {
         }
 
         val meta = Meta(
-            uri = "misskey.io",
+            uri = "https://misskey.io",
             emojis = listOf(
                 Emoji(name = "kawaii")
             )
@@ -189,7 +189,7 @@ class ToggleReactionUseCaseTest {
         val reactionHistoryDao = mock<ReactionHistoryRepository>()
         val account = Account(
             "testId",
-            "misskey.io",
+            "https://misskey.io",
             instanceType = Account.InstanceType.MISSKEY,
             token = "test",
             userName = "test",
@@ -203,7 +203,7 @@ class ToggleReactionUseCaseTest {
         }
         val fetchMeta = mock<MetaRepository> {
             onBlocking {
-                find(account.instanceDomain)
+                find(account.normalizedInstanceDomain)
             } doReturn Result.success(meta)
         }
         val checkEmoji = mock<CheckEmoji> {
@@ -227,7 +227,7 @@ class ToggleReactionUseCaseTest {
         }
 
         verifyBlocking(reactionHistoryDao) {
-            create(ReactionHistory(":kawaii:", "misskey.io"))
+            create(ReactionHistory(":kawaii:", "https://misskey.io"))
         }
     }
 
@@ -248,11 +248,11 @@ class ToggleReactionUseCaseTest {
             } doReturn targetNote
         }
 
-        val meta = Meta(uri = "misskey.io",)
+        val meta = Meta(uri = "https://misskey.io",)
         val reactionHistoryDao = mock<ReactionHistoryRepository>()
         val account = Account(
             "testId",
-            "misskey.io",
+            "https://misskey.io",
             instanceType = Account.InstanceType.MISSKEY,
             token = "test",
             userName = "test",
@@ -266,7 +266,7 @@ class ToggleReactionUseCaseTest {
         }
         val fetchMeta = mock<MetaRepository> {
             onBlocking {
-                find(account.instanceDomain)
+                find(account.normalizedInstanceDomain)
             } doReturn Result.success(meta)
         }
         val useCase = ToggleReactionUseCase(
@@ -289,7 +289,7 @@ class ToggleReactionUseCaseTest {
         }
 
         verifyBlocking(reactionHistoryDao) {
-            create(ReactionHistory("👍", "misskey.io"))
+            create(ReactionHistory("👍", "https://misskey.io"))
         }
     }
     @Test
@@ -309,11 +309,11 @@ class ToggleReactionUseCaseTest {
             } doReturn targetNote
         }
 
-        val meta = Meta(uri = "misskey.io",)
+        val meta = Meta(uri = "https://misskey.io",)
         val reactionHistoryDao = mock<ReactionHistoryRepository>()
         val account = Account(
             "testId",
-            "misskey.io",
+            "https://misskey.io",
             instanceType = Account.InstanceType.MISSKEY,
             token = "test",
             userName = "test",
@@ -327,7 +327,7 @@ class ToggleReactionUseCaseTest {
         }
         val fetchMeta = mock<MetaRepository> {
             onBlocking {
-                find(account.instanceDomain)
+                find(account.normalizedInstanceDomain)
             } doReturn Result.success(meta)
         }
         val useCase = ToggleReactionUseCase(
@@ -350,7 +350,7 @@ class ToggleReactionUseCaseTest {
         }
 
         verifyBlocking(reactionHistoryDao) {
-            create(ReactionHistory("🥺", "misskey.io"))
+            create(ReactionHistory("🥺", "https://misskey.io"))
         }
     }
 
@@ -371,11 +371,11 @@ class ToggleReactionUseCaseTest {
             } doReturn targetNote
         }
 
-        val meta = Meta(uri = "misskey.io",)
+        val meta = Meta(uri = "https://misskey.io",)
         val reactionHistoryDao = mock<ReactionHistoryRepository>()
         val account = Account(
             "testId",
-            "misskey.io",
+            "https://misskey.io",
             instanceType = Account.InstanceType.MISSKEY,
             token = "test",
             userName = "test",
@@ -389,7 +389,7 @@ class ToggleReactionUseCaseTest {
         }
         val fetchMeta = mock<MetaRepository> {
             onBlocking {
-                find(account.instanceDomain)
+                find(account.normalizedInstanceDomain)
             } doReturn Result.success(meta)
         }
         val useCase = ToggleReactionUseCase(
@@ -412,7 +412,7 @@ class ToggleReactionUseCaseTest {
         }
 
         verifyBlocking(reactionHistoryDao) {
-            create(ReactionHistory("like", "misskey.io"))
+            create(ReactionHistory("like", "https://misskey.io"))
         }
     }
 }

--- a/modules/worker/src/main/java/net/pantasystem/milktea/worker/meta/SyncMetaWorker.kt
+++ b/modules/worker/src/main/java/net/pantasystem/milktea/worker/meta/SyncMetaWorker.kt
@@ -34,7 +34,7 @@ class SyncMetaWorker @AssistedInject constructor(
             coroutineScope {
                 accounts.map {
                     async {
-                        metaRepository.sync(it.instanceDomain)
+                        metaRepository.sync(it.normalizedInstanceDomain)
                     }
                 }.awaitAll()
             }.forEach {


### PR DESCRIPTION
## やったこと
Accountテーブルに記録したインスタンスのURLの表記揺れ問題を修正しました。
また記録したDB上のURLをそのまま使うのではなく正しい形式にフォーマットした
URLを共通して利用するようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1084 


