### PR TITLE
ファイル名とAltを更新できるようにしました

### DIFF
--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/file/AppFileTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/file/AppFileTest.kt
@@ -10,7 +10,7 @@ class AppFileTest {
 
     @Test
     fun isAttributeSame() {
-        val file1 = AppFile.Local("test", "/test/test3", "image/jpeg", null, false, null, 0)
+        val file1 = AppFile.Local("test", "/test/test3", "image/jpeg", null, false, null, 0, null)
         val file2 = file1.copy()
         assertTrue(file1.isAttributeSame(file2))
 

--- a/modules/common_compose/build.gradle
+++ b/modules/common_compose/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation libs.android.material.material
     implementation project(path: ':modules:model')
     implementation project(path: ':modules:common')
+    implementation project(path: ':modules:common_resource')
     testImplementation libs.junit
     androidTestImplementation libs.androidx.test.ext.junit
     androidTestImplementation libs.androidx.test.espresso.core

--- a/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/drive/EditCaptionDialogLayout.kt
+++ b/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/drive/EditCaptionDialogLayout.kt
@@ -19,6 +19,7 @@ fun EditCaptionDialogLayout(
     Surface(
         shape = MaterialTheme.shapes.medium,
         color = MaterialTheme.colors.surface,
+        elevation = 24.dp
     ) {
         Column(
             modifier = Modifier.padding(16.dp)

--- a/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/drive/EditCaptionDialogLayout.kt
+++ b/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/drive/EditCaptionDialogLayout.kt
@@ -1,0 +1,51 @@
+package net.pantasystem.milktea.common_compose.drive
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import net.pantasystem.milktea.common_compose.R
+
+@Composable
+fun EditCaptionDialogLayout(
+    value: String,
+    onCancelButtonClicked: () -> Unit,
+    onTextChanged: (String) -> Unit,
+    onSaveButtonClicked: () -> Unit,
+) {
+    Surface(
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colors.surface,
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(
+                stringResource(R.string.edit_caption),
+                fontSize = 24.sp,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(
+                value = value,
+                placeholder = {
+                    Text(stringResource(R.string.input_caption))
+                },
+                onValueChange = onTextChanged
+            )
+            Row(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                TextButton(onClick = onCancelButtonClicked) {
+                    Text(stringResource(R.string.cancel))
+                }
+                TextButton(onClick = onSaveButtonClicked) {
+                    Text(stringResource(R.string.save))
+                }
+            }
+        }
+    }
+}

--- a/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/drive/EditFileNameDialogLayout.kt
+++ b/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/drive/EditFileNameDialogLayout.kt
@@ -1,0 +1,51 @@
+package net.pantasystem.milktea.common_compose.drive
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import net.pantasystem.milktea.common_compose.R
+
+@Composable
+fun EditFileNameDialogLayout(
+    value: String,
+    onTextChanged: (String) -> Unit,
+    onSaveButtonClicked: () -> Unit,
+    onCancelButtonClicked: () -> Unit,
+) {
+    Surface(
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colors.surface
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(
+                stringResource(id = R.string.edit_file_name),
+                fontSize = 24.sp,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(
+                value = value,
+                placeholder = {
+                    Text(stringResource(R.string.input_caption))
+                },
+                onValueChange = onTextChanged
+            )
+            Row(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                TextButton(onClick = onCancelButtonClicked) {
+                    Text(stringResource(id = R.string.cancel))
+                }
+                TextButton(onClick = onSaveButtonClicked) {
+                    Text(stringResource(id = R.string.save))
+                }
+            }
+        }
+    }
+}

--- a/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/drive/EditFileNameDialogLayout.kt
+++ b/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/drive/EditFileNameDialogLayout.kt
@@ -18,7 +18,8 @@ fun EditFileNameDialogLayout(
 ) {
     Surface(
         shape = MaterialTheme.shapes.medium,
-        color = MaterialTheme.colors.surface
+        color = MaterialTheme.colors.surface,
+        elevation = 24.dp
     ) {
         Column(
             modifier = Modifier.padding(16.dp)

--- a/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/horizontal_file_preview_list.kt
+++ b/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/horizontal_file_preview_list.kt
@@ -53,16 +53,6 @@ fun HorizontalFilePreviewList(
 }
 
 
-sealed interface FilePreviewActionType {
-    val target: FilePreviewSource
-
-    data class Show(override val target: FilePreviewSource) : FilePreviewActionType
-    data class Detach(override val target: FilePreviewSource) : FilePreviewActionType
-    data class ToggleSensitive(override val target: FilePreviewSource) : FilePreviewActionType
-
-    data class OnEditFileNameSelectionClicked(override val target: FilePreviewSource) : FilePreviewActionType
-    data class OnEditFileCommentSelectionClicked(override val target: FilePreviewSource) : FilePreviewActionType
-}
 
 @Composable
 fun FilePreview(

--- a/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/horizontal_file_preview_list.kt
+++ b/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/horizontal_file_preview_list.kt
@@ -29,7 +29,11 @@ fun HorizontalFilePreviewList(
     modifier: Modifier = Modifier,
     files: List<FilePreviewSource>,
     allowMaxFileSize: Long? = null,
-    onAction: (FilePreviewActionType) -> Unit,
+    onShow: (FilePreviewSource) -> Unit,
+    onDetach: (FilePreviewSource) -> Unit,
+    onToggleSensitive: (FilePreviewSource) -> Unit,
+    onEditFileCaption: ((FilePreviewSource) -> Unit)? = null,
+    onEditFileName: ((FilePreviewSource) -> Unit)? = null,
 ) {
     LazyRow(
         modifier
@@ -38,7 +42,11 @@ fun HorizontalFilePreviewList(
             FilePreview(
                 file = files[index],
                 allowMaxFileSize = allowMaxFileSize,
-                onAction = onAction
+                onShow = onShow,
+                onDetach = onDetach,
+                onToggleSensitive = onToggleSensitive,
+                onEditFileName = onEditFileName,
+                onEditFileCaption = onEditFileCaption,
             )
         }
     }
@@ -51,13 +59,20 @@ sealed interface FilePreviewActionType {
     data class Show(override val target: FilePreviewSource) : FilePreviewActionType
     data class Detach(override val target: FilePreviewSource) : FilePreviewActionType
     data class ToggleSensitive(override val target: FilePreviewSource) : FilePreviewActionType
+
+    data class OnEditFileNameSelectionClicked(override val target: FilePreviewSource) : FilePreviewActionType
+    data class OnEditFileCommentSelectionClicked(override val target: FilePreviewSource) : FilePreviewActionType
 }
 
 @Composable
 fun FilePreview(
     file: FilePreviewSource,
     allowMaxFileSize: Long?,
-    onAction: (FilePreviewActionType) -> Unit,
+    onShow: (FilePreviewSource) -> Unit,
+    onDetach: (FilePreviewSource) -> Unit,
+    onToggleSensitive: (FilePreviewSource) -> Unit,
+    onEditFileCaption: ((FilePreviewSource) -> Unit)? = null,
+    onEditFileName: ((FilePreviewSource) -> Unit)? = null,
 ) {
     var dropDownTarget: FilePreviewSource? by remember {
         mutableStateOf(null)
@@ -94,28 +109,29 @@ fun FilePreview(
                     ),
             expanded = dropDownTarget != null,
             onToggleSensitive = {
-                onAction(
-                    FilePreviewActionType.ToggleSensitive(
-                        dropDownTarget!!
-                    )
-                )
+                onToggleSensitive(dropDownTarget!!)
             },
             onDetach = {
-                onAction(
-                    FilePreviewActionType.Detach(
-                        dropDownTarget!!
-                    )
-                )
+                onDetach(dropDownTarget!!)
+
             },
             onShow = {
-                onAction(
-                    FilePreviewActionType.Show(
-                        dropDownTarget!!
-                    )
-                )
+                onShow(dropDownTarget!!)
+
             },
             onDismissRequest = {
                 dropDownTarget = null
+            },
+            onEditFileCaption = onEditFileCaption?.let{
+                {
+                    it(dropDownTarget!!)
+                }
+
+            },
+            onEditFileName = onEditFileName?.let {
+                {
+                    it(dropDownTarget!!)
+                }
             }
         )
     }
@@ -208,6 +224,8 @@ fun FilePreviewActionDropDown(
     onShow: () -> Unit,
     expanded: Boolean,
     onDismissRequest: () -> Unit,
+    onEditFileName: (() -> Unit)?,
+    onEditFileCaption: (() -> Unit)?,
 ) {
     DropdownMenu(
         expanded = expanded,
@@ -262,5 +280,26 @@ fun FilePreviewActionDropDown(
             )
         }
 
+        if (onEditFileName != null) {
+            DropdownMenuItem(onClick = {
+                onEditFileName()
+                onDismissRequest()
+            }) {
+                Icon(Icons.Filled.Edit, contentDescription = stringResource(id = R.string.edit_file_name), modifier = Modifier.size(24.dp))
+                Text(stringResource(R.string.edit_file_name))
+            }
+        }
+
+        if (onEditFileCaption != null) {
+            DropdownMenuItem(
+                onClick = {
+                    onEditFileCaption()
+                    onDismissRequest()
+                }
+            ) {
+                Icon(Icons.Filled.Comment, contentDescription = stringResource(id = R.string.edit_file_caption))
+                Text(stringResource(id = R.string.edit_file_caption))
+            }
+        }
     }
 }

--- a/modules/common_compose/src/main/res/values-ja-rJP/strings.xml
+++ b/modules/common_compose/src/main/res/values-ja-rJP/strings.xml
@@ -14,4 +14,5 @@
     <string name="minute_ago">分前</string>
     <string name="second_ago">秒前</string>
     <string name="edit_file_name">ファイル名を変更</string>
+    <string name="edit_file_caption">キャプションを編集</string>
 </resources>

--- a/modules/common_compose/src/main/res/values-ja-rJP/strings.xml
+++ b/modules/common_compose/src/main/res/values-ja-rJP/strings.xml
@@ -13,4 +13,5 @@
     <string name="hour_ago">時間前</string>
     <string name="minute_ago">分前</string>
     <string name="second_ago">秒前</string>
+    <string name="edit_file_name">ファイル名を変更</string>
 </resources>

--- a/modules/common_compose/src/main/res/values-zh/strings.xml
+++ b/modules/common_compose/src/main/res/values-zh/strings.xml
@@ -14,4 +14,5 @@
     <string name="minute_ago">分</string>
     <string name="second_ago">秒</string>
     <string name="edit_file_name">重新命名文件</string>
+    <string name="edit_file_caption">编辑标题</string>
 </resources>

--- a/modules/common_compose/src/main/res/values-zh/strings.xml
+++ b/modules/common_compose/src/main/res/values-zh/strings.xml
@@ -13,4 +13,5 @@
     <string name="hour_ago">时</string>
     <string name="minute_ago">分</string>
     <string name="second_ago">秒</string>
+    <string name="edit_file_name">重新命名文件</string>
 </resources>

--- a/modules/common_compose/src/main/res/values/strings.xml
+++ b/modules/common_compose/src/main/res/values/strings.xml
@@ -14,4 +14,5 @@
     <string name="hour_ago">HR</string>
     <string name="minute_ago">MIN</string>
     <string name="second_ago">S</string>
+    <string name="edit_file_name">Edit file name</string>
 </resources>

--- a/modules/common_compose/src/main/res/values/strings.xml
+++ b/modules/common_compose/src/main/res/values/strings.xml
@@ -14,5 +14,6 @@
     <string name="hour_ago">HR</string>
     <string name="minute_ago">MIN</string>
     <string name="second_ago">S</string>
-    <string name="edit_file_name">Edit file name</string>
+    <string name="edit_file_name">Edit name</string>
+    <string name="edit_file_caption">Edit caption</string>
 </resources>

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -406,4 +406,7 @@
     <string name="mute_thread">スレッドをミュート</string>
     <string name="unmute_thread">スレッドのミュートを解除</string>
 
+    <string name="edit_caption">キャプションを編集</string>
+    <string name="input_caption">キャプションを入力</string>
+
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -406,5 +406,7 @@
 <!--    <string name="n_posts">%d篇帖文</string>-->
 <!--    <string name="owned">拥有</string>-->
 
+    <string name="edit_caption">编辑标题</string>
+    <string name="input_caption">输入标题</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -396,4 +396,8 @@
     <string name="mute_thread">Mute thread</string>
     <string name="unmute_thread">Unmute thread</string>
 
+
+    <string name="edit_caption">Edit caption</string>
+    <string name="input_caption">Input caption</string>
+
 </resources>

--- a/modules/data/schemas/net.pantasystem.milktea.data.infrastructure.DataBase/30.json
+++ b/modules/data/schemas/net.pantasystem.milktea.data.infrastructure.DataBase/30.json
@@ -1,0 +1,3008 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 30,
+    "identityHash": "503d63cfab88a415cb200cf8184a8f46",
+    "entities": [
+      {
+        "tableName": "connection_information",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` TEXT NOT NULL, `instanceBaseUrl` TEXT NOT NULL, `encryptedI` TEXT NOT NULL, `viaName` TEXT, `createdAt` TEXT NOT NULL, `isDirect` INTEGER NOT NULL, `updatedAt` TEXT NOT NULL, PRIMARY KEY(`accountId`, `encryptedI`, `instanceBaseUrl`), FOREIGN KEY(`accountId`) REFERENCES `Account`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceBaseUrl",
+            "columnName": "instanceBaseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "encryptedI",
+            "columnName": "encryptedI",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viaName",
+            "columnName": "viaName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDirect",
+            "columnName": "isDirect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "accountId",
+            "encryptedI",
+            "instanceBaseUrl"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Account",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reaction_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`reaction` TEXT NOT NULL, `instance_domain` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "reaction",
+            "columnName": "reaction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instance_domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Account",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "reaction_user_setting",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`reaction` TEXT NOT NULL, `instance_domain` TEXT NOT NULL, `weight` INTEGER NOT NULL, PRIMARY KEY(`reaction`, `instance_domain`))",
+        "fields": [
+          {
+            "fieldPath": "reaction",
+            "columnName": "reaction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instance_domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "reaction",
+            "instance_domain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "page",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` TEXT, `title` TEXT NOT NULL, `pageNumber` INTEGER, `id` INTEGER PRIMARY KEY AUTOINCREMENT, `global_timeline_with_files` INTEGER, `global_timeline_type` TEXT, `local_timeline_with_files` INTEGER, `local_timeline_exclude_nsfw` INTEGER, `local_timeline_type` TEXT, `hybrid_timeline_withFiles` INTEGER, `hybrid_timeline_includeLocalRenotes` INTEGER, `hybrid_timeline_includeMyRenotes` INTEGER, `hybrid_timeline_includeRenotedMyRenotes` INTEGER, `hybrid_timeline_type` TEXT, `home_timeline_withFiles` INTEGER, `home_timeline_includeLocalRenotes` INTEGER, `home_timeline_includeMyRenotes` INTEGER, `home_timeline_includeRenotedMyRenotes` INTEGER, `home_timeline_type` TEXT, `user_list_timeline_listId` TEXT, `user_list_timeline_withFiles` INTEGER, `user_list_timeline_includeLocalRenotes` INTEGER, `user_list_timeline_includeMyRenotes` INTEGER, `user_list_timeline_includeRenotedMyRenotes` INTEGER, `user_list_timeline_type` TEXT, `mention_following` INTEGER, `mention_visibility` TEXT, `mention_type` TEXT, `show_noteId` TEXT, `show_type` TEXT, `tag_tag` TEXT, `tag_reply` INTEGER, `tag_renote` INTEGER, `tag_withFiles` INTEGER, `tag_poll` INTEGER, `tag_type` TEXT, `featured_offset` INTEGER, `featured_type` TEXT, `notification_following` INTEGER, `notification_markAsRead` INTEGER, `notification_type` TEXT, `user_userId` TEXT, `user_includeReplies` INTEGER, `user_includeMyRenotes` INTEGER, `user_withFiles` INTEGER, `user_type` TEXT, `search_query` TEXT, `search_host` TEXT, `search_userId` TEXT, `search_type` TEXT, `favorite_type` TEXT, `antenna_antennaId` TEXT, `antenna_type` TEXT, FOREIGN KEY(`accountId`) REFERENCES `Account`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageNumber",
+            "columnName": "pageNumber",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "globalTimeline.withFiles",
+            "columnName": "global_timeline_with_files",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "globalTimeline.type",
+            "columnName": "global_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localTimeline.withFiles",
+            "columnName": "local_timeline_with_files",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localTimeline.excludeNsfw",
+            "columnName": "local_timeline_exclude_nsfw",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localTimeline.type",
+            "columnName": "local_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.withFiles",
+            "columnName": "hybrid_timeline_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.includeLocalRenotes",
+            "columnName": "hybrid_timeline_includeLocalRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.includeMyRenotes",
+            "columnName": "hybrid_timeline_includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.includeRenotedMyRenotes",
+            "columnName": "hybrid_timeline_includeRenotedMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.type",
+            "columnName": "hybrid_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.withFiles",
+            "columnName": "home_timeline_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.includeLocalRenotes",
+            "columnName": "home_timeline_includeLocalRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.includeMyRenotes",
+            "columnName": "home_timeline_includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.includeRenotedMyRenotes",
+            "columnName": "home_timeline_includeRenotedMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.type",
+            "columnName": "home_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.listId",
+            "columnName": "user_list_timeline_listId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.withFiles",
+            "columnName": "user_list_timeline_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.includeLocalRenotes",
+            "columnName": "user_list_timeline_includeLocalRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.includeMyRenotes",
+            "columnName": "user_list_timeline_includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.includeRenotedMyRenotes",
+            "columnName": "user_list_timeline_includeRenotedMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.type",
+            "columnName": "user_list_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mention.following",
+            "columnName": "mention_following",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mention.visibility",
+            "columnName": "mention_visibility",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mention.type",
+            "columnName": "mention_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "show.noteId",
+            "columnName": "show_noteId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "show.type",
+            "columnName": "show_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.tag",
+            "columnName": "tag_tag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.reply",
+            "columnName": "tag_reply",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.renote",
+            "columnName": "tag_renote",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.withFiles",
+            "columnName": "tag_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.poll",
+            "columnName": "tag_poll",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.type",
+            "columnName": "tag_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "featured.offset",
+            "columnName": "featured_offset",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "featured.type",
+            "columnName": "featured_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notification.following",
+            "columnName": "notification_following",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notification.markAsRead",
+            "columnName": "notification_markAsRead",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notification.type",
+            "columnName": "notification_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.userId",
+            "columnName": "user_userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.includeReplies",
+            "columnName": "user_includeReplies",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.includeMyRenotes",
+            "columnName": "user_includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.withFiles",
+            "columnName": "user_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.type",
+            "columnName": "user_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "search.query",
+            "columnName": "search_query",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "search.host",
+            "columnName": "search_host",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "search.userId",
+            "columnName": "search_userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "search.type",
+            "columnName": "search_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "favorite.type",
+            "columnName": "favorite_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "antenna.antennaId",
+            "columnName": "antenna_antennaId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "antenna.type",
+            "columnName": "antenna_type",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_page_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Account",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "poll_choice_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`choice` TEXT NOT NULL, `draft_note_id` INTEGER NOT NULL, `weight` INTEGER NOT NULL, PRIMARY KEY(`choice`, `weight`, `draft_note_id`), FOREIGN KEY(`draft_note_id`) REFERENCES `draft_note_table`(`draft_note_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "choice",
+            "columnName": "choice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draft_note_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "choice",
+            "weight",
+            "draft_note_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_poll_choice_table_draft_note_id_choice",
+            "unique": false,
+            "columnNames": [
+              "draft_note_id",
+              "choice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_poll_choice_table_draft_note_id_choice` ON `${TABLE_NAME}` (`draft_note_id`, `choice`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "draft_note_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "draft_note_id"
+            ],
+            "referencedColumns": [
+              "draft_note_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_id",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `draft_note_id` INTEGER NOT NULL, PRIMARY KEY(`userId`, `draft_note_id`), FOREIGN KEY(`draft_note_id`) REFERENCES `draft_note_table`(`draft_note_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draft_note_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "userId",
+            "draft_note_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_user_id_draft_note_id",
+            "unique": false,
+            "columnNames": [
+              "draft_note_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_id_draft_note_id` ON `${TABLE_NAME}` (`draft_note_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "draft_note_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "draft_note_id"
+            ],
+            "referencedColumns": [
+              "draft_note_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "draft_file_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL DEFAULT 'name none', `remote_file_id` TEXT, `file_path` TEXT, `is_sensitive` INTEGER, `type` TEXT, `thumbnailUrl` TEXT, `draft_note_id` INTEGER NOT NULL, `folder_id` TEXT, `file_id` INTEGER PRIMARY KEY AUTOINCREMENT, FOREIGN KEY(`draft_note_id`) REFERENCES `draft_note_table`(`draft_note_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'name none'"
+          },
+          {
+            "fieldPath": "remoteFileId",
+            "columnName": "remote_file_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isSensitive",
+            "columnName": "is_sensitive",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draft_note_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folder_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fileId",
+            "columnName": "file_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "file_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_draft_file_table_draft_note_id",
+            "unique": false,
+            "columnNames": [
+              "draft_note_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_file_table_draft_note_id` ON `${TABLE_NAME}` (`draft_note_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "draft_note_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "draft_note_id"
+            ],
+            "referencedColumns": [
+              "draft_note_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "draft_note_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `visibility` TEXT NOT NULL, `text` TEXT, `cw` TEXT, `viaMobile` INTEGER, `localOnly` INTEGER, `noExtractMentions` INTEGER, `noExtractHashtags` INTEGER, `noExtractEmojis` INTEGER, `replyId` TEXT, `renoteId` TEXT, `channelId` TEXT, `scheduleWillPostAt` TEXT, `draft_note_id` INTEGER PRIMARY KEY AUTOINCREMENT, `multiple` INTEGER, `expiresAt` INTEGER, FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cw",
+            "columnName": "cw",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "viaMobile",
+            "columnName": "viaMobile",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localOnly",
+            "columnName": "localOnly",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noExtractMentions",
+            "columnName": "noExtractMentions",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noExtractHashtags",
+            "columnName": "noExtractHashtags",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noExtractEmojis",
+            "columnName": "noExtractEmojis",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "replyId",
+            "columnName": "replyId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "renoteId",
+            "columnName": "renoteId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "scheduleWillPostAt",
+            "columnName": "scheduleWillPostAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draft_note_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "poll.multiple",
+            "columnName": "multiple",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "poll.expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "draft_note_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_draft_note_table_accountId_text",
+            "unique": false,
+            "columnNames": [
+              "accountId",
+              "text"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_note_table_accountId_text` ON `${TABLE_NAME}` (`accountId`, `text`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "url_preview",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `title` TEXT NOT NULL, `icon` TEXT, `description` TEXT, `thumbnail` TEXT, `siteName` TEXT, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnail",
+            "columnName": "thumbnail",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "siteName",
+            "columnName": "siteName",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "url"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "account_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`remoteId` TEXT NOT NULL, `instanceDomain` TEXT NOT NULL, `userName` TEXT NOT NULL, `encryptedToken` TEXT NOT NULL, `instanceType` TEXT NOT NULL DEFAULT 'misskey', `accountId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instanceDomain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "userName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "encryptedToken",
+            "columnName": "encryptedToken",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceType",
+            "columnName": "instanceType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'misskey'"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "accountId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_account_table_remoteId",
+            "unique": false,
+            "columnNames": [
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_table_remoteId` ON `${TABLE_NAME}` (`remoteId`)"
+          },
+          {
+            "name": "index_account_table_instanceDomain",
+            "unique": false,
+            "columnNames": [
+              "instanceDomain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_table_instanceDomain` ON `${TABLE_NAME}` (`instanceDomain`)"
+          },
+          {
+            "name": "index_account_table_userName",
+            "unique": false,
+            "columnNames": [
+              "userName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_table_userName` ON `${TABLE_NAME}` (`userName`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "page_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `title` TEXT NOT NULL, `weight` INTEGER NOT NULL, `pageId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `withFiles` INTEGER, `excludeNsfw` INTEGER, `includeLocalRenotes` INTEGER, `includeMyRenotes` INTEGER, `includeRenotedMyRenotes` INTEGER, `listId` TEXT, `following` INTEGER, `visibility` TEXT, `noteId` TEXT, `tag` TEXT, `reply` INTEGER, `renote` INTEGER, `poll` INTEGER, `offset` INTEGER, `markAsRead` INTEGER, `userId` TEXT, `includeReplies` INTEGER, `query` TEXT, `host` TEXT, `antennaId` TEXT, `channelId` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageId",
+            "columnName": "pageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageParams.type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageParams.withFiles",
+            "columnName": "withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.excludeNsfw",
+            "columnName": "excludeNsfw",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.includeLocalRenotes",
+            "columnName": "includeLocalRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.includeMyRenotes",
+            "columnName": "includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.includeRenotedMyRenotes",
+            "columnName": "includeRenotedMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.listId",
+            "columnName": "listId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.following",
+            "columnName": "following",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.visibility",
+            "columnName": "visibility",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.reply",
+            "columnName": "reply",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.renote",
+            "columnName": "renote",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.poll",
+            "columnName": "poll",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.offset",
+            "columnName": "offset",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.markAsRead",
+            "columnName": "markAsRead",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.includeReplies",
+            "columnName": "includeReplies",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.antennaId",
+            "columnName": "antennaId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "pageId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_page_table_weight",
+            "unique": false,
+            "columnNames": [
+              "weight"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_table_weight` ON `${TABLE_NAME}` (`weight`)"
+          },
+          {
+            "name": "index_page_table_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_table_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "meta_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uri` TEXT NOT NULL, `bannerUrl` TEXT, `cacheRemoteFiles` INTEGER, `description` TEXT, `disableGlobalTimeline` INTEGER, `disableLocalTimeline` INTEGER, `disableRegistration` INTEGER, `driveCapacityPerLocalUserMb` INTEGER, `driveCapacityPerRemoteUserMb` INTEGER, `enableDiscordIntegration` INTEGER, `enableEmail` INTEGER, `enableEmojiReaction` INTEGER, `enableGithubIntegration` INTEGER, `enableRecaptcha` INTEGER, `enableServiceWorker` INTEGER, `enableTwitterIntegration` INTEGER, `errorImageUrl` TEXT, `feedbackUrl` TEXT, `iconUrl` TEXT, `maintainerEmail` TEXT, `maintainerName` TEXT, `mascotImageUrl` TEXT, `maxNoteTextLength` INTEGER, `name` TEXT, `recaptchaSiteKey` TEXT, `secure` INTEGER, `swPublicKey` TEXT, `toSUrl` TEXT, `version` TEXT NOT NULL, PRIMARY KEY(`uri`))",
+        "fields": [
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bannerUrl",
+            "columnName": "bannerUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cacheRemoteFiles",
+            "columnName": "cacheRemoteFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "disableGlobalTimeline",
+            "columnName": "disableGlobalTimeline",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "disableLocalTimeline",
+            "columnName": "disableLocalTimeline",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "disableRegistration",
+            "columnName": "disableRegistration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "driveCapacityPerLocalUserMb",
+            "columnName": "driveCapacityPerLocalUserMb",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "driveCapacityPerRemoteUserMb",
+            "columnName": "driveCapacityPerRemoteUserMb",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableDiscordIntegration",
+            "columnName": "enableDiscordIntegration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableEmail",
+            "columnName": "enableEmail",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableEmojiReaction",
+            "columnName": "enableEmojiReaction",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableGithubIntegration",
+            "columnName": "enableGithubIntegration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableRecaptcha",
+            "columnName": "enableRecaptcha",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableServiceWorker",
+            "columnName": "enableServiceWorker",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableTwitterIntegration",
+            "columnName": "enableTwitterIntegration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "errorImageUrl",
+            "columnName": "errorImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "feedbackUrl",
+            "columnName": "feedbackUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "iconUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maintainerEmail",
+            "columnName": "maintainerEmail",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maintainerName",
+            "columnName": "maintainerName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mascotImageUrl",
+            "columnName": "mascotImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxNoteTextLength",
+            "columnName": "maxNoteTextLength",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recaptchaSiteKey",
+            "columnName": "recaptchaSiteKey",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "secure",
+            "columnName": "secure",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "swPublicKey",
+            "columnName": "swPublicKey",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "toSUrl",
+            "columnName": "toSUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uri"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "emoji_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `instanceDomain` TEXT NOT NULL, `host` TEXT, `url` TEXT, `uri` TEXT, `type` TEXT, `category` TEXT, `id` TEXT, PRIMARY KEY(`name`, `instanceDomain`), FOREIGN KEY(`instanceDomain`) REFERENCES `meta_table`(`uri`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instanceDomain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "name",
+            "instanceDomain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_emoji_table_instanceDomain",
+            "unique": false,
+            "columnNames": [
+              "instanceDomain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_emoji_table_instanceDomain` ON `${TABLE_NAME}` (`instanceDomain`)"
+          },
+          {
+            "name": "index_emoji_table_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_emoji_table_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meta_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "instanceDomain"
+            ],
+            "referencedColumns": [
+              "uri"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "emoji_alias_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `name` TEXT NOT NULL, `instanceDomain` TEXT NOT NULL, PRIMARY KEY(`alias`, `name`, `instanceDomain`), FOREIGN KEY(`name`, `instanceDomain`) REFERENCES `emoji_table`(`name`, `instanceDomain`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instanceDomain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "alias",
+            "name",
+            "instanceDomain"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_emoji_alias_table_name_instanceDomain",
+            "unique": false,
+            "columnNames": [
+              "name",
+              "instanceDomain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_emoji_alias_table_name_instanceDomain` ON `${TABLE_NAME}` (`name`, `instanceDomain`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "emoji_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "name",
+              "instanceDomain"
+            ],
+            "referencedColumns": [
+              "name",
+              "instanceDomain"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "unread_notifications_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `notificationId` TEXT NOT NULL, PRIMARY KEY(`accountId`, `notificationId`), FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationId",
+            "columnName": "notificationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "accountId",
+            "notificationId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "nicknames",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`nickname` TEXT NOT NULL, `username` TEXT NOT NULL, `host` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_nicknames_username_host",
+            "unique": true,
+            "columnNames": [
+              "username",
+              "host"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_nicknames_username_host` ON `${TABLE_NAME}` (`username`, `host`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "utf8_emojis_by_amio",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`codes` TEXT NOT NULL, `name` TEXT NOT NULL, `char` TEXT NOT NULL, PRIMARY KEY(`codes`))",
+        "fields": [
+          {
+            "fieldPath": "codes",
+            "columnName": "codes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charCode",
+            "columnName": "char",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "codes"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "drive_file_v1",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `relatedAccountId` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `md5` TEXT NOT NULL, `size` INTEGER NOT NULL, `url` TEXT NOT NULL, `isSensitive` INTEGER NOT NULL, `thumbnailUrl` TEXT, `folderId` TEXT, `userId` TEXT, `comment` TEXT, `blurhash` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`relatedAccountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatedAccountId",
+            "columnName": "relatedAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "md5",
+            "columnName": "md5",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSensitive",
+            "columnName": "isSensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "blurhash",
+            "columnName": "blurhash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_drive_file_v1_serverId_relatedAccountId",
+            "unique": true,
+            "columnNames": [
+              "serverId",
+              "relatedAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_drive_file_v1_serverId_relatedAccountId` ON `${TABLE_NAME}` (`serverId`, `relatedAccountId`)"
+          },
+          {
+            "name": "index_drive_file_v1_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drive_file_v1_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_drive_file_v1_relatedAccountId",
+            "unique": false,
+            "columnNames": [
+              "relatedAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drive_file_v1_relatedAccountId` ON `${TABLE_NAME}` (`relatedAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "relatedAccountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "draft_file_v2_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`draftNoteId` INTEGER NOT NULL, `filePropertyId` INTEGER, `localFileId` INTEGER, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`filePropertyId`) REFERENCES `drive_file_v1`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`localFileId`) REFERENCES `draft_local_file_v2_table`(`localFileId`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draftNoteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePropertyId",
+            "columnName": "filePropertyId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localFileId",
+            "columnName": "localFileId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_draft_file_v2_table_draftNoteId_filePropertyId_localFileId",
+            "unique": true,
+            "columnNames": [
+              "draftNoteId",
+              "filePropertyId",
+              "localFileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_draft_file_v2_table_draftNoteId_filePropertyId_localFileId` ON `${TABLE_NAME}` (`draftNoteId`, `filePropertyId`, `localFileId`)"
+          },
+          {
+            "name": "index_draft_file_v2_table_draftNoteId",
+            "unique": false,
+            "columnNames": [
+              "draftNoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_file_v2_table_draftNoteId` ON `${TABLE_NAME}` (`draftNoteId`)"
+          },
+          {
+            "name": "index_draft_file_v2_table_localFileId",
+            "unique": false,
+            "columnNames": [
+              "localFileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_file_v2_table_localFileId` ON `${TABLE_NAME}` (`localFileId`)"
+          },
+          {
+            "name": "index_draft_file_v2_table_filePropertyId",
+            "unique": false,
+            "columnNames": [
+              "filePropertyId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_file_v2_table_filePropertyId` ON `${TABLE_NAME}` (`filePropertyId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "drive_file_v1",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "filePropertyId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "draft_local_file_v2_table",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "localFileId"
+            ],
+            "referencedColumns": [
+              "localFileId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "draft_local_file_v2_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `file_path` TEXT NOT NULL, `is_sensitive` INTEGER, `type` TEXT NOT NULL, `thumbnailUrl` TEXT, `folder_id` TEXT, `file_size` INTEGER, `comment` TEXT, `localFileId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSensitive",
+            "columnName": "is_sensitive",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folder_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localFileId",
+            "columnName": "localFileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "localFileId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "group_v1",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `name` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_group_v1_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_v1_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_group_v1_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_v1_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_group_v1_accountId_serverId",
+            "unique": true,
+            "columnNames": [
+              "accountId",
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_group_v1_accountId_serverId` ON `${TABLE_NAME}` (`accountId`, `serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "group_member_v1",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `userId` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`groupId`) REFERENCES `group_v1`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_group_member_v1_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_member_v1_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_group_member_v1_groupId_userId",
+            "unique": true,
+            "columnNames": [
+              "groupId",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_group_member_v1_groupId_userId` ON `${TABLE_NAME}` (`groupId`, `userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "group_v1",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `userName` TEXT NOT NULL, `name` TEXT, `avatarUrl` TEXT, `isCat` INTEGER, `isBot` INTEGER, `host` TEXT NOT NULL, `isSameHost` INTEGER NOT NULL, `avatarBlurhash` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "userName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isCat",
+            "columnName": "isCat",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isBot",
+            "columnName": "isBot",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSameHost",
+            "columnName": "isSameHost",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarBlurhash",
+            "columnName": "avatarBlurhash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_user_serverId_accountId",
+            "unique": true,
+            "columnNames": [
+              "serverId",
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_serverId_accountId` ON `${TABLE_NAME}` (`serverId`, `accountId`)"
+          },
+          {
+            "name": "index_user_userName",
+            "unique": false,
+            "columnNames": [
+              "userName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_userName` ON `${TABLE_NAME}` (`userName`)"
+          },
+          {
+            "name": "index_user_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_user_host",
+            "unique": false,
+            "columnNames": [
+              "host"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_host` ON `${TABLE_NAME}` (`host`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_detailed_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`description` TEXT, `followersCount` INTEGER, `followingCount` INTEGER, `hostLower` TEXT, `notesCount` INTEGER, `bannerUrl` TEXT, `url` TEXT, `isFollowing` INTEGER NOT NULL, `isFollower` INTEGER NOT NULL, `isBlocking` INTEGER NOT NULL, `isMuting` INTEGER NOT NULL, `hasPendingFollowRequestFromYou` INTEGER NOT NULL, `hasPendingFollowRequestToYou` INTEGER NOT NULL, `isLocked` INTEGER NOT NULL, `birthday` TEXT, `createdAt` TEXT, `updatedAt` TEXT, `publicReactions` INTEGER, `userId` INTEGER NOT NULL, PRIMARY KEY(`userId`), FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followersCount",
+            "columnName": "followersCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followingCount",
+            "columnName": "followingCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hostLower",
+            "columnName": "hostLower",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesCount",
+            "columnName": "notesCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bannerUrl",
+            "columnName": "bannerUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isFollowing",
+            "columnName": "isFollowing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFollower",
+            "columnName": "isFollower",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBlocking",
+            "columnName": "isBlocking",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMuting",
+            "columnName": "isMuting",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasPendingFollowRequestFromYou",
+            "columnName": "hasPendingFollowRequestFromYou",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasPendingFollowRequestToYou",
+            "columnName": "hasPendingFollowRequestToYou",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLocked",
+            "columnName": "isLocked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "birthday",
+            "columnName": "birthday",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "publicReactions",
+            "columnName": "publicReactions",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "userId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_user_detailed_state_userId",
+            "unique": true,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_detailed_state_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_emoji",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `url` TEXT, `uri` TEXT, `userId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_user_emoji_name_userId",
+            "unique": true,
+            "columnNames": [
+              "name",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_emoji_name_userId` ON `${TABLE_NAME}` (`name`, `userId`)"
+          },
+          {
+            "name": "index_user_emoji_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_emoji_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pinned_note_id",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`noteId` TEXT NOT NULL, `userId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_pinned_note_id_noteId_userId",
+            "unique": true,
+            "columnNames": [
+              "noteId",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_pinned_note_id_noteId_userId` ON `${TABLE_NAME}` (`noteId`, `userId`)"
+          },
+          {
+            "name": "index_pinned_note_id_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pinned_note_id_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_instance_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`faviconUrl` TEXT, `iconUrl` TEXT, `name` TEXT, `softwareName` TEXT, `softwareVersion` TEXT, `themeColor` TEXT, `userId` INTEGER NOT NULL, PRIMARY KEY(`userId`), FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "faviconUrl",
+            "columnName": "faviconUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "iconUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "softwareName",
+            "columnName": "softwareName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "softwareVersion",
+            "columnName": "softwareVersion",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "userId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_user_instance_info_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_instance_info_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile_field",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `value` TEXT NOT NULL, `userId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_user_profile_field_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_profile_field_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "word_filter_condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "word_filter_regex_condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pattern` TEXT NOT NULL, `parentId` INTEGER NOT NULL, PRIMARY KEY(`parentId`), FOREIGN KEY(`parentId`) REFERENCES `word_filter_condition`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "pattern",
+            "columnName": "pattern",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "parentId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_word_filter_regex_condition_parentId",
+            "unique": false,
+            "columnNames": [
+              "parentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_word_filter_regex_condition_parentId` ON `${TABLE_NAME}` (`parentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "word_filter_condition",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "parentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "word_filter_word_condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`word` TEXT NOT NULL, `parentId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`parentId`) REFERENCES `word_filter_condition`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "word",
+            "columnName": "word",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_word_filter_word_condition_parentId",
+            "unique": false,
+            "columnNames": [
+              "parentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_word_filter_word_condition_parentId` ON `${TABLE_NAME}` (`parentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "word_filter_condition",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "parentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `name` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_user_list_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_list_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_user_list_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_list_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_user_list_accountId_serverId",
+            "unique": true,
+            "columnNames": [
+              "accountId",
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_list_accountId_serverId` ON `${TABLE_NAME}` (`accountId`, `serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_list_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userListId` INTEGER NOT NULL, `userId` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`userListId`) REFERENCES `user_list`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userListId",
+            "columnName": "userListId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_user_list_member_userListId",
+            "unique": false,
+            "columnNames": [
+              "userListId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_list_member_userListId` ON `${TABLE_NAME}` (`userListId`)"
+          },
+          {
+            "name": "index_user_list_member_userListId_userId",
+            "unique": true,
+            "columnNames": [
+              "userListId",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_list_member_userListId_userId` ON `${TABLE_NAME}` (`userListId`, `userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user_list",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userListId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "instance_info_v1_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `host` TEXT NOT NULL, `name` TEXT, `description` TEXT, `clientMaxBodyByteSize` INTEGER, `iconUrl` TEXT, `themeColor` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "clientMaxBodyByteSize",
+            "columnName": "clientMaxBodyByteSize",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "iconUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_instance_info_v1_table_host",
+            "unique": true,
+            "columnNames": [
+              "host"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_instance_info_v1_table_host` ON `${TABLE_NAME}` (`host`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [
+      {
+        "viewName": "user_view",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS select user.*, nicknames.nickname from user left join nicknames on user.userName = nicknames.username and user.host = nicknames.host"
+      },
+      {
+        "viewName": "group_member_view",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS select m.groupId, u.id as userId, u.avatarUrl, u.serverId from group_member_v1 as m \n            inner join group_v1 as g\n            inner join user as u\n            on m.groupId = g.id\n                and m.userId = u.serverId\n                and g.accountId = u.accountId"
+      },
+      {
+        "viewName": "user_list_member_view",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS select m.userListId, u.id as userId, u.avatarUrl, u.serverId from user_list_member as m \n            inner join user_list as ul\n            inner join user as u\n            on m.userListId = ul.id\n                and m.userId = u.serverId\n                and ul.accountId = u.accountId"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '503d63cfab88a415cb200cf8184a8f46')"
+    ]
+  }
+}

--- a/modules/data/src/androidTest/java/net/pantasystem/milktea/data/infrastructure/DatabaseMigrationTest.kt
+++ b/modules/data/src/androidTest/java/net/pantasystem/milktea/data/infrastructure/DatabaseMigrationTest.kt
@@ -109,4 +109,11 @@ class DatabaseMigrationTest {
         helper.createDatabase(testDb, 11)
         helper.runMigrationsAndValidate(testDb, 29, true)
     }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate11To30() {
+        helper.createDatabase(testDb, 11)
+        helper.runMigrationsAndValidate(testDb, 30, true)
+    }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/DataBase.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/DataBase.kt
@@ -84,7 +84,7 @@ import net.pantasystem.milktea.data.infrastructure.user.db.*
         UserListMemberIdRecord::class,
         InstanceInfoRecord::class,
     ],
-    version = 29,
+    version = 30,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 11, to = 12),
@@ -105,6 +105,7 @@ import net.pantasystem.milktea.data.infrastructure.user.db.*
         AutoMigration(from = 26, to = 27),
         AutoMigration(from = 27, to = 28),
         AutoMigration(from = 28, to = 29),
+        AutoMigration(from = 29, to = 30)
     ],
     views = [UserView::class, GroupMemberView::class, UserListMemberView::class]
 )

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/draft/DraftNoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/draft/DraftNoteRepositoryImpl.kt
@@ -62,6 +62,7 @@ class DraftNoteRepositoryImpl @Inject constructor(
                                         thumbnailUrl = it.thumbnailUrl,
                                         isSensitive = it.isSensitive,
                                         fileSize = it.fileSize,
+                                        comment = it.comment
                                     )
                                 ),
                                 filePropertyId = null,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/draft/db/DraftFileDTO.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/draft/db/DraftFileDTO.kt
@@ -51,6 +51,7 @@ data class DraftLocalFile(
     @ColumnInfo(name = "thumbnailUrl") val thumbnailUrl: String?,
     @ColumnInfo(name = "folder_id") val folderId: String?,
     @ColumnInfo(name = "file_size") val fileSize: Long?,
+    @ColumnInfo(name = "comment") val comment: String?,
     @PrimaryKey(autoGenerate = true) val localFileId: Long = 0L,
 ) {
     companion object
@@ -65,7 +66,8 @@ fun DraftLocalFile.Companion.from(draftNote: DraftNoteFile.Local): DraftLocalFil
         type = draftNote.type,
         thumbnailUrl = draftNote.thumbnailUrl,
         isSensitive = draftNote.isSensitive,
-        fileSize = draftNote.fileSize
+        fileSize = draftNote.fileSize,
+        comment = draftNote.comment
     )
 }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/draft/db/DraftNoteRelation.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/draft/db/DraftNoteRelation.kt
@@ -72,7 +72,8 @@ class DraftNoteRelation {
                         thumbnailUrl = thumbnailUrl,
                         type = type,
                         localFileId = ref.localFileId,
-                        fileSize = fileSize
+                        fileSize = fileSize,
+                        comment = comment
                     )
                 }
 

--- a/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/FilePropertyGridItem.kt
+++ b/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/FilePropertyGridItem.kt
@@ -101,6 +101,9 @@ fun FilePropertyGridItem(
                     FileCardDropdownMenuAction.OnNsfwMenuItemClicked -> {
                         onAction(FilePropertyCardAction.OnToggleNsfw(fileViewData.fileProperty.id))
                     }
+                    FileCardDropdownMenuAction.OnEditFileName -> {
+                        onAction(FilePropertyCardAction.OnSelectEditFileNameMenuItem(fileViewData.fileProperty))
+                    }
                 }
             },
             property = fileViewData.fileProperty

--- a/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/FilePropertyGridItem.kt
+++ b/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/FilePropertyGridItem.kt
@@ -68,7 +68,7 @@ fun FilePropertyGridItem(
             }
 
             if (fileViewData.fileProperty.isSensitive) {
-                SensitiveIcon()
+                SensitiveIcon(modifier = Modifier.align(Alignment.TopStart))
             }
 
             if (isSelectMode) {

--- a/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/FileUtils.kt
+++ b/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/FileUtils.kt
@@ -26,7 +26,8 @@ fun Uri.toAppFile(context: Context): AppFile.Local {
         thumbnailUrl = thumbnail,
         isSensitive = false,
         folderId = null,
-        fileSize = getFileSize(context)
+        fileSize = getFileSize(context),
+        comment = null,
     )
 }
 

--- a/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/file_action_dropdownmenu.kt
+++ b/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/file_action_dropdownmenu.kt
@@ -1,6 +1,7 @@
 package net.pantasystem.milktea.drive
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
@@ -11,8 +12,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import net.pantasystem.milktea.common_compose.drive.EditCaptionDialogLayout
 import net.pantasystem.milktea.model.drive.FileProperty
 
 @Composable
@@ -127,46 +128,16 @@ fun EditCaptionDialog(
     }
     if (fileProperty != null) {
         Dialog(onDismissRequest = onDismiss) {
-            Surface(
-                shape = MaterialTheme.shapes.medium,
-                color = MaterialTheme.colors.surface,
-            ) {
-                Column(
-                    modifier = Modifier.padding(16.dp)
-                ) {
-                    Text(
-                        stringResource(R.string.edit_caption),
-                        fontSize = 24.sp,
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    TextField(
-                        value = captionText,
-                        placeholder = {
-                            Text(stringResource(R.string.input_caption))
-                        },
-                        onValueChange = { text ->
-                            captionText = text
-                        }
-                    )
-                    Row(
-                        Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End
-                    ) {
-                        TextButton(onClick = onDismiss) {
-                            Text(stringResource(R.string.cancel))
-                        }
-                        TextButton(onClick = {
-                            onSave.invoke(fileProperty.id, captionText)
-                        }) {
-                            Text(stringResource(R.string.save))
-                        }
-                    }
-                }
-            }
+            EditCaptionDialogLayout(value = captionText, onCancelButtonClicked = onDismiss, onTextChanged = {
+                captionText = it
+            }, onSaveButtonClicked = {
+                onSave(fileProperty.id, captionText)
+            })
         }
     }
 
 }
+
 
 sealed interface FileCardDropdownMenuAction {
     object OnDismissRequest : FileCardDropdownMenuAction

--- a/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/file_action_dropdownmenu.kt
+++ b/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/file_action_dropdownmenu.kt
@@ -4,16 +4,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.HideImage
-import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import net.pantasystem.milktea.common_compose.drive.EditCaptionDialogLayout
+import net.pantasystem.milktea.common_compose.drive.EditFileNameDialogLayout
 import net.pantasystem.milktea.model.drive.FileProperty
 
 @Composable
@@ -72,11 +70,22 @@ fun FileActionDropdownMenu(
             onAction(FileCardDropdownMenuAction.OnEditFileCaption)
         }) {
             Icon(
-                Icons.Default.Edit,
+                Icons.Default.Comment,
                 modifier = Modifier.size(24.dp),
                 contentDescription = stringResource(R.string.edit_caption)
             )
             Text(text = stringResource(R.string.edit_caption))
+        }
+        Divider()
+        DropdownMenuItem(onClick = {
+            onAction(FileCardDropdownMenuAction.OnEditFileName)
+        }) {
+            Icon(
+                Icons.Default.Edit,
+                modifier = Modifier.size(24.dp),
+                contentDescription = stringResource(id = R.string.edit_file_name)
+            )
+            Text(text = stringResource(id = R.string.edit_file_name))
         }
     }
 
@@ -138,10 +147,37 @@ fun EditCaptionDialog(
 
 }
 
+@Composable
+fun EditFileNameDialog(
+    fileProperty: FileProperty?,
+    onDismiss: () -> Unit,
+    onSave: (FileProperty.Id, newName: String) -> Unit
+) {
+    var nameText: String by remember(fileProperty) {
+        mutableStateOf(fileProperty?.name ?: "")
+    }
+    if (fileProperty != null) {
+        Dialog(onDismissRequest = onDismiss) {
+            EditFileNameDialogLayout(
+                value = nameText,
+                onTextChanged = {
+                    nameText = it
+                },
+                onSaveButtonClicked = {
+                    onSave(fileProperty.id, nameText)
+                },
+                onCancelButtonClicked = {
+                    onDismiss()
+                }
+            )
+        }
+
+    }}
 
 sealed interface FileCardDropdownMenuAction {
     object OnDismissRequest : FileCardDropdownMenuAction
     object OnNsfwMenuItemClicked : FileCardDropdownMenuAction
     object OnDeleteMenuItemClicked : FileCardDropdownMenuAction
     object OnEditFileCaption : FileCardDropdownMenuAction
+    object OnEditFileName : FileCardDropdownMenuAction
 }

--- a/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/file_property_card.kt
+++ b/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/file_property_card.kt
@@ -119,6 +119,9 @@ fun FilePropertySimpleCard(
                             FileCardDropdownMenuAction.OnNsfwMenuItemClicked -> {
                                 onAction(FilePropertyCardAction.OnToggleNsfw(file.fileProperty.id))
                             }
+                            FileCardDropdownMenuAction.OnEditFileName -> {
+                                onAction(FilePropertyCardAction.OnSelectEditFileNameMenuItem(file.fileProperty))
+                            }
                         }
                     },
                     property = file.fileProperty
@@ -142,4 +145,5 @@ sealed interface FilePropertyCardAction {
     data class OnToggleNsfw(val fileId: FileProperty.Id) : FilePropertyCardAction
     data class OnSelectDeletionMenuItem(val file: FileProperty) : FilePropertyCardAction
     data class OnSelectEditCaptionMenuItem(val file: FileProperty) : FilePropertyCardAction
+    data class OnSelectEditFileNameMenuItem(val file: FileProperty) : FilePropertyCardAction
 }

--- a/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/files.kt
+++ b/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/files.kt
@@ -50,8 +50,11 @@ fun FilePropertyListScreen(
     }
 
 
-
     var editCaptionTargetFile: FileProperty? by remember {
+        mutableStateOf(null)
+    }
+
+    var editNameTargetFile: FileProperty? by remember {
         mutableStateOf(null)
     }
 
@@ -78,6 +81,15 @@ fun FilePropertyListScreen(
         }
     )
 
+    EditFileNameDialog(
+        fileProperty = editNameTargetFile,
+        onDismiss = { editNameTargetFile = null },
+        onSave = { id, newName ->
+            editNameTargetFile = null
+            fileViewModel.updateFileName(id, newName)
+        },
+    )
+
     val actionHandler: (FilePropertyCardAction) -> Unit = { cardAction ->
         when (cardAction) {
             is FilePropertyCardAction.OnCloseDropdownMenu -> {
@@ -97,6 +109,9 @@ fun FilePropertyListScreen(
             }
             is FilePropertyCardAction.OnSelectEditCaptionMenuItem -> {
                 editCaptionTargetFile = cardAction.file
+            }
+            is FilePropertyCardAction.OnSelectEditFileNameMenuItem -> {
+                editNameTargetFile = cardAction.file
             }
         }
     }
@@ -192,7 +207,11 @@ fun DriveFilesGridView(
         state = state
     ) {
         items(files.size) { index ->
-            FilePropertyGridItem(fileViewData = files[index], onAction = onAction, isSelectMode = isSelectMode)
+            FilePropertyGridItem(
+                fileViewData = files[index],
+                onAction = onAction,
+                isSelectMode = isSelectMode
+            )
         }
     }
 }

--- a/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/viewmodel/FileViewModel.kt
+++ b/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/viewmodel/FileViewModel.kt
@@ -214,6 +214,16 @@ class FileViewModel @AssistedInject constructor(
         }
     }
 
+    fun updateFileName(id: FileProperty.Id, name: String) {
+        viewModelScope.launch {
+            filePropertyRepository.update(
+                filePropertyRepository.find(id)
+                    .update(name = name)
+            ).onFailure {
+                logger.error("update file name failed", it)
+            }
+        }
+    }
     fun openFileCardDropDownMenu(fileId: FileProperty.Id) {
         _fileCardDropDowned.value = fileId
     }

--- a/modules/features/drive/src/main/res/values-ja/strings.xml
+++ b/modules/features/drive/src/main/res/values-ja/strings.xml
@@ -6,9 +6,7 @@
     <string name="do_u_want_2_delete_s">%sを削除しますか？</string>
     <string name="mark_as_nsfw">閲覧注意にする</string>
     <string name="delete">削除</string>
-    <string name="edit_caption">キャプションを編集</string>
-    <string name="input_caption">キャプションを入力</string>
-    <string name="save">保存</string>
+
     <string name="drive">ドライブ</string>
     <string name="file">ファイル</string>
     <string name="folder">フォルダー</string>

--- a/modules/features/drive/src/main/res/values-zh/strings.xml
+++ b/modules/features/drive/src/main/res/values-zh/strings.xml
@@ -6,9 +6,7 @@
     <string name="do_u_want_2_delete_s">你确定要删除 %s 吗？</string>
     <string name="mark_as_nsfw">标记为NSFW</string>
     <string name="delete">删除</string>
-    <string name="edit_caption">编辑标题</string>
-    <string name="input_caption">输入标题</string>
-    <string name="save">保存</string>
+
     <string name="drive">网盘</string>
 
     <string name="file">文件</string>

--- a/modules/features/drive/src/main/res/values/strings.xml
+++ b/modules/features/drive/src/main/res/values/strings.xml
@@ -6,9 +6,7 @@
     <string name="do_u_want_2_delete_s">Do you want to delete %s?</string>
     <string name="mark_as_nsfw">Mark as NSFW</string>
     <string name="delete">Delete</string>
-    <string name="edit_caption">Edit caption</string>
-    <string name="input_caption">Input caption</string>
-    <string name="save">Save</string>
+
     <string name="drive">Drive</string>
 
     <string name="file">File</string>

--- a/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/picked_image_preview.kt
+++ b/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/picked_image_preview.kt
@@ -2,7 +2,6 @@ package net.pantasystem.milktea.gallery
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import net.pantasystem.milktea.common_compose.FilePreviewActionType
 import net.pantasystem.milktea.common_compose.HorizontalFilePreviewList
 import net.pantasystem.milktea.gallery.viewmodel.GalleryEditorViewModel
 import net.pantasystem.milktea.model.file.FilePreviewSource
@@ -15,18 +14,14 @@ fun PickedImagePreview(
     val files = viewModel.pickedImages.collectAsState()
     HorizontalFilePreviewList(
         files = files.value,
-        onAction = {
-            when(it) {
-                is FilePreviewActionType.ToggleSensitive -> {
-                    viewModel.toggleSensitive(it.target.file)
-                }
-                is FilePreviewActionType.Show -> {
-                    onShow(it.target)
-                }
-                is FilePreviewActionType.Detach -> {
-                    viewModel.detach(it.target.file)
-                }
-            }
+        onShow = {
+            onShow(it)
+        },
+        onToggleSensitive = {
+            viewModel.toggleSensitive(it.file)
+        },
+        onDetach = {
+            viewModel.detach(it.file)
         }
     )
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/draft/DraftNotesFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/draft/DraftNotesFragment.kt
@@ -11,6 +11,10 @@ import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import net.pantasystem.milktea.common_navigation.MediaNavigation
 import net.pantasystem.milktea.common_navigation.MediaNavigationArgs
+import net.pantasystem.milktea.model.file.AppFile
+import net.pantasystem.milktea.model.file.FilePreviewSource
+import net.pantasystem.milktea.model.file.from
+import net.pantasystem.milktea.model.notes.draft.DraftNoteFile
 import net.pantasystem.milktea.note.NoteEditorActivity
 import net.pantasystem.milktea.note.draft.viewmodel.DraftNotesViewModel
 import javax.inject.Inject
@@ -37,36 +41,31 @@ class DraftNotesFragment : Fragment() {
                 MdcTheme {
                     DraftNotesPage(
                         viewModel = viewModel,
-                        onAction = {
-                            onAction(it)
+                        onNavigateUp = {
+                                       requireActivity().finish()
+                        },
+                        onEdit = {
+                            val intent = NoteEditorActivity.newBundle(
+                                requireContext(),
+                                draftNoteId = it.draftNoteId
+                            )
+                            requireActivity().startActivityFromFragment(this@DraftNotesFragment, intent, 300)
+                        },
+                        onShowFile = {
+                            val intent = mediaNavigation.newIntent(
+                                MediaNavigationArgs.AFile(
+                                    when(it) {
+                                        is DraftNoteFile.Local -> FilePreviewSource.Local(AppFile.from(it) as AppFile.Local)
+                                        is DraftNoteFile.Remote -> FilePreviewSource.Remote(AppFile.Remote(it.fileProperty.id), it.fileProperty)
+                                    }
+                                )
+                            )
+                            startActivity(intent)
                         }
                     )
                 }
             }
         }.rootView
-    }
-
-    private fun onAction(action: DraftNotePageAction) {
-        when (action) {
-            is DraftNotePageAction.Edit -> {
-                val intent = NoteEditorActivity.newBundle(
-                    requireContext(),
-                    draftNoteId = action.draftNote.draftNoteId
-                )
-                requireActivity().startActivityFromFragment(this, intent, 300)
-            }
-            DraftNotePageAction.NavigateUp -> {
-                requireActivity().finish()
-            }
-            is DraftNotePageAction.ShowFile -> {
-                val intent = mediaNavigation.newIntent(
-                    MediaNavigationArgs.AFile(
-                        action.previewActionType
-                    )
-                )
-                startActivity(intent)
-            }
-        }
     }
 
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/draft/draft_note_card.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/draft/draft_note_card.kt
@@ -12,9 +12,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import net.pantasystem.milktea.common_compose.FilePreviewActionType
 import net.pantasystem.milktea.common_compose.HorizontalFilePreviewList
 import net.pantasystem.milktea.model.notes.draft.DraftNote
+import net.pantasystem.milktea.model.notes.draft.DraftNoteFile
 import net.pantasystem.milktea.note.R
 
 
@@ -23,6 +23,9 @@ fun DraftNoteCard(
     draftNote: DraftNote,
     isVisibleContent: Boolean,
     onAction: (DraftNoteCardAction) -> Unit,
+    onDetach: (DraftNoteFile) -> Unit,
+    onShow: (DraftNoteFile) -> Unit,
+    onToggleSensitive: (DraftNoteFile) -> Unit,
 ) {
 
     var confirmDeleteDraftNoteId: Long? by remember {
@@ -74,9 +77,21 @@ fun DraftNoteCard(
             if (draftNote.appFiles.isNotEmpty()) {
                 HorizontalFilePreviewList(
                     files = draftNote.filePreviewSources,
-                    onAction = {
-                        onAction(DraftNoteCardAction.FileAction(draftNote, it))
+//                    onAction = {
+//                        onAction(DraftNoteCardAction.FileAction(draftNote, it))
+//                    },
+                    onDetach = {
+                        val index = draftNote.filePreviewSources.indexOf(it)
+                        onDetach(draftNote.draftFiles!![index])
                     },
+                    onShow = {
+                        val index = draftNote.filePreviewSources.indexOf(it)
+                        onShow(draftNote.draftFiles!![index])
+                    },
+                    onToggleSensitive = {
+                        val index = draftNote.filePreviewSources.indexOf(it)
+                        onToggleSensitive(draftNote.draftFiles!![index])
+                    }
                 )
             }
 
@@ -163,11 +178,6 @@ fun ConfirmDeleteDraftNoteDialog(onDismiss: () -> Unit, onConfirmed: () -> Unit)
 
 sealed interface DraftNoteCardAction {
     val draftNote: DraftNote
-
-    data class FileAction(
-        override val draftNote: DraftNote,
-        val fileAction: FilePreviewActionType
-    ) : DraftNoteCardAction
 
     data class DeleteDraftNote(override val draftNote: DraftNote) : DraftNoteCardAction
     data class Edit(override val draftNote: DraftNote) : DraftNoteCardAction

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
@@ -51,6 +51,8 @@ import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.FragmentNoteEditorBinding
 import net.pantasystem.milktea.note.databinding.ViewNoteEditorToolbarBinding
+import net.pantasystem.milktea.note.editor.file.EditFileCaptionDialog
+import net.pantasystem.milktea.note.editor.file.EditFileNameDialog
 import net.pantasystem.milktea.note.editor.viewmodel.NoteEditorViewModel
 import net.pantasystem.milktea.note.emojis.CustomEmojiPickerDialog
 import net.pantasystem.milktea.note.emojis.viewmodel.EmojiSelection
@@ -297,6 +299,12 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
                             )
 
                             requireActivity().startActivity(intent)
+                        },
+                        onEditFileCaptionSelectionClicked = {
+                            EditFileCaptionDialog.newInstance(it.file, it.comment ?: "").show(childFragmentManager, "editCaption")
+                        },
+                        onEditFileNameSelectionClicked = {
+                            EditFileNameDialog.newInstance(it.file, it.name).show(childFragmentManager, "editFileName")
                         }
                     )
                 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/SimpleEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/SimpleEditorFragment.kt
@@ -38,6 +38,8 @@ import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.note.NoteEditorActivity
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.FragmentSimpleEditorBinding
+import net.pantasystem.milktea.note.editor.file.EditFileCaptionDialog
+import net.pantasystem.milktea.note.editor.file.EditFileNameDialog
 import net.pantasystem.milktea.note.editor.viewmodel.NoteEditorViewModel
 import net.pantasystem.milktea.note.editor.viewmodel.toCreateNote
 import net.pantasystem.milktea.note.emojis.CustomEmojiPickerDialog
@@ -157,6 +159,12 @@ class SimpleEditorFragment : Fragment(R.layout.fragment_simple_editor), SimpleEd
                                 0
                             ))
                             requireActivity().startActivity(intent)
+                        },
+                        onEditFileCaptionSelectionClicked = {
+                            EditFileCaptionDialog.newInstance(it.file, it.comment).show(childFragmentManager, "editFileName")
+                        },
+                        onEditFileNameSelectionClicked = {
+                            EditFileNameDialog.newInstance(it.file, it.name).show(childFragmentManager, "showEditComment")
                         }
                     )
                 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/file/EditFileCaptionDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/file/EditFileCaptionDialog.kt
@@ -1,0 +1,65 @@
+package net.pantasystem.milktea.note.editor.file
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.activityViewModels
+import com.google.android.material.composethemeadapter.MdcTheme
+import dagger.hilt.android.AndroidEntryPoint
+import net.pantasystem.milktea.common_compose.drive.EditCaptionDialogLayout
+import net.pantasystem.milktea.model.file.AppFile
+import net.pantasystem.milktea.note.editor.viewmodel.NoteEditorViewModel
+
+@Suppress("DEPRECATION")
+@AndroidEntryPoint
+class EditFileCaptionDialog : AppCompatDialogFragment() {
+
+    companion object {
+        fun newInstance(appFile: AppFile, comment: String?): EditFileNameDialog {
+            return EditFileNameDialog().apply {
+                arguments = Bundle().apply {
+                    putSerializable("EXTRA_APP_FILE", appFile)
+                    putString("EXTRA_COMMENT", comment)
+                }
+            }
+        }
+    }
+
+    val noteEditorViewModel by activityViewModels<NoteEditorViewModel>()
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState)
+
+        val appFile = requireArguments().getSerializable("EXTRA_APP_FILE") as AppFile
+
+        val view = ComposeView(requireContext()).apply {
+            setContent {
+                var text: String by remember {
+                    mutableStateOf(requireArguments().getString("EXTRA_COMMENT") ?: "")
+                }
+                MdcTheme {
+                    EditCaptionDialogLayout(
+                        value = text,
+                        onCancelButtonClicked = {
+                            dismiss()
+                        },
+                        onTextChanged = {
+                            text = it
+                        },
+                        onSaveButtonClicked = {
+                            noteEditorViewModel.updateFileComment(appFile, text)
+                            dismiss()
+                        }
+                    )
+                }
+            }
+        }
+        dialog.setContentView(view)
+        return dialog
+    }
+}

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/file/EditFileCaptionDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/file/EditFileCaptionDialog.kt
@@ -20,8 +20,8 @@ import net.pantasystem.milktea.note.editor.viewmodel.NoteEditorViewModel
 class EditFileCaptionDialog : AppCompatDialogFragment() {
 
     companion object {
-        fun newInstance(appFile: AppFile, comment: String?): EditFileNameDialog {
-            return EditFileNameDialog().apply {
+        fun newInstance(appFile: AppFile, comment: String?): EditFileCaptionDialog {
+            return EditFileCaptionDialog().apply {
                 arguments = Bundle().apply {
                     putSerializable("EXTRA_APP_FILE", appFile)
                     putString("EXTRA_COMMENT", comment)
@@ -37,10 +37,11 @@ class EditFileCaptionDialog : AppCompatDialogFragment() {
 
         val appFile = requireArguments().getSerializable("EXTRA_APP_FILE") as AppFile
 
+        val comment = requireArguments().getString("EXTRA_COMMENT") ?: ""
         val view = ComposeView(requireContext()).apply {
             setContent {
-                var text: String by remember {
-                    mutableStateOf(requireArguments().getString("EXTRA_COMMENT") ?: "")
+                var text: String by remember(comment) {
+                    mutableStateOf(comment)
                 }
                 MdcTheme {
                     EditCaptionDialogLayout(

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/file/EditFileNameDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/file/EditFileNameDialog.kt
@@ -1,0 +1,97 @@
+package net.pantasystem.milktea.note.editor.file
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.fragment.app.activityViewModels
+import com.google.android.material.composethemeadapter.MdcTheme
+import dagger.hilt.android.AndroidEntryPoint
+import net.pantasystem.milktea.model.file.AppFile
+import net.pantasystem.milktea.note.R
+import net.pantasystem.milktea.note.editor.viewmodel.NoteEditorViewModel
+
+@Suppress("DEPRECATION")
+@AndroidEntryPoint
+class EditFileNameDialog : AppCompatDialogFragment() {
+
+    companion object {
+        fun newInstance(appFile: AppFile, name: String?): EditFileNameDialog {
+            return EditFileNameDialog().apply {
+                arguments = Bundle().apply {
+                    putSerializable("EXTRA_APP_FILE", appFile)
+                    putString("EXTRA_NAME", name)
+                }
+            }
+        }
+    }
+
+    val noteEditorViewModel by activityViewModels<NoteEditorViewModel>()
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState)
+
+        val appFile = requireArguments().getSerializable("EXTRA_APP_FILE") as AppFile
+
+        val view = ComposeView(requireContext()).apply {
+            setContent {
+                var text: String by remember {
+                    mutableStateOf(requireArguments().getString("EXTRA_NAME") ?: "")
+                }
+                MdcTheme {
+                    Surface(
+                        shape = MaterialTheme.shapes.medium,
+                        color = MaterialTheme.colors.surface
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(16.dp)
+                        ) {
+                            Text(
+                                stringResource(id = R.string.edit_file_name),
+                                fontSize = 24.sp,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            TextField(
+                                value = text,
+                                placeholder = {
+                                    Text(stringResource(R.string.input_caption))
+                                },
+                                onValueChange = { t ->
+                                    text = t
+                                }
+                            )
+                            Row(
+                                Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.End
+                            ) {
+                                TextButton(onClick = {
+                                    dismiss()
+                                }) {
+                                    Text(stringResource(id = R.string.cancel))
+                                }
+                                TextButton(onClick = {
+                                    noteEditorViewModel.updateFileName(appFile, text)
+                                    dismiss()
+                                }) {
+                                    Text(stringResource(id = R.string.save))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        dialog.setContentView(view)
+        return dialog
+    }
+}

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/file/EditFileNameDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/file/EditFileNameDialog.kt
@@ -3,22 +3,16 @@ package net.pantasystem.milktea.note.editor.file
 import android.app.Dialog
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatDialogFragment
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.fragment.app.activityViewModels
 import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
+import net.pantasystem.milktea.common_compose.drive.EditFileNameDialogLayout
 import net.pantasystem.milktea.model.file.AppFile
-import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.editor.viewmodel.NoteEditorViewModel
 
 @Suppress("DEPRECATION")
@@ -49,45 +43,19 @@ class EditFileNameDialog : AppCompatDialogFragment() {
                     mutableStateOf(requireArguments().getString("EXTRA_NAME") ?: "")
                 }
                 MdcTheme {
-                    Surface(
-                        shape = MaterialTheme.shapes.medium,
-                        color = MaterialTheme.colors.surface
-                    ) {
-                        Column(
-                            modifier = Modifier.padding(16.dp)
-                        ) {
-                            Text(
-                                stringResource(id = R.string.edit_file_name),
-                                fontSize = 24.sp,
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            TextField(
-                                value = text,
-                                placeholder = {
-                                    Text(stringResource(R.string.input_caption))
-                                },
-                                onValueChange = { t ->
-                                    text = t
-                                }
-                            )
-                            Row(
-                                Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.End
-                            ) {
-                                TextButton(onClick = {
-                                    dismiss()
-                                }) {
-                                    Text(stringResource(id = R.string.cancel))
-                                }
-                                TextButton(onClick = {
-                                    noteEditorViewModel.updateFileName(appFile, text)
-                                    dismiss()
-                                }) {
-                                    Text(stringResource(id = R.string.save))
-                                }
-                            }
+                    EditFileNameDialogLayout(
+                        value = text,
+                        onTextChanged = {
+                            text = it
+                        },
+                        onSaveButtonClicked = {
+                            noteEditorViewModel.updateFileName(appFile, text)
+                            dismiss()
+                        },
+                        onCancelButtonClicked = {
+                            dismiss()
                         }
-                    }
+                    )
                 }
             }
         }
@@ -95,3 +63,4 @@ class EditFileNameDialog : AppCompatDialogFragment() {
         return dialog
     }
 }
+

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/note_file_preview.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/note_file_preview.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.asLiveData
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import net.pantasystem.milktea.common_compose.FilePreviewActionType
 import net.pantasystem.milktea.common_compose.HorizontalFilePreviewList
 import net.pantasystem.milktea.model.file.FilePreviewSource
 import net.pantasystem.milktea.note.editor.viewmodel.NoteEditorViewModel
@@ -19,31 +18,29 @@ import net.pantasystem.milktea.note.editor.viewmodel.NoteEditorViewModel
 @Composable
 fun NoteFilePreview(
     noteEditorViewModel: NoteEditorViewModel,
-    onShow: (FilePreviewSource)->Unit
+    onShow: (FilePreviewSource) -> Unit,
+    onEditFileNameSelectionClicked: (FilePreviewSource) -> Unit,
+    onEditFileCaptionSelectionClicked: (FilePreviewSource) -> Unit,
 ) {
     val uiState by noteEditorViewModel.uiState.collectAsState()
     val maxFileCount = noteEditorViewModel.maxFileCount.asLiveData().observeAsState()
     val instanceInfo by noteEditorViewModel.instanceInfo.collectAsState()
-    Row (
+    Row(
         verticalAlignment = Alignment.CenterVertically,
-    ){
+    ) {
         HorizontalFilePreviewList(
             files = uiState.files,
             modifier = Modifier.weight(1f),
             allowMaxFileSize = instanceInfo?.clientMaxBodyByteSize,
-            onAction = {
-                when(it) {
-                    is FilePreviewActionType.ToggleSensitive -> {
-                        noteEditorViewModel.toggleNsfw(it.target.file)
-                    }
-                    is FilePreviewActionType.Detach -> {
-                        noteEditorViewModel.removeFileNoteEditorData(it.target.file)
-                    }
-                    is FilePreviewActionType.Show -> {
-                        onShow(it.target)
-                    }
-                }
-            }
+            onToggleSensitive = {
+                noteEditorViewModel.toggleNsfw(it.file)
+            },
+            onDetach = {
+                noteEditorViewModel.removeFileNoteEditorData(it.file)
+            },
+            onShow = onShow,
+            onEditFileName = onEditFileNameSelectionClicked,
+            onEditFileCaption = onEditFileCaptionSelectionClicked
         )
         if (uiState.files.isNotEmpty())
             Text(

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
@@ -21,6 +21,7 @@ import net.pantasystem.milktea.model.channel.ChannelRepository
 import net.pantasystem.milktea.model.drive.DriveFileRepository
 import net.pantasystem.milktea.model.drive.FileProperty
 import net.pantasystem.milktea.model.drive.FilePropertyDataSource
+import net.pantasystem.milktea.model.drive.UpdateFileProperty
 import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.file.AppFile
 import net.pantasystem.milktea.model.file.FilePreviewSource
@@ -454,6 +455,29 @@ class NoteEditorViewModel @Inject constructor(
             }
         }
 
+    }
+
+    fun updateFileName(appFile: AppFile, name: String) {
+        when(appFile) {
+            is AppFile.Local -> {
+                savedStateHandle.setFiles(files.value.updateFileName(appFile, name))
+            }
+            is AppFile.Remote -> {
+                viewModelScope.launch {
+                    runCancellableCatching {
+                        val file = driveFileRepository.find(appFile.id)
+                        driveFileRepository.update(UpdateFileProperty(
+                            fileId = file.id,
+                            comment = file.comment,
+                            folderId = file.folderId,
+                            isSensitive = file.isSensitive,
+                            name = name
+                        ))
+                    }
+
+                }
+            }
+        }
     }
 
     fun add(file: AppFile) = viewModelScope.launch {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
@@ -480,6 +480,28 @@ class NoteEditorViewModel @Inject constructor(
         }
     }
 
+    fun updateFileComment(appFile: AppFile, comment: String) {
+        when(appFile) {
+            is AppFile.Local -> {
+                savedStateHandle.setFiles(files.value.updateFileComment(appFile, comment))
+            }
+            is AppFile.Remote -> {
+                viewModelScope.launch {
+                    runCancellableCatching {
+                        val file = driveFileRepository.find(appFile.id)
+                        driveFileRepository.update(UpdateFileProperty(
+                            fileId = file.id,
+                            comment = comment,
+                            folderId = file.folderId,
+                            isSensitive = file.isSensitive,
+                            name = file.name
+                        ))
+                    }
+                }
+            }
+        }
+    }
+
     fun add(file: AppFile) = viewModelScope.launch {
         val files = files.value.toMutableList()
         files.add(

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/file/AppFile.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/file/AppFile.kt
@@ -22,6 +22,7 @@ sealed interface AppFile : JSerializable {
         val isSensitive: Boolean,
         val folderId: String?,
         val fileSize: Long?,
+        val comment: String?,
         val id: Long = 0,
     ) : AppFile {
         fun isAttributeSame(file: Local): Boolean {
@@ -29,6 +30,7 @@ sealed interface AppFile : JSerializable {
                     && file.path == path
                     && file.type == type
                     && file.fileSize == fileSize
+                    && file.comment == comment
         }
     }
 
@@ -110,6 +112,7 @@ fun AppFile.Companion.from(file: DraftNoteFile): AppFile {
             isSensitive = file.isSensitive ?: false,
             fileSize = file.fileSize,
             folderId = file.folderId,
+            comment = file.comment,
         )
         is DraftNoteFile.Remote -> AppFile.Remote(file.fileProperty.id)
     }
@@ -136,7 +139,8 @@ fun Uri.toAppFile(context: Context): AppFile.Local {
         thumbnailUrl = thumbnail,
         isSensitive = false,
         folderId = null,
-        fileSize = fileSize
+        fileSize = fileSize,
+        comment = null,
     )
 }
 

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/file/AppFile.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/file/AppFile.kt
@@ -57,7 +57,7 @@ sealed interface FilePreviewSource {
             else -> AboutMediaType.OTHER
         }
         override val path: String = file.path
-        override val comment: String? = null
+        override val comment: String? = file.comment
         override val name: String = file.name
         override val thumbnailUrl: String? = file.thumbnailUrl
         override val blurhash: String? = null

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteEditingState.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteEditingState.kt
@@ -78,6 +78,16 @@ fun List<AppFile>.toggleFileSensitiveStatus(appFile: AppFile.Local): List<AppFil
     }
 }
 
+fun List<AppFile>.updateFileName(appFile: AppFile.Local, name: String): List<AppFile> {
+    return this.map {
+        if (it === appFile || it is AppFile.Local && it.isAttributeSame(appFile)) {
+            appFile.copy(name = name)
+        } else {
+            it
+        }
+    }
+}
+
 fun String?.addMentionUserNames(userNames: List<String>, pos: Int): Pair<String?, Int> {
     val mentionBuilder = StringBuilder()
     userNames.forEachIndexed { index, userName ->

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteEditingState.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteEditingState.kt
@@ -88,6 +88,15 @@ fun List<AppFile>.updateFileName(appFile: AppFile.Local, name: String): List<App
     }
 }
 
+fun List<AppFile>.updateFileComment(appFile: AppFile.Local, comment: String): List<AppFile> {
+    return this.map {
+        if (it === appFile || it is AppFile.Local && it.isAttributeSame(appFile)) {
+            appFile.copy(comment = comment)
+        } else {
+            it
+        }
+    }
+}
 fun String?.addMentionUserNames(userNames: List<String>, pos: Int): Pair<String?, Int> {
     val mentionBuilder = StringBuilder()
     userNames.forEachIndexed { index, userName ->

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/draft/DraftNote.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/draft/DraftNote.kt
@@ -60,6 +60,7 @@ sealed interface DraftNoteFile {
         val folderId: String?,
         val fileSize: Long?,
         val localFileId: Long,
+        val comment: String?
     ) : DraftNoteFile {
         companion object
     }
@@ -74,7 +75,8 @@ fun DraftNoteFile.Local.Companion.from(appFile: AppFile.Local, id: Long = 0L): D
         name = appFile.name,
         thumbnailUrl = appFile.thumbnailUrl,
         fileSize = appFile.fileSize,
-        localFileId = id
+        localFileId = id,
+        comment = appFile.comment,
     )
 }
 


### PR DESCRIPTION
## やったこと
ファイル名とalt(comment(caption))をノートの編集画面から編集できるようにしました。
ファイル一覧画面からファイル名を更新できるようにしました。
またそのためにcommentを下書きとして保存できるようにしました。
## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1159 
Closed #326 

