### PR TITLE
検索画面のユーザ一覧でカスタム絵文字が表示されない不具合を修正

### DIFF
--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/simple_users.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/simple_users.kt
@@ -74,7 +74,13 @@ fun ItemSimpleUserCard(
             )
             Spacer(modifier = Modifier.width(4.dp))
             Column {
-                CustomEmojiText(text = user.displayName, emojis = user.emojis, accountHost = accountHost)
+                CustomEmojiText(
+                    text = user.displayName,
+                    emojis = user.emojis,
+                    accountHost = accountHost,
+                    sourceHost = user.host,
+                    parsedResult = user.parsedResult,
+                )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(text = user.displayUserName)
             }
@@ -99,5 +105,6 @@ fun PreviewItemSimpleUser() {
         isSameHost = true,
         instance = null,
         avatarBlurhash = null,
-    ), onSelected = {}, accountHost = "misskey.io")
+    ), onSelected = {}, accountHost = "misskey.io"
+    )
 }


### PR DESCRIPTION
## やったこと
必要な引数を渡し忘れていたため、
うまくパースされず表示されないことがわかりました。
引数(投稿元のホスト)を渡すことで解決しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1185

