### PR TITLE
カスタム絵文字が追加された時に内部のキャッシュを更新するように

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/viewmodel/MainViewModel.kt
@@ -109,7 +109,7 @@ class MainViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            accountStore.observeCurrentAccount.filterNotNull().collect(emojiEventHandler::observe)
+            accountStore.observeCurrentAccount.collect(emojiEventHandler::observe)
         }
     }
 

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/viewmodel/MainViewModel.kt
@@ -20,6 +20,7 @@ import net.pantasystem.milktea.data.gettters.NotificationRelationGetter
 import net.pantasystem.milktea.data.infrastructure.streaming.stateEvent
 import net.pantasystem.milktea.data.streaming.ChannelAPIWithAccountProvider
 import net.pantasystem.milktea.data.streaming.SocketWithAccountProvider
+import net.pantasystem.milktea.model.emoji.EmojiEventHandler
 import net.pantasystem.milktea.model.instance.MetaRepository
 import net.pantasystem.milktea.model.messaging.UnReadMessages
 import net.pantasystem.milktea.model.notification.NotificationRepository
@@ -38,6 +39,7 @@ class MainViewModel @Inject constructor(
     private val configRepository: LocalConfigRepository,
     private val metaRepository: MetaRepository,
     private val misskeyAPIProvider: MisskeyAPIProvider,
+    private val emojiEventHandler: EmojiEventHandler,
     settingStore: SettingStore
 ) : ViewModel() {
     val logger by lazy {
@@ -104,6 +106,12 @@ class MainViewModel @Inject constructor(
     ) { unc, umc->
         MainUiState(unc, umc)
     }.stateIn(viewModelScope, SharingStarted.Lazily, MainUiState())
+
+    init {
+        viewModelScope.launch {
+            accountStore.observeCurrentAccount.filterNotNull().collect(emojiEventHandler::observe)
+        }
+    }
 
     fun setCrashlyticsCollectionEnabled(enabled: Boolean) {
         viewModelScope.launch {

--- a/modules/common/src/main/java/net/pantasystem/milktea/common/errors.kt
+++ b/modules/common/src/main/java/net/pantasystem/milktea/common/errors.kt
@@ -40,7 +40,6 @@ fun<T> Response<T>.throwIfHasError(): Response<T> {
         }
     }.getOrNull()
     error.let {
-        println("throwIfHasError: endpoint:${this.raw().request.url} code:${this.code()}, errorBody:${error}, body:${body()}")
         when(this.code()) {
             400 -> throw APIError.ClientException(it)
             401 -> throw APIError.AuthenticationException(it)

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
@@ -31,7 +31,6 @@ object MFMParser {
     ): Root? {
         text ?: return null
         //println("textSize:${text.length}")
-        println("userHost:$userHost")
         val root = Root(text)
         NodeParser(
             text, root,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/SocketModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/SocketModule.kt
@@ -8,6 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import net.pantasystem.milktea.common.Logger
+import net.pantasystem.milktea.data.infrastructure.emoji.EmojiEventHandlerImpl
 import net.pantasystem.milktea.data.infrastructure.notes.NoteCaptureAPIAdapterImpl
 import net.pantasystem.milktea.data.infrastructure.notes.NoteCaptureAPIWithAccountProvider
 import net.pantasystem.milktea.data.infrastructure.notes.NoteCaptureAPIWithAccountProviderImpl
@@ -15,6 +16,7 @@ import net.pantasystem.milktea.data.streaming.ChannelAPIWithAccountProvider
 import net.pantasystem.milktea.data.streaming.SocketWithAccountProvider
 import net.pantasystem.milktea.data.streaming.impl.SocketWithAccountProviderImpl
 import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.emoji.EmojiEventHandler
 import net.pantasystem.milktea.model.notes.NoteCaptureAPIAdapter
 import net.pantasystem.milktea.model.notes.NoteDataSource
 import javax.inject.Singleton
@@ -34,6 +36,10 @@ abstract class SocketBindsModule {
     abstract fun provideNoteCaptureAPIWithAccountProvider(
         provider: NoteCaptureAPIWithAccountProviderImpl
     ) : NoteCaptureAPIWithAccountProvider
+
+    @Binds
+    @Singleton
+    abstract fun bindEmojiEventHandler(impl: EmojiEventHandlerImpl): EmojiEventHandler
 }
 
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/SocketModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/SocketModule.kt
@@ -1,4 +1,4 @@
-package jp.panta.misskeyandroidclient.di.module
+package net.pantasystem.milktea.data.di.module
 
 import dagger.Binds
 import dagger.Module

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/EmojiEventHandlerImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/EmojiEventHandlerImpl.kt
@@ -16,12 +16,14 @@ class EmojiEventHandlerImpl @Inject constructor(
 
     private var currentAccount: Account? = null
 
-    override fun observe(account: Account) {
+    override fun observe(account: Account?) {
         synchronized(this) {
             currentAccount?.let {
                 socketProvider.get(it)
             }?.removeMessageEventListener(this)
-            socketProvider.get(account.accountId)?.addMessageEventListener(this)
+            if (account != null) {
+                socketProvider.get(account.accountId)?.addMessageEventListener(this)
+            }
             currentAccount = account
 
         }
@@ -30,7 +32,9 @@ class EmojiEventHandlerImpl @Inject constructor(
     override fun onMessage(e: StreamingEvent): Boolean {
         return when(e) {
             is EmojiAdded -> {
-                executor.invoke(requireNotNull(currentAccount).normalizedInstanceDomain)
+                if (currentAccount != null) {
+                    executor.invoke(requireNotNull(currentAccount).normalizedInstanceDomain)
+                }
                 true
             }
             else -> {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/EmojiEventHandlerImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/EmojiEventHandlerImpl.kt
@@ -1,0 +1,41 @@
+package net.pantasystem.milktea.data.infrastructure.emoji
+
+import net.pantasystem.milktea.api_streaming.EmojiAdded
+import net.pantasystem.milktea.api_streaming.SocketMessageEventListener
+import net.pantasystem.milktea.api_streaming.StreamingEvent
+import net.pantasystem.milktea.data.streaming.SocketWithAccountProvider
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.emoji.EmojiEventHandler
+import net.pantasystem.milktea.model.instance.SyncMetaExecutor
+import javax.inject.Inject
+
+class EmojiEventHandlerImpl @Inject constructor(
+    private val socketProvider: SocketWithAccountProvider,
+    private val executor: SyncMetaExecutor
+) : EmojiEventHandler, SocketMessageEventListener {
+
+    private var currentAccount: Account? = null
+
+    override fun observe(account: Account) {
+        synchronized(this) {
+            currentAccount?.let {
+                socketProvider.get(it)
+            }?.removeMessageEventListener(this)
+            socketProvider.get(account.accountId)?.addMessageEventListener(this)
+            currentAccount = account
+
+        }
+    }
+
+    override fun onMessage(e: StreamingEvent): Boolean {
+        return when(e) {
+            is EmojiAdded -> {
+                executor.invoke(requireNotNull(currentAccount).normalizedInstanceDomain)
+                true
+            }
+            else -> {
+                false
+            }
+        }
+    }
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/EmojiEventHandler.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/EmojiEventHandler.kt
@@ -4,5 +4,5 @@ import net.pantasystem.milktea.model.account.Account
 
 interface EmojiEventHandler {
 
-    fun observe(account: Account)
+    fun observe(account: Account?)
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/EmojiEventHandler.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/EmojiEventHandler.kt
@@ -1,0 +1,8 @@
+package net.pantasystem.milktea.model.emoji
+
+import net.pantasystem.milktea.model.account.Account
+
+interface EmojiEventHandler {
+
+    fun observe(account: Account)
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/instance/SyncMetaExecutor.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/instance/SyncMetaExecutor.kt
@@ -1,0 +1,9 @@
+package net.pantasystem.milktea.model.instance
+
+interface SyncMetaExecutor {
+
+    operator fun invoke(instanceBaseUrl: String) {
+
+    }
+}
+

--- a/modules/worker/src/main/java/net/pantasystem/milktea/worker/di/module/ExecutorModule.kt
+++ b/modules/worker/src/main/java/net/pantasystem/milktea/worker/di/module/ExecutorModule.kt
@@ -1,0 +1,18 @@
+package net.pantasystem.milktea.worker.di.module
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import net.pantasystem.milktea.model.instance.SyncMetaExecutor
+import net.pantasystem.milktea.worker.meta.SyncMetaExecutorImpl
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+abstract class ExecutorBindModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindSyncMetaExecutor(impl: SyncMetaExecutorImpl): SyncMetaExecutor
+}

--- a/modules/worker/src/main/java/net/pantasystem/milktea/worker/meta/SpecifiedSyncMetaWorker.kt
+++ b/modules/worker/src/main/java/net/pantasystem/milktea/worker/meta/SpecifiedSyncMetaWorker.kt
@@ -1,6 +1,7 @@
 package net.pantasystem.milktea.worker.meta
 
 import android.content.Context
+import androidx.hilt.work.HiltWorker
 import androidx.work.*
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -9,6 +10,7 @@ import net.pantasystem.milktea.model.instance.MetaRepository
 import net.pantasystem.milktea.model.instance.SyncMetaExecutor
 import javax.inject.Inject
 
+@HiltWorker
 class SpecifiedSyncMetaWorker  @AssistedInject constructor(
     @Assisted private val context: Context,
     @Assisted private val params: WorkerParameters,

--- a/modules/worker/src/main/java/net/pantasystem/milktea/worker/meta/SpecifiedSyncMetaWorker.kt
+++ b/modules/worker/src/main/java/net/pantasystem/milktea/worker/meta/SpecifiedSyncMetaWorker.kt
@@ -1,0 +1,53 @@
+package net.pantasystem.milktea.worker.meta
+
+import android.content.Context
+import androidx.work.*
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.qualifiers.ApplicationContext
+import net.pantasystem.milktea.model.instance.MetaRepository
+import net.pantasystem.milktea.model.instance.SyncMetaExecutor
+import javax.inject.Inject
+
+class SpecifiedSyncMetaWorker  @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted private val params: WorkerParameters,
+    private val metaRepository: MetaRepository,
+): CoroutineWorker(context, params) {
+
+    companion object {
+        const val EXTRA_INSTANCE_BASE_URL = "EXTRA_INSTANCE_BASE_URL"
+        fun createOneTimeWorkRequest(instanceBaseUrl: String): OneTimeWorkRequest {
+            return OneTimeWorkRequestBuilder<SpecifiedSyncMetaWorker>()
+                .setInputData(
+                    workDataOf(
+                        EXTRA_INSTANCE_BASE_URL to instanceBaseUrl
+                    )
+                )
+                .build()
+        }
+    }
+    override suspend fun doWork(): Result {
+        return metaRepository.sync(
+            requireNotNull(params.inputData.getString(EXTRA_INSTANCE_BASE_URL))
+        ).fold(
+            onSuccess = {
+                Result.success()
+            },
+            onFailure = {
+                Result.failure()
+            }
+        )
+    }
+}
+
+class SyncMetaExecutorImpl @Inject constructor(
+    @ApplicationContext val context: Context
+) : SyncMetaExecutor {
+    override fun invoke(instanceBaseUrl: String) {
+        WorkManager.getInstance(context).enqueue(
+            SpecifiedSyncMetaWorker.createOneTimeWorkRequest(instanceBaseUrl)
+        )
+
+    }
+}


### PR DESCRIPTION
## やったこと
Streaming API経由でカスタム絵文字が追加されたことを表すイベントが来た時に、
Metaのキャッシュを更新するようにして、追加されたカスタム絵文字がキャッシュ上に反映されるようにしました。
またMetaのキャッシュを更新するために、指定したインスタンスのMetaを取得して更新するためのWorkerを新たに作成しました。
## 動作確認
エミュレーターで動作確認済み

## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1022


