### PR TITLE
スレッドのミュート機能を実装しました

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
@@ -138,7 +138,7 @@ interface MisskeyAPI {
     suspend fun searchNote(@Body noteRequest: NoteRequest): Response<List<NoteDTO>?>
 
     @POST("api/notes/state")
-    suspend fun noteState(@Body noteRequest: NoteRequest): Response<NoteState>
+    suspend fun noteState(@Body noteRequest: NoteRequest): Response<NoteStateResponse>
 
     @POST("api/notes/show")
     suspend fun showNote(@Body requestNote: NoteRequest): Response<NoteDTO>

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
@@ -15,6 +15,7 @@ import net.pantasystem.milktea.api.misskey.messaging.RequestMessage
 import net.pantasystem.milktea.api.misskey.notes.*
 import net.pantasystem.milktea.api.misskey.notes.favorite.CreateFavorite
 import net.pantasystem.milktea.api.misskey.notes.favorite.DeleteFavorite
+import net.pantasystem.milktea.api.misskey.notes.mute.ToggleThreadMuteRequest
 import net.pantasystem.milktea.api.misskey.notes.reaction.ReactionHistoryDTO
 import net.pantasystem.milktea.api.misskey.notes.reaction.RequestReactionHistoryDTO
 import net.pantasystem.milktea.api.misskey.notes.translation.Translate
@@ -252,4 +253,10 @@ interface MisskeyAPI {
 
     @POST("api/ap/show")
     suspend fun resolve(@Body req: ApResolveRequest) : Response<ApResolveResult>
+
+    @POST("api/notes/thread-muting/create")
+    suspend fun createThreadMute(@Body req: ToggleThreadMuteRequest) : Response<Unit>
+
+    @POST("api/notes/thread-muting/delete")
+    suspend fun deleteThreadMute(@Body req: ToggleThreadMuteRequest) : Response<Unit>
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteState.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteState.kt
@@ -2,4 +2,9 @@ package net.pantasystem.milktea.api.misskey.notes
 
 import kotlinx.serialization.Serializable
 
-@Serializable data class NoteState(val isFavorited: Boolean, val isWatching: Boolean)
+@Serializable
+data class NoteState(
+    val isFavorited: Boolean,
+    val isWatching: Boolean,
+    val isMutedThread: Boolean = false
+)

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteStateResponse.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteStateResponse.kt
@@ -3,7 +3,7 @@ package net.pantasystem.milktea.api.misskey.notes
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class NoteState(
+data class NoteStateResponse(
     val isFavorited: Boolean,
     val isWatching: Boolean,
     val isMutedThread: Boolean = false

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteStateResponse.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteStateResponse.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 data class NoteStateResponse(
     val isFavorited: Boolean,
     val isWatching: Boolean,
-    val isMutedThread: Boolean = false
+    val isMutedThread: Boolean? = null,
 )

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/mute/ToggleThreadMuteRequest.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/mute/ToggleThreadMuteRequest.kt
@@ -1,0 +1,7 @@
+package net.pantasystem.milktea.api.misskey.notes.mute
+
+@kotlinx.serialization.Serializable
+data class ToggleThreadMuteRequest(
+    val i: String,
+    val noteId: String,
+)

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -403,5 +403,7 @@
     <string name="successfully_created_schedule_note">スケジュール投稿が正常に作成されました</string>
     <string name="account">アカウント</string>
     <string name="switch_account">アカウント切り替え</string>
+    <string name="mute_thread">スレッドをミュート</string>
+    <string name="unmute_thread">スレッドのミュートを解除</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -399,6 +399,8 @@
     <string name="successfully_created_schedule_note">已成功创建计划帖子</string>
     <string name="account">帐户</string>
     <string name="switch_account">切换帐号</string>
+    <string name="mute_thread">静音线程</string>
+    <string name="unmute_thread">取消静音线程</string>
 
     <!--    <string name="n_people">%d位用户</string>-->
 <!--    <string name="n_posts">%d篇帖文</string>-->

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -393,5 +393,7 @@
     <string name="is_enable_instance_ticker">Use Instance Ticker</string>
     <string name="successfully_created_schedule_note">Successfully created a schedule post</string>
     <string name="switch_account">Switch Account</string>
+    <string name="mute_thread">Mute thread</string>
+    <string name="unmute_thread">Unmute thread</string>
 
 </resources>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import net.pantasystem.milktea.api.misskey.notes.CreateReactionDTO
 import net.pantasystem.milktea.api.misskey.notes.DeleteNote
 import net.pantasystem.milktea.api.misskey.notes.NoteRequest
+import net.pantasystem.milktea.api.misskey.notes.mute.ToggleThreadMuteRequest
 import net.pantasystem.milktea.common.APIError
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common.throwIfHasError
@@ -53,7 +54,8 @@ class NoteRepositoryImpl @Inject constructor(
                 uploader.get(createNote.author)
             ) ?: throw IllegalStateException("ファイルのアップロードに失敗しました")
         }.mapCatching {
-            misskeyAPIProvider.get(createNote.author).create(it).throwIfHasError().body()?.createdNote
+            misskeyAPIProvider.get(createNote.author).create(it).throwIfHasError()
+                .body()?.createdNote
         }.onFailure {
             logger.error("create note error", it)
         }
@@ -250,7 +252,7 @@ class NoteRepositoryImpl @Inject constructor(
                 i = account.token,
                 noteId = noteId.noteId,
 
-            )
+                )
         ).throwIfHasError().body()!!
         dtoList.map {
             noteDataSourceAdder.addNoteDtoToDataSource(account, it)
@@ -261,11 +263,37 @@ class NoteRepositoryImpl @Inject constructor(
     override suspend fun sync(noteId: Note.Id): Result<Unit> = runCatching {
         withContext(Dispatchers.IO) {
             val account = getAccount.get(noteId.accountId)
-            val note = misskeyAPIProvider.get(account).showNote(NoteRequest(
-                i = account.token,
-                noteId = noteId.noteId
-            )).throwIfHasError().body()!!
+            val note = misskeyAPIProvider.get(account).showNote(
+                NoteRequest(
+                    i = account.token,
+                    noteId = noteId.noteId
+                )
+            ).throwIfHasError().body()!!
             noteDataSourceAdder.addNoteDtoToDataSource(account, note)
+        }
+    }
+
+    override suspend fun createThreadMute(noteId: Note.Id): Result<Unit> = runCatching {
+        withContext(Dispatchers.IO) {
+            val account = getAccount.get(noteId.accountId)
+            misskeyAPIProvider.get(account).createThreadMute(
+                ToggleThreadMuteRequest(
+                    i = account.token,
+                    noteId = noteId.noteId
+                )
+            ).throwIfHasError()
+        }
+    }
+
+    override suspend fun deleteThreadMute(noteId: Note.Id): Result<Unit> = runCatching {
+        withContext(Dispatchers.IO) {
+            val account = getAccount.get(noteId.accountId)
+            misskeyAPIProvider.get(account).deleteThreadMute(
+                ToggleThreadMuteRequest(
+                    i = account.token,
+                    noteId = noteId.noteId,
+                )
+            ).throwIfHasError()
         }
     }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -297,6 +297,24 @@ class NoteRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun findNoteState(noteId: Note.Id): Result<NoteState> = runCatching {
+        withContext(Dispatchers.IO) {
+            val account = getAccount.get(noteId.accountId)
+            misskeyAPIProvider.get(account.normalizedInstanceDomain).noteState(
+                NoteRequest(
+                    i = account.token,
+                    noteId = noteId.noteId
+                )
+            ).throwIfHasError().body()!!.let {
+                NoteState(
+                    isFavorited = it.isFavorited,
+                    isMutedThread = it.isMutedThread,
+                    isWatching = it.isWatching
+                )
+            }
+        }
+    }
+
     override fun observeIn(noteIds: List<Note.Id>): Flow<List<Note>> {
         return noteDataSource.observeIn(noteIds)
     }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialog.kt
@@ -108,6 +108,12 @@ class NoteOptionDialog : BottomSheetDialogFragment() {
                             val report = it?.toReport(baseUrl!!)
                             notesViewModel.confirmReportEvent.event = report
                             dismiss()
+                        },
+                        onCreateThreadMuteButtonClicked = {
+
+                        },
+                        onDeleteThreadMuteButtonClicked = {
+
                         }
                     )
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialog.kt
@@ -110,10 +110,12 @@ class NoteOptionDialog : BottomSheetDialogFragment() {
                             dismiss()
                         },
                         onCreateThreadMuteButtonClicked = {
-
+                            viewModel.createThreadMute(it)
+                            dismiss()
                         },
                         onDeleteThreadMuteButtonClicked = {
-
+                            viewModel.deleteThreadMute(it)
+                            dismiss()
                         }
                     )
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
@@ -82,7 +82,7 @@ fun NoteOptionDialogLayout(
                 )
             }
 
-            if (uiState.noteState != null && uiState.noteState.isMutedThread == null) {
+            if (uiState.noteState?.isMutedThread != null) {
                 if (uiState.noteState.isMutedThread == true) {
                     NormalBottomSheetDialogSelectionLayout(
                         onClick = {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
@@ -24,6 +24,8 @@ fun NoteOptionDialogLayout(
     onTranslateButtonClicked: (noteId: Note.Id) -> Unit,
     onDeleteFavoriteButtonClicked: (noteId: Note.Id) -> Unit,
     onCreateFavoriteButtonClicked: (noteId: Note.Id) -> Unit,
+    onCreateThreadMuteButtonClicked: (noteId: Note.Id) -> Unit,
+    onDeleteThreadMuteButtonClicked: (noteId: Note.Id) -> Unit,
     onDeleteAndEditButtonClicked: (NoteRelation?) -> Unit,
     onDeleteButtonClicked: (NoteRelation?) -> Unit,
     onReportButtonClicked: (NoteRelation?) -> Unit,
@@ -78,6 +80,29 @@ fun NoteOptionDialogLayout(
                     icon = Icons.Outlined.Star,
                     text = stringResource(id = R.string.favorite)
                 )
+            }
+
+            if (uiState.noteState?.isMutedThread == true) {
+                NormalBottomSheetDialogSelectionLayout(
+                    onClick = {
+                        onDeleteThreadMuteButtonClicked(requireNotNull(uiState.noteId))
+                    },
+                    icon = Icons.Default.VolumeMute,
+                    text = stringResource(
+                        id = R.string.unmute_thread
+                    )
+                )
+            } else {
+                NormalBottomSheetDialogSelectionLayout(
+                    onClick = {
+                        onCreateThreadMuteButtonClicked(requireNotNull(uiState.noteId))
+                    },
+                    icon = Icons.Default.VolumeMute,
+                    text = stringResource(
+                        id = R.string.mute_thread
+                    )
+                )
+
             }
 
             if (uiState.isMyNote) {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
@@ -82,27 +82,29 @@ fun NoteOptionDialogLayout(
                 )
             }
 
-            if (uiState.noteState?.isMutedThread == true) {
-                NormalBottomSheetDialogSelectionLayout(
-                    onClick = {
-                        onDeleteThreadMuteButtonClicked(requireNotNull(uiState.noteId))
-                    },
-                    icon = Icons.Default.VolumeMute,
-                    text = stringResource(
-                        id = R.string.unmute_thread
+            if (uiState.noteState != null && uiState.noteState.isMutedThread == null) {
+                if (uiState.noteState.isMutedThread == true) {
+                    NormalBottomSheetDialogSelectionLayout(
+                        onClick = {
+                            onDeleteThreadMuteButtonClicked(requireNotNull(uiState.noteId))
+                        },
+                        icon = Icons.Default.VolumeMute,
+                        text = stringResource(
+                            id = R.string.unmute_thread
+                        )
                     )
-                )
-            } else {
-                NormalBottomSheetDialogSelectionLayout(
-                    onClick = {
-                        onCreateThreadMuteButtonClicked(requireNotNull(uiState.noteId))
-                    },
-                    icon = Icons.Default.VolumeMute,
-                    text = stringResource(
-                        id = R.string.mute_thread
+                } else {
+                    NormalBottomSheetDialogSelectionLayout(
+                        onClick = {
+                            onCreateThreadMuteButtonClicked(requireNotNull(uiState.noteId))
+                        },
+                        icon = Icons.Default.VolumeMute,
+                        text = stringResource(
+                            id = R.string.mute_thread
+                        )
                     )
-                )
 
+                }
             }
 
             if (uiState.isMyNote) {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
@@ -82,8 +82,8 @@ fun NoteOptionDialogLayout(
                 )
             }
 
-            if (uiState.noteState?.isMutedThread != null) {
-                if (uiState.noteState.isMutedThread == true) {
+            if (uiState.noteState == null || uiState.noteState.isMutedThread != null) {
+                if (uiState.noteState?.isMutedThread == true) {
                     NormalBottomSheetDialogSelectionLayout(
                         onClick = {
                             onDeleteThreadMuteButtonClicked(requireNotNull(uiState.noteId))

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionViewModel.kt
@@ -29,7 +29,7 @@ class NoteOptionViewModel @Inject constructor(
     val noteRepository: NoteRepository,
     val noteRelationGetter: NoteRelationGetter,
     val loggerFactory: Logger.Factory,
-    savedStateHandle: SavedStateHandle
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     companion object {
         const val NOTE_ID = "NoteOptionViewModel.NOTE_ID"
@@ -84,6 +84,24 @@ class NoteOptionViewModel @Inject constructor(
             }.catch {
                 logger.error("sync note error", it)
             }.collect()
+        }
+    }
+
+    fun createThreadMute(noteId: Note.Id) {
+        viewModelScope.launch {
+            noteRepository.createThreadMute(noteId).onFailure {
+                logger.error("create thread mute failed", it)
+            }
+            savedStateHandle[NOTE_ID] = noteId
+        }
+    }
+
+    fun deleteThreadMute(noteId: Note.Id) {
+        viewModelScope.launch {
+            noteRepository.deleteThreadMute(noteId).onFailure {
+                logger.error("delete thread mute failed", it)
+            }
+            savedStateHandle[NOTE_ID] = noteId
         }
     }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionViewModel.kt
@@ -8,11 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import net.pantasystem.milktea.api.misskey.notes.NoteRequest
-import net.pantasystem.milktea.api.misskey.notes.NoteStateResponse
 import net.pantasystem.milktea.common.Logger
-import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
 import net.pantasystem.milktea.data.gettters.NoteRelationGetter
 import net.pantasystem.milktea.model.account.Account
@@ -20,6 +16,7 @@ import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.NoteRelation
 import net.pantasystem.milktea.model.notes.NoteRepository
+import net.pantasystem.milktea.model.notes.NoteState
 import javax.inject.Inject
 
 @HiltViewModel
@@ -42,7 +39,7 @@ class NoteOptionViewModel @Inject constructor(
     private val noteIdFlow = savedStateHandle.getStateFlow<Note.Id?>(NOTE_ID, null)
 
     private val noteState = noteIdFlow.filterNotNull().map { noteId ->
-        loadNoteState(noteId).onFailure {
+        noteRepository.findNoteState(noteId).onFailure {
             logger.error("noteState load error", it)
         }.getOrNull()
     }.stateIn(
@@ -105,23 +102,11 @@ class NoteOptionViewModel @Inject constructor(
         }
     }
 
-    private suspend fun loadNoteState(id: Note.Id): Result<NoteStateResponse> = runCatching {
-        withContext(Dispatchers.IO) {
-            val account = accountRepository.get(id.accountId).getOrThrow()
-            misskeyAPIProvider.get(account.normalizedInstanceDomain).noteState(
-                NoteRequest(
-                    i = account.token,
-                    noteId = id.noteId
-                )
-            ).throwIfHasError().body()!!
-        }
-    }
-
 }
 
 data class NoteOptionUiState(
     val noteId: Note.Id? = null,
-    val noteState: NoteStateResponse? = null,
+    val noteState: NoteState? = null,
     val note: Note? = null,
     val noteRelation: NoteRelation? = null,
     val isMyNote: Boolean = false,

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import net.pantasystem.milktea.api.misskey.notes.NoteRequest
-import net.pantasystem.milktea.api.misskey.notes.NoteState
+import net.pantasystem.milktea.api.misskey.notes.NoteStateResponse
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
@@ -105,7 +105,7 @@ class NoteOptionViewModel @Inject constructor(
         }
     }
 
-    private suspend fun loadNoteState(id: Note.Id): Result<NoteState> = runCatching {
+    private suspend fun loadNoteState(id: Note.Id): Result<NoteStateResponse> = runCatching {
         withContext(Dispatchers.IO) {
             val account = accountRepository.get(id.accountId).getOrThrow()
             misskeyAPIProvider.get(account.normalizedInstanceDomain).noteState(
@@ -121,7 +121,7 @@ class NoteOptionViewModel @Inject constructor(
 
 data class NoteOptionUiState(
     val noteId: Note.Id? = null,
-    val noteState: NoteState? = null,
+    val noteState: NoteStateResponse? = null,
     val note: Note? = null,
     val noteRelation: NoteRelation? = null,
     val isMyNote: Boolean = false,

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteRepository.kt
@@ -30,6 +30,8 @@ interface NoteRepository {
 
     suspend fun deleteThreadMute(noteId: Note.Id): Result<Unit>
 
+    suspend fun findNoteState(noteId: Note.Id): Result<NoteState>
+
     fun observeIn(noteIds: List<Note.Id>): Flow<List<Note>>
 
     fun observeOne(noteId: Note.Id): Flow<Note?>

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteRepository.kt
@@ -26,6 +26,10 @@ interface NoteRepository {
 
     suspend fun sync(noteId: Note.Id): Result<Unit>
 
+    suspend fun createThreadMute(noteId: Note.Id): Result<Unit>
+
+    suspend fun deleteThreadMute(noteId: Note.Id): Result<Unit>
+
     fun observeIn(noteIds: List<Note.Id>): Flow<List<Note>>
 
     fun observeOne(noteId: Note.Id): Flow<Note?>

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteState.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteState.kt
@@ -3,5 +3,5 @@ package net.pantasystem.milktea.model.notes
 data class NoteState(
     val isFavorited: Boolean,
     val isWatching: Boolean,
-    val isMutedThread: Boolean
+    val isMutedThread: Boolean?
 )

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteState.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteState.kt
@@ -1,0 +1,7 @@
+package net.pantasystem.milktea.model.notes
+
+data class NoteState(
+    val isFavorited: Boolean,
+    val isWatching: Boolean,
+    val isMutedThread: Boolean
+)


### PR DESCRIPTION
## やったこと
スレッドをミュート・ミュートの解除を行うためのUIとそのロジックの実装を行いました。
またそれに伴いノートの状態を取得するNoteStateに新たにスレッドのミュートの状態を取得するためのフィールドを追加しました。
v10, v11では動作しない機能です。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1103 


