### PR TITLE
再インストール時にログインできなくなる不具合を修正

### DIFF
--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/account/db/AccountRecord.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/account/db/AccountRecord.kt
@@ -2,8 +2,8 @@ package net.pantasystem.milktea.data.infrastructure.account.db
 
 import androidx.room.*
 import net.pantasystem.milktea.common.Encryption
+import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.model.account.Account
-import net.pantasystem.milktea.model.account.UnauthorizedException
 import net.pantasystem.milktea.model.account.page.Page
 import java.io.Serializable
 
@@ -47,8 +47,12 @@ data class AccountRecord(
 
     @Ignore
     fun toAccount(encryption: Encryption): Account {
-        val decryptedToken = encryption.decrypt(remoteId, encryptedToken)
-            ?: throw UnauthorizedException()
+        val decryptedToken = runCancellableCatching {
+            requireNotNull(encryption.decrypt(remoteId, encryptedToken))
+        }.getOrElse {
+            ""
+        }
+
         return Account(
             remoteId = remoteId,
             instanceDomain = instanceDomain,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/streaming/ChannelAPIWithAccountProvider.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/streaming/ChannelAPIWithAccountProvider.kt
@@ -21,10 +21,13 @@ class ChannelAPIWithAccountProvider @Inject constructor(
         mutex.withLock {
             logger.debug("ChannelAPIWithAccountProvider get accountId=${account.accountId} hash=${hashCode()}")
             var channelAPI = accountWithChannelAPI[account.accountId]
-            if (channelAPI != null) {
+            val socketAPI = socketWithAccountProvider.get(account)
+
+            // Socketのインスタンスが変わっていた場合、Tokenなどに更新があった可能性があるので再生成する
+            if (channelAPI != null && channelAPI.socket == socketAPI) {
                 return channelAPI
             }
-            channelAPI = ChannelAPI(socketWithAccountProvider.get(account), loggerFactory)
+            channelAPI = ChannelAPI(socketAPI, loggerFactory)
             require(accountWithChannelAPI.put(account.accountId, channelAPI) == null)
             return channelAPI
         }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineErrorHandler.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineErrorHandler.kt
@@ -29,6 +29,10 @@ class TimelineErrorHandler(
                 Toast.makeText(context, R.string.auth_error, Toast.LENGTH_LONG)
                     .show()
             }
+            is APIError.ForbiddenException -> {
+                Toast.makeText(context, R.string.auth_error, Toast.LENGTH_LONG)
+                    .show()
+            }
             is APIError.IAmAIException -> {
                 Toast.makeText(context, R.string.bot_error, Toast.LENGTH_LONG)
                     .show()

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -217,6 +217,7 @@ sealed interface TimelineListItem {
 
         fun isUnauthorizedError(): Boolean {
             return throwable is APIError.AuthenticationException
+                    || throwable is APIError.ForbiddenException
                     || throwable is UnauthorizedException
         }
     }


### PR DESCRIPTION
## やったこと
まず前提として再インストール時にallowBackup=trueの影響により
前のデータが残るという挙動になっています。
MilkteaではTokenをKeystoreによって暗号化しています。
再インストール時に以前のTokenをデコードできなくなってしまうため、
アカウントに関連するロジック全てでエラーが発生してしまい、アカウント追加処理すらできなくなるというものでした。
そこでTokenをDecryptした時にエラーあるいはNullが帰ってきたときは空のデータを入れるようにしました。
またタイムライン取得時に403のエラーが返ってきたときは画面に認可エラーとして表示し、
401の時と同じく再認証を促すようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号

Closed #1126

