### PR TITLE
Google Play Serviceが有効でないとクラッシュしてしまう問題を修正

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/di/module/PushSubscriptionModule.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/di/module/PushSubscriptionModule.kt
@@ -1,8 +1,10 @@
 package jp.panta.misskeyandroidclient.di.module
 
+import android.content.Context
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import jp.panta.misskeyandroidclient.BuildConfig
 import net.pantasystem.milktea.common.Logger
@@ -22,6 +24,7 @@ object PushSubscriptionModule {
     @Singleton
     @Provides
     fun provideSubscriptionRegistration(
+        @ApplicationContext context: Context,
         accountRepository: AccountRepository,
         misskeyAPIProvider: MisskeyAPIProvider,
         loggerFactory: Logger.Factory
@@ -34,12 +37,14 @@ object PushSubscriptionModule {
             auth = BuildConfig.PUSH_TO_FCM_AUTH,
             publicKey = BuildConfig.PUSH_TO_FCM_PUBLIC_KEY,
             endpointBase = BuildConfig.PUSH_TO_FCM_SERVER_BASE_URL,
+            context = context,
         )
     }
 
     @Singleton
     @Provides
     fun provideUnSubscriptionRegistration(
+        @ApplicationContext context: Context,
         accountRepository: AccountRepository,
         misskeyAPIProvider: MisskeyAPIProvider,
     ): SubscriptionUnRegistration {
@@ -50,6 +55,7 @@ object PushSubscriptionModule {
             endpointBase = BuildConfig.PUSH_TO_FCM_SERVER_BASE_URL,
             auth = BuildConfig.PUSH_TO_FCM_AUTH,
             publicKey = BuildConfig.PUSH_TO_FCM_PUBLIC_KEY,
+            context = context,
         )
     }
 }


### PR DESCRIPTION
## やったこと
FirebaseMessagingのtokenメソッドを呼び出すと
内部的にToken取得 or 作成が走ってしまい、Google Play Serviceが無効であると
そこでクラッシュしてしまうということがわかった。
そこで事前にGoogle Play Serviceが有効であるかをチェックしてtokenを取得するようにした。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号

#822

