### PR TITLE
検索画面にハッシュタグの候補を表示するようにしました

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
@@ -8,6 +8,7 @@ import net.pantasystem.milktea.api.misskey.auth.App
 import net.pantasystem.milktea.api.misskey.drive.*
 import net.pantasystem.milktea.api.misskey.favorite.Favorite
 import net.pantasystem.milktea.api.misskey.hashtag.RequestHashTagList
+import net.pantasystem.milktea.api.misskey.hashtag.SearchHashtagRequest
 import net.pantasystem.milktea.api.misskey.list.*
 import net.pantasystem.milktea.api.misskey.messaging.MessageAction
 import net.pantasystem.milktea.api.misskey.messaging.MessageDTO
@@ -259,4 +260,7 @@ interface MisskeyAPI {
 
     @POST("api/notes/thread-muting/delete")
     suspend fun deleteThreadMute(@Body req: ToggleThreadMuteRequest) : Response<Unit>
+
+    @POST("api/hashtags/search")
+    suspend fun searchHashtag(@Body req: SearchHashtagRequest) : Response<List<String>>
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/hashtag/SearchHashtagRequest.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/hashtag/SearchHashtagRequest.kt
@@ -1,0 +1,8 @@
+package net.pantasystem.milktea.api.misskey.hashtag
+
+@kotlinx.serialization.Serializable
+data class SearchHashtagRequest(
+    val query: String,
+    val limit: Int = 10,
+    val offset: Int = 0
+)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/HashtagModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/HashtagModule.kt
@@ -1,0 +1,18 @@
+package net.pantasystem.milktea.data.di.module
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import net.pantasystem.milktea.data.infrastructure.hashtag.HashtagRepositoryImpl
+import net.pantasystem.milktea.model.hashtag.HashtagRepository
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class HashtagBindModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindHashtagRepository(impl: HashtagRepositoryImpl): HashtagRepository
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/hashtag/HashtagRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/hashtag/HashtagRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package net.pantasystem.milktea.data.infrastructure.hashtag
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.pantasystem.milktea.api.misskey.hashtag.SearchHashtagRequest
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.common.throwIfHasError
+import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.model.hashtag.HashtagRepository
+import javax.inject.Inject
+
+class HashtagRepositoryImpl @Inject constructor(
+    val misskeyAPIProvider: MisskeyAPIProvider,
+): HashtagRepository {
+    override suspend fun search(baseUrl: String, query: String, limit: Int, offset: Int): Result<List<String>> = runCancellableCatching{
+        withContext(Dispatchers.IO) {
+
+            misskeyAPIProvider.get(baseUrl).searchHashtag(SearchHashtagRequest(
+                query = query,
+                limit = limit,
+                offset = offset
+            )).throwIfHasError().body() ?: emptyList()
+        }
+    }
+}

--- a/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchActivity.kt
+++ b/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchActivity.kt
@@ -8,10 +8,8 @@ import android.widget.SearchView
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import com.google.android.material.composethemeadapter.MdcTheme
 import com.wada811.databinding.dataBinding
@@ -20,8 +18,6 @@ import net.pantasystem.milktea.common.ui.ApplyTheme
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.search.databinding.ActivitySearchBinding
 import net.pantasystem.milktea.user.activity.UserDetailActivity
-import net.pantasystem.milktea.user.compose.SimpleUserListView
-import net.pantasystem.milktea.user.search.SearchUserViewModel
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -39,9 +35,9 @@ class SearchActivity : AppCompatActivity() {
 
     private var mSearchWord: String? = null
 
-    private val mSearchUserViewModel: SearchUserViewModel by viewModels()
-
     private val binding: ActivitySearchBinding by dataBinding()
+
+    private val searchViewModel: SearchViewModel by viewModels()
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -57,12 +53,11 @@ class SearchActivity : AppCompatActivity() {
 
         findViewById<ComposeView>(R.id.composeBase).setContent {
             MdcTheme {
-                val users by mSearchUserViewModel.users.collectAsState()
-                SimpleUserListView(
-                    users = users,
-                    onSelected = ::showUserDetail,
-                    modifier = Modifier.fillMaxSize()
-                )
+                val uiState by searchViewModel.uiState.collectAsState()
+
+                SearchResultLayout(uiState = uiState, onUserSelected = ::showUserDetail, onHashtagSelected = {
+                    showSearchResult("#$it")
+                })
             }
         }
 
@@ -73,7 +68,7 @@ class SearchActivity : AppCompatActivity() {
 
     }
 
-    fun showUserDetail(user: User) {
+    private fun showUserDetail(user: User) {
         startActivity(UserDetailActivity.newInstance(this, user.id))
     }
 
@@ -95,7 +90,7 @@ class SearchActivity : AppCompatActivity() {
 
     private val queryTextListener = object : SearchView.OnQueryTextListener{
         override fun onQueryTextChange(newText: String?): Boolean {
-            mSearchUserViewModel.setUserName(newText?: "")
+            searchViewModel.onInputKeyword(newText ?: "")
             return true
         }
 

--- a/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchActivity.kt
+++ b/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchActivity.kt
@@ -55,7 +55,7 @@ class SearchActivity : AppCompatActivity() {
             MdcTheme {
                 val uiState by searchViewModel.uiState.collectAsState()
 
-                SearchResultLayout(uiState = uiState, onUserSelected = ::showUserDetail, onHashtagSelected = {
+                SearchSuggestionsLayout(uiState = uiState, onUserSelected = ::showUserDetail, onHashtagSelected = {
                     showSearchResult("#$it")
                 })
             }

--- a/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultLayout.kt
+++ b/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultLayout.kt
@@ -18,7 +18,7 @@ import net.pantasystem.milktea.user.compose.ItemSimpleUserCard
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun SearchResultLayout(
+fun SearchSuggestionsLayout(
     modifier: Modifier = Modifier,
     uiState: SearchUiState,
     onUserSelected: (User) -> Unit,

--- a/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultLayout.kt
+++ b/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultLayout.kt
@@ -1,0 +1,44 @@
+package net.pantasystem.milktea.search
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Card
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.user.compose.ItemSimpleUserCard
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun SearchResultLayout(
+    modifier: Modifier = Modifier,
+    uiState: SearchUiState,
+    onUserSelected: (User) -> Unit,
+    onHashtagSelected: (String) -> Unit
+) {
+    LazyColumn(modifier = modifier.fillMaxSize()) {
+        items(uiState.hashtags) { hashtag ->
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    onHashtagSelected(hashtag)
+                }
+            ) {
+                Box(modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp)) {
+                    Text(text = "#$hashtag", fontSize = 20.sp)
+                }
+            }
+        }
+        items(uiState.users) { user ->
+            ItemSimpleUserCard(user = user, onSelected = onUserSelected)
+        }
+    }
+}

--- a/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchViewModel.kt
@@ -1,0 +1,118 @@
+package net.pantasystem.milktea.search
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.*
+import net.pantasystem.milktea.common.ResultState
+import net.pantasystem.milktea.common.StateContent
+import net.pantasystem.milktea.common.asLoadingStateFlow
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.account.CurrentAccountWatcher
+import net.pantasystem.milktea.model.hashtag.HashtagRepository
+import net.pantasystem.milktea.model.user.Acct
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.UserDataSource
+import net.pantasystem.milktea.model.user.UserRepository
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+    private val userDataSource: UserDataSource,
+    private val hashtagRepository: HashtagRepository,
+    val accountRepository: AccountRepository,
+    private val savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    val keyword = savedStateHandle.getStateFlow<String>("keyword", "")
+    private val currentAccountWatcher = CurrentAccountWatcher(null, accountRepository)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val hashtagResult = keyword.filter {
+        it.isHashTagFormat()
+    }.map {
+        it.substring(1, it.length)
+    }.flatMapLatest {
+        suspend {
+            hashtagRepository.search(
+                currentAccountWatcher.getAccount().normalizedInstanceDomain,
+                it
+            ).getOrThrow()
+        }.asLoadingStateFlow()
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        ResultState.Loading(StateContent.NotExist())
+    )
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val searchUserResult = keyword.filterNot {
+        it.isHashTagFormat()
+    }.flatMapLatest {
+        suspend {
+            userRepository.syncByUserName(
+                currentAccountWatcher.getAccount().accountId,
+                Acct(it).userName,
+                Acct(it).host
+            )
+            userRepository.searchByNameOrUserName(currentAccountWatcher.getAccount().accountId, it)
+        }.asLoadingStateFlow()
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        ResultState.Loading(StateContent.NotExist())
+    )
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val users = searchUserResult.map {
+        (it.content as? StateContent.Exist)?.rawContent ?: emptyList()
+    }.flatMapLatest { users ->
+        val ids = users.map { it.id.id }
+        userDataSource.observeIn(currentAccountWatcher.getAccount().accountId, ids)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val uiState = combine(
+        keyword,
+        hashtagResult,
+        searchUserResult,
+        users
+    ) { keyword, hashtags, searchUserResult, users ->
+        SearchUiState(
+            keyword,
+            (hashtags.content as? StateContent.Exist)?.rawContent ?: emptyList(),
+            users,
+            searchUserResult,
+            hashtags,
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        SearchUiState(
+            keyword.value,
+            emptyList(),
+            emptyList(),
+            searchUserResult.value,
+            hashtagResult.value
+        )
+    )
+
+    fun onInputKeyword(word: String) {
+        savedStateHandle["keyword"] = word
+    }
+
+}
+
+data class SearchUiState(
+    val keyword: String,
+    val hashtags: List<String>,
+    val users: List<User>,
+    val searchUserState: ResultState<List<User>>,
+    val hashtagsState: ResultState<List<String>>
+)
+
+private fun String.isHashTagFormat(): Boolean {
+    return startsWith("#") && length > 1
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/hashtag/HashtagRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/hashtag/HashtagRepository.kt
@@ -1,0 +1,5 @@
+package net.pantasystem.milktea.model.hashtag
+
+interface HashtagRepository {
+    suspend fun search(baseUrl: String, query: String, limit: Int = 10, offset: Int = 0): Result<List<String>>
+}


### PR DESCRIPTION
## やったこと
検索画面にハッシュタグの候補を表示するようにしました。
そのためにRetrofitにハッシュタグを検索するためのエンドポイントにリクエストを送信するためのメソッドと、
そのためのリクエストオブジェクトを作成しました。
またユーザーからの検索結果とハッシュタグの検索結果を表現するためのViewModel(SearchViewModel)を作成しました。
またそれらを表示するためのComposable関数(SearchSuggestionsLayout)を作成しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1163 


