### PR TITLE
インスタンス情報を送信するようにv13対応

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/MiApplication.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/MiApplication.kt
@@ -28,6 +28,7 @@ import net.pantasystem.milktea.data.streaming.SocketWithAccountProvider
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.account.ClientIdRepository
 import net.pantasystem.milktea.model.sw.register.SubscriptionRegistration
+import net.pantasystem.milktea.worker.instance.ScheduleAuthInstancesPostWorker
 import net.pantasystem.milktea.worker.meta.SyncMetaWorker
 import net.pantasystem.milktea.worker.sw.RegisterAllSubscriptionRegistration
 import net.pantasystem.milktea.worker.user.SyncLoggedInUserInfoWorker
@@ -164,6 +165,11 @@ class MiApplication : Application(), Configuration.Provider {
                 "syncLoggedInUsers",
                 ExistingPeriodicWorkPolicy.REPLACE,
                 SyncLoggedInUserInfoWorker.createPeriodicWorkRequest(),
+            )
+            enqueueUniquePeriodicWork(
+                "scheduleAuthInstancePostWorker",
+                ExistingPeriodicWorkPolicy.REPLACE,
+                ScheduleAuthInstancesPostWorker.createPeriodicWorkRequest(),
             )
         }
 

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPIServiceBuilder.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPIServiceBuilder.kt
@@ -79,11 +79,10 @@ class MisskeyAPIServiceBuilder @Inject constructor(
                 val diff = retrofit.create(MisskeyAPIV10Diff::class.java)
                 return MisskeyAPIV10(build(baseUrl), diff)
             }
-            version.isInRange(Version.Major.V_11)
-                    || version.isInRange(Version.Major.V_12) ->{
+            version.isInRange(Version.Major.V_11) || version.isInRange(Version.Major.V_12) || version.isInRange(Version.Major.V_13) ->{
                 val baseAPI = build(baseUrl)
                 val misskeyAPIV11Diff = retrofit.create(MisskeyAPIV11Diff::class.java)
-                if(version.isInRange(Version.Major.V_12)){
+                if(version.isInRange(Version.Major.V_12) || version.isInRange(Version.Major.V_13)){
                     val misskeyAPI12DiffImpl = retrofit.create(MisskeyAPIV12Diff::class.java)
                     if(version >= Version("12.75.0")) {
                         val misskeyAPIV1275Diff = retrofit.create(MisskeyAPIV1275Diff::class.java)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/InstanceInfoRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/InstanceInfoRepositoryImpl.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+import net.pantasystem.milktea.api.milktea.CreateInstanceRequest
 import net.pantasystem.milktea.api.milktea.InstanceInfoResponse
 import net.pantasystem.milktea.api.milktea.MilkteaAPIServiceBuilder
 import net.pantasystem.milktea.common.throwIfHasError
@@ -63,6 +64,11 @@ class InstanceInfoRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun postInstance(host: String): Result<Unit> = runCatching {
+        withContext(Dispatchers.IO) {
+            milkteaAPIService.createInstance(CreateInstanceRequest(host = host)).throwIfHasError()
+        }
+    }
 
 }
 

--- a/modules/features/auth/src/main/java/net/pantasystem/milktea/auth/viewmodel/app/UIState.kt
+++ b/modules/features/auth/src/main/java/net/pantasystem/milktea/auth/viewmodel/app/UIState.kt
@@ -4,6 +4,7 @@ import net.pantasystem.milktea.api.mastodon.instance.Instance
 import net.pantasystem.milktea.common.ResultState
 import net.pantasystem.milktea.common.StateContent
 import net.pantasystem.milktea.data.infrastructure.auth.Authorization
+import net.pantasystem.milktea.model.instance.InstanceInfo
 import net.pantasystem.milktea.model.instance.Meta
 
 
@@ -69,7 +70,8 @@ data class AuthUiState(
     val stateType: Authorization,
     val waiting4ApproveState: ResultState<Authorization.Waiting4UserAuthorization> = ResultState.Fixed(
         StateContent.NotExist()),
-    val clientId: String = ""
+    val clientId: String = "",
+    val instances: List<InstanceInfo> = emptyList(),
 ) {
     val isProgress by lazy {
         metaState is ResultState.Loading || waiting4ApproveState is ResultState.Loading

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/instance/InstanceInfoRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/instance/InstanceInfoRepository.kt
@@ -14,4 +14,6 @@ interface InstanceInfoRepository {
 
     fun observeByHost(host: String): Flow<InstanceInfo?>
 
+    suspend fun postInstance(host: String): Result<Unit>
+
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/instance/Version.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/instance/Version.kt
@@ -1,7 +1,5 @@
 package net.pantasystem.milktea.model.instance
 
-import java.lang.IndexOutOfBoundsException
-
 class Version : Comparable<Version>{
 
     enum class Major{
@@ -18,6 +16,11 @@ class Version : Comparable<Version>{
         V_12{
             override fun range(version: Version): Boolean {
                 return version >= Version("12") && version < Version("13")
+            }
+        },
+        V_13 {
+            override fun range(version: Version): Boolean {
+                return version >= Version("13") && version < Version("14")
             }
         };
 

--- a/modules/worker/src/main/java/net/pantasystem/milktea/worker/instance/ScheduleAuthInstancesPostWorker.kt
+++ b/modules/worker/src/main/java/net/pantasystem/milktea/worker/instance/ScheduleAuthInstancesPostWorker.kt
@@ -1,0 +1,62 @@
+package net.pantasystem.milktea.worker.instance
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.PeriodicWorkRequest
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.instance.InstanceInfoRepository
+import net.pantasystem.milktea.model.setting.LocalConfigRepository
+import java.util.concurrent.TimeUnit
+
+@HiltWorker
+class ScheduleAuthInstancesPostWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted private val params: WorkerParameters,
+    private val accountRepository: AccountRepository,
+    private val instanceInfoRepository: InstanceInfoRepository,
+    private val configRepository: LocalConfigRepository
+) : CoroutineWorker(context, params){
+
+    companion object {
+        fun createPeriodicWorkRequest(): PeriodicWorkRequest {
+            return PeriodicWorkRequestBuilder<ScheduleAuthInstancesPostWorker>(7, TimeUnit.DAYS)
+                .build()
+        }
+    }
+    override suspend fun doWork(): Result {
+        return coroutineScope {
+            runCatching {
+                val config = configRepository.get().getOrThrow()
+                if (config.isAnalyticsCollectionEnabled.isEnabled) {
+
+                    accountRepository.findAll().map { accounts ->
+                        accounts.map {
+                            it.getHost()
+                        }.distinct()
+                    }.map { hosts ->
+                        hosts.map {
+                            async {
+                                instanceInfoRepository.postInstance(it)
+                            }
+                        }.awaitAll()
+                    }.getOrThrow()
+                }
+            }.fold(
+                onSuccess = {
+                    Result.success()
+                },
+                onFailure = {
+                    Result.failure()
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
## やったこと
情報収集を許可しているユーザーから認証しているインスタンスを
所定のサーバに定期的に送信するようにしました。
ただし送信するときはどのユーザーなのか特定できないようにインスタンスのURLのみを送信するようにしました。
v13対応を応急的に行いました。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



