### PR TITLE
最近使用したリアクションをリアクションピッカーに表示するようにしました

### DIFF
--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -410,5 +410,6 @@
     <string name="input_caption">キャプションを入力</string>
     <string name="notes_and_replies">投稿と返信</string>
     <string name="other">その他</string>
+    <string name="recently_used">最近使った</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -410,5 +410,6 @@
     <string name="input_caption">输入标题</string>
     <string name="notes_and_replies">帖子和回复</string>
     <string name="other">其他</string>
+    <string name="recently_used">最近使用</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -401,5 +401,6 @@
     <string name="edit_caption">Edit caption</string>
     <string name="input_caption">Input caption</string>
     <string name="other">Other</string>
+    <string name="recently_used">Recently used</string>
 
 </resources>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/history/ReactionHistoryDao.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/history/ReactionHistoryDao.kt
@@ -17,6 +17,9 @@ interface ReactionHistoryDao{
 
     @Query("select reaction, count(reaction) as reaction_count from reaction_history where instance_domain=:instanceDomain group by reaction order by reaction_count desc limit :limit")
     fun observeSumReactions(instanceDomain: String, limit: Int) : Flow<List<ReactionHistoryCountRecord>>
+    
+    @Query("select * from reaction_history where instance_domain=:instanceDomain order by id desc limit :limit")
+    fun observeRecentlyUsed(instanceDomain: String, limit: Int): Flow<List<ReactionHistoryRecord>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(reactionHistory: ReactionHistoryRecord)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/history/ReactionHistoryDao.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/history/ReactionHistoryDao.kt
@@ -17,7 +17,7 @@ interface ReactionHistoryDao{
 
     @Query("select reaction, count(reaction) as reaction_count from reaction_history where instance_domain=:instanceDomain group by reaction order by reaction_count desc limit :limit")
     fun observeSumReactions(instanceDomain: String, limit: Int) : Flow<List<ReactionHistoryCountRecord>>
-    
+
     @Query("select * from reaction_history where instance_domain=:instanceDomain order by id desc limit :limit")
     fun observeRecentlyUsed(instanceDomain: String, limit: Int): Flow<List<ReactionHistoryRecord>>
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/history/ReactionHistoryDao.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/history/ReactionHistoryDao.kt
@@ -10,15 +10,15 @@ import kotlinx.coroutines.flow.Flow
 interface ReactionHistoryDao{
 
     @Query("select * from reaction_history")
-    fun findAll() : List<ReactionHistoryRecord>?
+    suspend fun findAll() : List<ReactionHistoryRecord>?
 
     @Query("select reaction, count(reaction) as reaction_count from reaction_history where instance_domain=:instanceDomain group by reaction order by reaction_count desc limit :limit")
-    fun sumReactions(instanceDomain: String, limit: Int) : List<ReactionHistoryCountRecord>
+    suspend fun sumReactions(instanceDomain: String, limit: Int) : List<ReactionHistoryCountRecord>
 
     @Query("select reaction, count(reaction) as reaction_count from reaction_history where instance_domain=:instanceDomain group by reaction order by reaction_count desc limit :limit")
     fun observeSumReactions(instanceDomain: String, limit: Int) : Flow<List<ReactionHistoryCountRecord>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insert(reactionHistory: ReactionHistoryRecord)
+    suspend fun insert(reactionHistory: ReactionHistoryRecord)
 }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/history/ReactionHistoryRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/history/ReactionHistoryRepositoryImpl.kt
@@ -1,7 +1,9 @@
 package net.pantasystem.milktea.data.infrastructure.notes.reaction.impl.history
 
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import net.pantasystem.milktea.common.runCancellableCatching
@@ -44,5 +46,17 @@ class ReactionHistoryRepositoryImpl @Inject constructor(
                 it.toReactionHistoryCount()
             }
         }
+    }
+
+    override fun observeRecentlyUsedBy(instanceDomain: String, limit: Int): Flow<List<ReactionHistory>> {
+        return reactionHistoryDao.observeRecentlyUsed(instanceDomain, limit).map { records ->
+            records.map { history ->
+                ReactionHistory(
+                    instanceDomain = history.instanceDomain,
+                    reaction = history.reaction,
+                    id = history.id
+                )
+            }
+        }.flowOn(Dispatchers.IO)
     }
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/reaction/history/ReactionHistoryRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/reaction/history/ReactionHistoryRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 interface ReactionHistoryRepository {
     suspend fun create(reactionHistory: ReactionHistory): Result<Unit>
     fun observeSumReactions(instanceDomain: String, limit: Int = 50): Flow<List<ReactionHistoryCount>>
+    fun observeRecentlyUsedBy(instanceDomain: String, limit: Int = 20): Flow<List<ReactionHistory>>
     suspend fun sumReactions(instanceDomain: String, limit: Int = 50): List<ReactionHistoryCount>
     suspend fun findAll(): List<ReactionHistory>
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/reaction/history/ReactionHistoryRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/reaction/history/ReactionHistoryRepository.kt
@@ -4,8 +4,8 @@ import kotlinx.coroutines.flow.Flow
 
 interface ReactionHistoryRepository {
     suspend fun create(reactionHistory: ReactionHistory): Result<Unit>
-    fun observeSumReactions(instanceDomain: String, limit: Int = 50): Flow<List<ReactionHistoryCount>>
+    fun observeSumReactions(instanceDomain: String, limit: Int = 80): Flow<List<ReactionHistoryCount>>
     fun observeRecentlyUsedBy(instanceDomain: String, limit: Int = 20): Flow<List<ReactionHistory>>
-    suspend fun sumReactions(instanceDomain: String, limit: Int = 50): List<ReactionHistoryCount>
+    suspend fun sumReactions(instanceDomain: String, limit: Int = 80): List<ReactionHistoryCount>
     suspend fun findAll(): List<ReactionHistory>
 }


### PR DESCRIPTION
## やったこと
最近使用したリアクションをリアクションピッカーに表示するようにしました。
ReactionHistoryDaoに最近使用したリアクションを取得できるようにし、
ReactionHistoryRepository経由で実装を抽象化するようにしました。
それをViewModelで取得しUIに反映できるようにしました。
またCoroutines Flowのcombineの特性上6個より多くのFlowを束ねることはできないので、
一度任意のdata classにまとめてそれを再度別のdata classにまとめるようにしました。

またよく使用するリアクションの件数を80件まで表示するようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1174 


