### PR TITLE
メンションのホスト部が勝手に消えてしまう問題を修正しました

### DIFF
--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
@@ -503,13 +503,34 @@ object MFMParser {
         }
     }
 
+    /**
+     * メンションのホスト部を投稿者とアカウントのホストに合わせて正しいホスト部の文字列を返す観数
+     * @param hostInMentionText Nullまたはから文字、または先頭の文字が@で始まる2文字以上のアットマーク+ホスト部で構成されます
+     * @Param accountHost 現在ログインしているアカウントが所属するインスタンスのホスト
+     * @param userHost その投稿の投稿主が所属するインスタンスのホスト
+     */
     internal fun getMentionHost(hostInMentionText: String?, accountHost: String?, userHost: String?): String {
         if (accountHost == null) {
             return ""
         }
+
+        // メンションのアットマーク部分を取り除く
+        val sendTo = hostInMentionText?.let {
+            if (it.startsWith("@") && it.length > 1) {
+                it.substring(1, it.length)
+            } else {
+                it
+            }
+        }
+
         // NOTE: 投稿主とアカウントの所有者が同一のホスト(インスタンス)である時
         if (userHost == accountHost) {
-            return ""
+            // メンションの送信先インスタンスと、アカウントのインスタンスが同じの場合は空にする
+            return if (sendTo == accountHost) {
+                ""
+            } else {
+                hostInMentionText ?: ""
+            }
         }
 
         // NOTE: 投稿先ユーザーのインスタンスとと現在のアカウントのインスタンスが異なり、

--- a/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
+++ b/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
@@ -73,4 +73,13 @@ class MFMParserTest {
         Assert.assertEquals("@pokemon.mastportal.info", matcher.group(2))
     }
 
+    @Test
+    fun getMentionHost_OtherHost() {
+        val host = MFMParser.getMentionHost(
+            hostInMentionText = "@misskey.pantasystem.com",
+            accountHost = "misskey.io",
+            userHost = "misskey.io"
+        )
+        Assert.assertEquals("@misskey.pantasystem.com", host)
+    }
 }

--- a/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
+++ b/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
@@ -74,7 +74,7 @@ class MFMParserTest {
     }
 
     @Test
-    fun getMentionHost_OtherHost() {
+    fun getMentionHost_GiveSameUserAndAccountHostInMentionHostOtherInstance() {
         val host = MFMParser.getMentionHost(
             hostInMentionText = "@misskey.pantasystem.com",
             accountHost = "misskey.io",


### PR DESCRIPTION
## やったこと
投稿者と現在のアカウントのインスタンスが同一で
投稿者が他インスタンスにメンションした時に
勝手にホスト部が消えてしまう問題を修正しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号


