### PR TITLE
ユーザープロフィールに表示されるタイムラインの項目を変更しました

### DIFF
--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -408,5 +408,6 @@
 
     <string name="edit_caption">キャプションを編集</string>
     <string name="input_caption">キャプションを入力</string>
+    <string name="notes_and_replies">投稿と返信</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -408,5 +408,6 @@
 
     <string name="edit_caption">编辑标题</string>
     <string name="input_caption">输入标题</string>
+    <string name="notes_and_replies">帖子和回复</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <!--    <string name="create_folder">Create folder</string>-->
     <string name="add_account">Add account</string>
     <string name="post">Post</string>
+    <string name="notes_and_replies">Notes and replies</string>
     <string name="please_speak">What\'s on your mind?</string>
     <string name="open">Open</string>
     <string name="multiple_answer">Multiple answers</string>

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
@@ -446,7 +446,8 @@ class UserTimelinePagerAdapterV2(
             is UserDetailTabType.Media -> pageableFragmentFactory.create(Pageable.UserTimeline(tab.userId.id, withFiles = true))
             is UserDetailTabType.PinNote -> userPinnedNotesFragmentFactory.create(tab.userId)
             is UserDetailTabType.Reactions -> UserReactionsFragment.newInstance(tab.userId)
-            is UserDetailTabType.UserTimeline -> pageableFragmentFactory.create(Pageable.UserTimeline(tab.userId.id))
+            is UserDetailTabType.UserTimeline -> pageableFragmentFactory.create(Pageable.UserTimeline(tab.userId.id, includeReplies = false))
+            is UserDetailTabType.UserTimelineWithReplies -> pageableFragmentFactory.create(Pageable.UserTimeline(tab.userId.id, includeReplies = true))
         }
 
     }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
@@ -110,6 +110,7 @@ class UserDetailViewModel @AssistedInject constructor(
             ))
         listOfNotNull(
             UserDetailTabType.UserTimeline(user.id),
+            UserDetailTabType.UserTimelineWithReplies(user.id),
             UserDetailTabType.PinNote(user.id),
             UserDetailTabType.Media(user.id),
             if (isEnableGallery) UserDetailTabType.Gallery(
@@ -315,6 +316,7 @@ sealed class UserDetailTabType(
 ) {
 
     data class UserTimeline(val userId: User.Id) : UserDetailTabType(R.string.post)
+    data class UserTimelineWithReplies(val userId: User.Id) : UserDetailTabType(R.string.notes_and_replies)
     data class PinNote(val userId: User.Id) : UserDetailTabType(R.string.pin)
     data class Gallery(val userId: User.Id, val accountId: Long) :
         UserDetailTabType(R.string.gallery)


### PR DESCRIPTION
## やったこと
ユーザープロフィール画面に表示されているタイムラインの項目を変更と追加をしました。
具体的な変更は下記の通りになります。
投稿->リプライを含んだノートからリプライを除いたノートに変更
投稿と返信->リプライを含んだノートを追加

またこの変更に伴い新たに文字列リソースを追加しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1162


