### PR TITLE
返信先を表示するように

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewDataCache.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewDataCache.kt
@@ -8,14 +8,13 @@ import kotlinx.coroutines.plus
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import net.pantasystem.milktea.app_store.notes.NoteTranslationStore
-import net.pantasystem.milktea.model.notes.NoteRelationGetter
 import net.pantasystem.milktea.model.account.Account
-import net.pantasystem.milktea.model.notes.Note
-import net.pantasystem.milktea.model.notes.NoteCaptureAPIAdapter
-import net.pantasystem.milktea.model.notes.NoteDataSource
-import net.pantasystem.milktea.model.notes.NoteRelation
+import net.pantasystem.milktea.model.notes.*
 import net.pantasystem.milktea.model.url.UrlPreviewLoadTask
 import net.pantasystem.milktea.model.url.UrlPreviewStore
+import net.pantasystem.milktea.model.url.UrlPreviewStoreProvider
+import javax.inject.Inject
+import javax.inject.Singleton
 
 
 class PlaneNoteViewDataCache(
@@ -26,6 +25,30 @@ class PlaneNoteViewDataCache(
     private val coroutineScope: CoroutineScope,
     private val noteRelationGetter: NoteRelationGetter,
 ) {
+
+    @Singleton
+    class Factory @Inject constructor(
+        private val noteCaptureAdapter: NoteCaptureAPIAdapter,
+        private val translationStore: NoteTranslationStore,
+        private val urlPreviewStoreProvider: UrlPreviewStoreProvider,
+        private val noteRelationGetter: NoteRelationGetter,
+    ) {
+        fun create(
+            getAccount: suspend () -> Account,
+            coroutineScope: CoroutineScope,
+        ): PlaneNoteViewDataCache {
+            return PlaneNoteViewDataCache(
+                getAccount,
+                noteCaptureAdapter,
+                translationStore,
+                {
+                    urlPreviewStoreProvider.getUrlPreviewStore(it)
+                },
+                coroutineScope,
+                noteRelationGetter
+            )
+        }
+    }
 
     private val lock = Mutex()
     private val cache = mutableMapOf<Note.Id, PlaneNoteViewData>()

--- a/modules/features/note/src/main/res/layout/fragment_note_editor.xml
+++ b/modules/features/note/src/main/res/layout/fragment_note_editor.xml
@@ -52,6 +52,18 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="vertical">
+                    <FrameLayout
+                            android:id="@+id/replyToViewBase"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:visibility="@{ viewModel.replyTo == null ? View.GONE : View.VISIBLE }"
+                            >
+                        <include
+                                android:id="@+id/replyToLayout"
+                                layout="@layout/item_note_editor_reply_to_note"
+                                app:note="@{ viewModel.replyTo }"
+                                />
+                    </FrameLayout>
 
                     <androidx.constraintlayout.widget.ConstraintLayout
                             android:layout_width="match_parent"

--- a/modules/features/note/src/main/res/layout/fragment_note_editor.xml
+++ b/modules/features/note/src/main/res/layout/fragment_note_editor.xml
@@ -70,6 +70,7 @@
                             android:layout_height="wrap_content"
                             android:gravity="center_vertical"
                             android:layout_marginBottom="16dp"
+                            android:layout_marginHorizontal="16dp"
                             android:visibility="@{ viewModel.reservationPostingAt == null ? View.GONE : View.VISIBLE }">
                         <TextView
                                 android:id="@+id/reservationLabelTextView"
@@ -155,6 +156,8 @@
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toBottomOf="@+id/note_editor_toolbar"
                             android:text="@{viewModel.text}"
+                            android:minLines="6"
+                            android:background="#00000000"
                             />
 
                     <FrameLayout

--- a/modules/features/note/src/main/res/layout/item_detail_note.xml
+++ b/modules/features/note/src/main/res/layout/item_detail_note.xml
@@ -378,7 +378,7 @@
                     android:orientation="horizontal">
 
                 <ImageButton
-                        android:id="@+id/imageButton"
+                        android:id="@+id/replyButton"
                         style="?android:attr/borderlessButtonStyle"
                         android:layout_width="@dimen/note_bottom_action_icon_size"
                         android:layout_height="@dimen/note_bottom_action_icon_size"
@@ -390,7 +390,7 @@
                         app:tint="?attr/normalIconTint" />
 
                 <TextView
-                        android:id="@+id/textView3"
+                        android:id="@+id/replyCountView"
                         android:layout_width="50dp"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_vertical"
@@ -400,7 +400,7 @@
                         android:visibility='@{note.replyCount == null || note.replyCount == 0 ? View.INVISIBLE : View.VISIBLE}' />
 
                 <ImageButton
-                        android:id="@+id/imageButton2"
+                        android:id="@+id/renoteButton"
                         style="?android:attr/borderlessButtonStyle"
                         android:layout_width="@dimen/note_bottom_action_icon_size"
                         android:layout_height="@dimen/note_bottom_action_icon_size"
@@ -413,7 +413,7 @@
                         app:tint="?attr/normalIconTint" />
 
                 <TextView
-                        android:id="@+id/textView4"
+                        android:id="@+id/renoteCountView"
                         android:layout_width="50dp"
 
                         android:layout_height="wrap_content"
@@ -426,7 +426,7 @@
                         />
 
                 <ImageButton
-                        android:id="@+id/imageButton3"
+                        android:id="@+id/toggleReactionButton"
                         style="?android:attr/borderlessButtonStyle"
                         android:layout_width="@dimen/note_bottom_action_icon_size"
                         android:layout_height="@dimen/note_bottom_action_icon_size"
@@ -451,7 +451,7 @@
                         />
 
                 <ImageButton
-                        android:id="@+id/imageButton4"
+                        android:id="@+id/noteOptionButton"
                         style="?android:attr/borderlessButtonStyle"
                         android:layout_width="@dimen/note_bottom_action_icon_size"
                         android:layout_height="@dimen/note_bottom_action_icon_size"

--- a/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
+++ b/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
@@ -1,0 +1,372 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+                name="note"
+                type="net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData" />
+
+        <import type="android.view.View" />
+
+
+        <import type="net.pantasystem.milktea.note.R" />
+
+        <import type="net.pantasystem.milktea.common_android.ui.SafeUnbox" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"
+            android:paddingTop="8dp"
+
+            app:transitionDestinationNote="@{note.toShowNote.note}"
+            app:clickedView="@{elapsedTime}"
+            app:mainNameView="@{mainName}"
+            app:subNameView="@{subName}"
+            app:user="@{note.toShowNote.user}"
+
+            app:foldingNote="@{note}"
+            app:foldingButton="@{contentFoldingButton}"
+            app:cw="@{cw}"
+            app:foldingContent="@{contentMain}"
+            app:isFolding="@{note.contentFolding}">
+
+        <ImageView
+                android:id="@+id/avatarIcon"
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                app:circleIcon='@{note.avatarUrl}'
+                tools:srcCompat="@android:drawable/sym_def_app_icon"
+                android:contentDescription="@string/avataricon"
+                app:transitionDestinationUser="@{note.toShowNote.user}"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/mainName"
+                android:textStyle="bold"
+                android:textSize="15sp"
+                android:singleLine="true"
+                android:ellipsize="end"
+                app:layout_constrainedWidth="true"
+                tools:text="名前aio"
+                app:layout_constraintStart_toEndOf="@id/avatarIcon"
+                app:layout_constraintTop_toTopOf="parent"
+                android:layout_marginStart="8dp"
+                app:layout_constraintEnd_toStartOf="@id/elapsedTime"
+                app:layout_constraintHorizontal_bias="0"
+                />
+
+        <TextView
+                android:id="@+id/subName"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_toEndOf="@id/mainName"
+                android:textStyle="italic"
+                android:singleLine="true"
+                android:ellipsize="end"
+                android:textSize="15sp"
+                tools:text="ユーザー名awefawefawefawefawefawefwaefwef"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toEndOf="@id/mainName"
+                android:layout_marginStart="4dp"
+                app:layout_constraintEnd_toStartOf="@id/elapsedTime"/>
+
+        <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="15sp"
+                android:layout_toEndOf="@id/subName"
+                android:layout_marginStart="4dp"
+                android:singleLine="true"
+                android:ellipsize="end"
+                elapsedTime="@{note.toShowNote.note.createdAt}"
+                android:layout_alignParentEnd="true"
+                android:gravity="end"
+                tools:text="16分前"
+                android:id="@+id/elapsedTime"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                android:textColor="?attr/colorPrimary"
+                app:emojiCompatEnabled="false" />
+
+        <net.pantasystem.milktea.common_android.ui.AutoCollapsingLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:id="@+id/autoExpanded"
+                android:layout_toEndOf="@+id/avatarIcon"
+                android:layout_below="@+id/mainName"
+                overflowExpanded="@{note.expanded}"
+                app:expandableButton="@id/autoExpandableButton"
+                app:layout_constraintStart_toEndOf="@id/avatarIcon"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/subName"
+                targetButton="@{autoExpandableButton}"
+                onExpandedChanged="@{note::expand}"
+                >
+
+            <com.google.android.material.button.MaterialButton
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/expand"
+                    android:layout_gravity="center_horizontal|bottom"
+                    app:cornerRadius="24dp"
+                    android:id="@+id/autoExpandableButton"
+                    android:visibility="@{ note.expanded ? View.GONE : View.VISIBLE}"
+                    app:emojiCompatEnabled="false"
+
+                    />
+
+            <LinearLayout
+                    android:id="@+id/expandableBase"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_marginStart="8dp"
+
+                    >
+
+                <TextView
+                        android:id="@+id/instanceInfoLabel"
+                        tools:text="Misskey.io"
+                        android:textSize="12sp"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        tools:background="#8BC34A"
+                        rectViewById="@{4}"
+                        android:gravity="center_vertical"
+                        android:padding="2dp"
+                        instanceInfo="@{note.toShowNote.user.instance}"
+                        android:singleLine="true"
+                        />
+                <TextView
+                        android:id="@+id/cw"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        tools:text="cwcwcwwcwcw"
+                        app:textNode="@{note.cwNode}"
+                        />
+
+
+                <TextView
+                        android:id="@+id/contentFoldingButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+
+                        android:layout_marginBottom="4dp"
+                        tools:text="展開する"
+                        android:textColor="?attr/colorAccent"
+                        android:text="@string/auto_note_folding"
+                        onToggleCw="@{ note::changeContentFolding }"
+                        noteId="@{note.id}"
+                        targetView="@{contentMain}"
+                        isVisible="@{note.contentFolding}"
+                        app:emojiCompatEnabled="false"
+                        />
+
+                <LinearLayout
+                        android:id="@+id/contentMain"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                    <TextView
+                            android:id="@id/text"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textSize="15sp"
+                            app:textNode="@{note.textNode}"
+                            tools:text="aoiwefjowiaejiowajefihawoefoiawehfioawheoifawoiefioawejfowaoeifjawoiejfoaw"
+                            android:visibility='@{note.text == null ? View.GONE : View.VISIBLE}'
+
+                            />
+
+                    <include
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:id="@+id/translationView"
+                            layout="@layout/view_translation"
+                            app:emojis="@{note.toShowNote.note.emojis}"
+                            app:translationState="@{note.translateState}"
+                            android:layout_marginBottom="4dp"
+                            android:layout_marginTop="4dp" />
+
+                    <include
+                            android:id="@+id/mediaPreview"
+
+                            layout="@layout/media_preview"
+                            app:media="@{note.media}"
+                            android:layout_width="match_parent"
+                            android:layout_height="200dp"
+                            android:layout_marginTop="2dp"
+                            android:visibility="@{note.media.visibleMediaPreviewArea ? View.VISIBLE : View.GONE}"
+                            tools:visibility="visible"
+                            tools:layout_height="20dp" />
+
+                    <androidx.recyclerview.widget.RecyclerView
+                            android:id="@+id/manyFilePreviewListView"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            tools:layout_height="20dp"
+                            android:visibility="gone"
+                            mediaViewData="@{note.media}"
+                            previewAbleList="@{note.media.files}" />
+
+
+                    <androidx.recyclerview.widget.RecyclerView
+                            android:id="@+id/poll"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            tools:listitem="@layout/item_choice"
+                            tools:itemCount="2"
+                            android:visibility="@{note.poll == null ? View.GONE : View.VISIBLE}"
+
+                            noteId="@{note.toShowNote.note.id}"
+                            poll="@{note.poll}"
+                            noteCardActionListenerAdapter="@{null}"
+                            />
+
+                    <androidx.recyclerview.widget.RecyclerView
+                            android:id="@+id/url_preview_list"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            tools:itemCount="1"
+                            tools:listitem="@layout/item_url_preview"
+                            app:previewList="@{note.previews}" />
+
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:padding="8dp"
+                            android:visibility='@{note.subNote != null ? View.VISIBLE : View.GONE}'
+                            android:id="@+id/subNote"
+                            android:background="@drawable/shape_rounded_square_line"
+                            app:transitionDestinationNote="@{note.subNote.note}"
+                            app:clickedView="@{subNote}"
+                            app:subNameView="@{subNoteSubName}"
+                            app:mainNameView="@{subNoteMainName}"
+                            app:user="@{note.subNote.user}"
+                            android:layout_marginTop="4dp">
+
+                        <ImageView
+                                android:id="@+id/subAvatarIcon"
+                                android:layout_width="20dp"
+                                android:layout_height="20dp"
+                                app:circleIcon='@{note.subNoteAvatarUrl}'
+                                android:contentDescription="@string/avataricon"
+                                app:transitionDestinationUser="@{note.subNote.user}"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toTopOf="parent"/>
+
+                        <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_toEndOf="@+id/subAvatarIcon"
+                                android:id="@+id/subNoteMainName"
+                                android:textStyle="bold"
+                                android:textSize="15sp"
+                                app:layout_constraintStart_toEndOf="@id/subAvatarIcon"
+                                android:layout_marginStart="4dp"
+                                app:layout_constraintTop_toTopOf="parent"
+                                tools:text="mainName"
+                                android:singleLine="true"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintHorizontal_bias="0"
+                                app:layout_constrainedWidth="true"
+                                android:ellipsize="end"
+
+
+                                />
+
+                        <TextView
+                                android:layout_toEndOf="@id/subNoteMainName"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:textStyle="italic"
+                                android:id="@+id/subNoteSubName"
+                                android:textSize="15sp"
+                                android:singleLine="true"
+                                app:layout_constraintStart_toEndOf="@id/subNoteMainName"
+                                app:layout_constraintTop_toTopOf="parent"
+                                tools:text="subName"
+                                android:layout_marginStart="4dp"
+
+                                />
+
+                        <TextView
+                                android:id="@+id/subCw"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                tools:text="cwcwcwwcwcw"
+                                app:textNode="@{note.subCwNode}"
+                                android:layout_below="@+id/subNoteMainName"
+                                android:visibility='@{note.cw == null ? View.GONE : View.VISIBLE}'
+                                app:layout_constraintTop_toBottomOf="@id/subNoteMainName"
+                                app:layout_constraintStart_toStartOf="parent"/>
+
+
+                        <TextView
+                                android:id="@+id/subContentFoldingButton"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_below="@+id/subCw"
+                                android:layout_marginStart="5dp"
+                                android:layout_marginBottom="5dp"
+                                tools:text="展開する"
+                                android:visibility='@{note.subCw == null ? View.GONE : View.VISIBLE }'
+                                android:textColor="?attr/colorAccent"
+                                android:text="@{SafeUnbox.unboxString(note.subContentFoldingStatusMessage)}"
+                                app:layout_constraintTop_toBottomOf="@id/subCw"
+                                app:layout_constraintStart_toStartOf="parent"
+
+                                android:onClick="@{ () -> note.changeSubContentFolding() }"
+                                />
+
+                        <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_below="@+id/subContentFoldingButton"
+                                android:textSize="15sp"
+                                android:id="@+id/subNoteText"
+                                tools:text="aowjfoiwajehofijawioefjioawejfiowajeiofhawoifahwoiefwaioe"
+                                app:textNode="@{note.subNoteTextNode}"
+                                app:layout_constraintTop_toBottomOf="@id/subContentFoldingButton"
+                                app:layout_constraintStart_toStartOf="parent"
+                                android:visibility="@{ note.subContentFolding || note.subNote.note.text == null ? View.GONE : View.VISIBLE }"/>
+
+                        <include
+                                layout="@layout/media_preview"
+                                app:media="@{note.subNoteMedia}"
+                                android:id="@+id/subNoteMediaPreview"
+                                android:layout_width="match_parent"
+                                android:layout_height="200dp"
+                                android:layout_below="@id/subNoteText"
+                                android:visibility="@{note.subContentFolding || note.subNoteFiles.empty || note.subNoteMedia.isOver4Files ? View.GONE : View.VISIBLE}"
+                                tools:layout_height="20dp"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintTop_toBottomOf="@id/subNoteText"
+                                android:layout_marginTop="2dp"
+                                />
+
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+                </LinearLayout>
+
+
+            </LinearLayout>
+
+        </net.pantasystem.milktea.common_android.ui.AutoCollapsingLayout>
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -390,7 +390,7 @@
                 android:layout_width="@dimen/note_bottom_action_icon_size"
                 android:layout_height="@dimen/note_bottom_action_icon_size"
                 app:srcCompat="@drawable/ic_reply_black_24dp"
-                android:id="@+id/imageButton"
+                android:id="@+id/replyButton"
                 style="?android:attr/borderlessButtonStyle"
                 android:padding="@dimen/note_bottom_action_icon_padding_size"
                 android:scaleType="centerCrop"
@@ -401,25 +401,25 @@
                 app:layout_constraintStart_toEndOf="@id/avatarIcon"
                 app:layout_constraintTop_toBottomOf="@id/reaction_view"
                 android:layout_marginStart="8dp"
-                app:layout_constraintEnd_toStartOf="@+id/textView3"
+                app:layout_constraintEnd_toStartOf="@+id/replyCountView"
                 tools:ignore="TouchTargetSizeCheck" />
 
         <TextView
                 android:text='@{String.valueOf(SafeUnbox.unbox(note.replyCount))}'
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:id="@+id/textView3"
+                android:id="@+id/replyCountView"
                 android:layout_weight="1"
                 android:layout_gravity="center_vertical"
                 android:singleLine="true"
                 android:visibility='@{note.replyCount == null || note.replyCount == 0 ? View.INVISIBLE : View.VISIBLE}'
                 app:layout_constraintTop_toBottomOf="@id/reaction_view"
 
-                app:layout_constraintEnd_toStartOf="@+id/imageButton2"
-                app:layout_constraintStart_toEndOf="@+id/imageButton"
+                app:layout_constraintEnd_toStartOf="@+id/renoteButton"
+                app:layout_constraintStart_toEndOf="@+id/replyButton"
                 tools:text="99999999999"
-                app:layout_constraintTop_toTopOf="@id/imageButton"
-                app:layout_constraintBottom_toBottomOf="@id/imageButton"
+                app:layout_constraintTop_toTopOf="@id/replyButton"
+                app:layout_constraintBottom_toBottomOf="@id/replyButton"
                 app:emojiCompatEnabled="false"/>
 
 
@@ -427,7 +427,7 @@
                 android:layout_width="@dimen/note_bottom_action_icon_size"
                 android:layout_height="@dimen/note_bottom_action_icon_size"
                 app:srcCompat="@drawable/ic_re_note"
-                android:id="@+id/imageButton2"
+                android:id="@+id/renoteButton"
                 style="?android:attr/borderlessButtonStyle"
                 android:padding="@dimen/note_bottom_action_icon_padding_size"
                 android:scaleType="centerCrop"
@@ -436,8 +436,8 @@
                 app:clickTargetNote="@{note}"
                 app:notesViewModelForClickRenote="@{noteCardActionListener}"
                 app:layout_constraintTop_toBottomOf="@id/reaction_view"
-                app:layout_constraintEnd_toStartOf="@+id/textView4"
-                app:layout_constraintStart_toEndOf="@id/textView3"
+                app:layout_constraintEnd_toStartOf="@+id/renoteCountView"
+                app:layout_constraintStart_toEndOf="@id/replyCountView"
                 android:visibility="@{ note.canRenote ? View.VISIBLE : View.GONE }"
                 tools:ignore="TouchTargetSizeCheck" />
 
@@ -447,17 +447,17 @@
 
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:id="@+id/textView4"
+                android:id="@+id/renoteCountView"
                 android:layout_weight="1"
                 android:layout_gravity="center_vertical"
                 android:singleLine="true"
 
                 app:layout_constraintTop_toBottomOf="@id/reaction_view"
-                app:layout_constraintEnd_toStartOf="@id/imageButton3"
-                app:layout_constraintStart_toEndOf="@id/imageButton2"
+                app:layout_constraintEnd_toStartOf="@id/toggleReactionButton"
+                app:layout_constraintStart_toEndOf="@id/renoteButton"
                 tools:text="10"
-                app:layout_constraintTop_toTopOf="@id/imageButton2"
-                app:layout_constraintBottom_toBottomOf="@id/imageButton2"
+                app:layout_constraintTop_toTopOf="@id/renoteButton"
+                app:layout_constraintBottom_toBottomOf="@id/renoteButton"
                 app:emojiCompatEnabled="false"
 
                 />
@@ -467,7 +467,7 @@
                 android:layout_height="@dimen/note_bottom_action_icon_size"
                 app:isReacted="@{note.myReaction != null}"
                 tools:srcCompat="@drawable/ic_add_black_24dp"
-                android:id="@+id/imageButton3"
+                android:id="@+id/toggleReactionButton"
                 style="?android:attr/borderlessButtonStyle"
                 android:padding="@dimen/note_bottom_action_icon_padding_size"
                 android:scaleType="centerCrop"
@@ -476,8 +476,8 @@
                 app:tint="?attr/normalIconTint"
                 app:layout_constraintTop_toBottomOf="@id/reaction_view"
 
-                app:layout_constraintEnd_toStartOf="@+id/textView5"
-                app:layout_constraintStart_toEndOf="@id/textView4"
+                app:layout_constraintEnd_toStartOf="@+id/reactionCountView"
+                app:layout_constraintStart_toEndOf="@id/renoteCountView"
                 tools:ignore="TouchTargetSizeCheck" />
 
 
@@ -491,13 +491,13 @@
                 android:layout_gravity="center_vertical"
                 android:layout_weight="1"
                 app:layout_constraintTop_toBottomOf="@id/reaction_view"
-                android:id="@+id/textView5"
-                app:layout_constraintEnd_toStartOf="@+id/imageButton4"
-                app:layout_constraintStart_toEndOf="@id/imageButton3"
+                android:id="@+id/reactionCountView"
+                app:layout_constraintEnd_toStartOf="@+id/noteOptionButton"
+                app:layout_constraintStart_toEndOf="@id/toggleReactionButton"
                 android:maxLines="1"
                 tools:text="10000"
-                app:layout_constraintTop_toTopOf="@id/imageButton3"
-                app:layout_constraintBottom_toBottomOf="@id/imageButton3"
+                app:layout_constraintTop_toTopOf="@id/toggleReactionButton"
+                app:layout_constraintBottom_toBottomOf="@id/toggleReactionButton"
                 app:emojiCompatEnabled="false"
                 />
 
@@ -505,7 +505,7 @@
                 android:layout_width="@dimen/note_bottom_action_icon_size"
                 android:layout_height="@dimen/note_bottom_action_icon_size"
                 app:srcCompat="@drawable/ic_more_horiz_black_24dp"
-                android:id="@+id/imageButton4"
+                android:id="@+id/noteOptionButton"
                 style="?android:attr/borderlessButtonStyle"
                 android:padding="@dimen/note_bottom_action_icon_padding_size"
                 android:scaleType="centerCrop"


### PR DESCRIPTION
## やったこと
返信時にノートの編集画面のヘッダー部分に返信先のノートの内容を表示するようにしました。

## 動作確認


## スクリーンショット(任意)
<img src="https://user-images.githubusercontent.com/38454985/210107851-a4db27c6-2add-45ee-b52f-acbea6100d34.png" width="240" />




## 備考


## Issue番号
Closed #1110 


