### PR TITLE
Misskey v13で特定のカスタム絵文字が表示されない不具合を修正

### DIFF
--- a/modules/common/build.gradle
+++ b/modules/common/build.gradle
@@ -68,8 +68,8 @@ dependencies {
 
 
     //glide
-    implementation 'com.github.bumptech.glide:glide:4.12.0'
-    kapt 'com.github.bumptech.glide:compiler:4.13.2'
+    implementation libs.glide.glide
+    kapt libs.glide.compiler
     implementation "com.google.accompanist:accompanist-glide:0.14.0"
     implementation 'com.github.penfeizhou.android.animation:apng:2.23.0'
     implementation 'com.caverock:androidsvg-aar:1.4'

--- a/modules/common_android/build.gradle
+++ b/modules/common_android/build.gradle
@@ -66,9 +66,9 @@ dependencies {
 
     implementation libs.flexbox
 
+    implementation libs.glide.glide
     //glide
-    implementation 'com.github.bumptech.glide:glide:4.12.0'
-    kapt 'com.github.bumptech.glide:compiler:4.13.2'
+    kapt libs.glide.compiler
     implementation "com.google.accompanist:accompanist-glide:0.14.0"
     implementation 'com.github.penfeizhou.android.animation:apng:2.23.0'
     implementation 'com.caverock:androidsvg-aar:1.4'

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DrawableEmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DrawableEmojiSpan.kt
@@ -1,7 +1,9 @@
 package net.pantasystem.milktea.common_android.ui.text
 
 
+import android.graphics.drawable.AnimatedImageDrawable
 import android.graphics.drawable.Drawable
+import android.os.Build
 import com.bumptech.glide.load.resource.gif.GifDrawable
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
@@ -46,7 +48,13 @@ class DrawableEmojiSpan(adapter: EmojiAdapter) : EmojiSpan<Drawable>(adapter){
                     resource.start()
                 }
                 else -> {
-                    adapter.update()
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        if (resource is AnimatedImageDrawable) {
+                            resource.start()
+                        }
+                    } else {
+                        adapter.update()
+                    }
                 }
             }
         }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
@@ -11,10 +11,10 @@ import android.text.style.*
 import android.util.Log
 import android.view.View
 import android.widget.TextView
-import com.bumptech.glide.Glide
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.internal.managers.FragmentComponentManager
 import jp.panta.misskeyandroidclient.mfm.*
+import net.pantasystem.milktea.common.glide.GlideApp
 import net.pantasystem.milktea.common_android.R
 import net.pantasystem.milktea.common_android.ui.Activities
 import net.pantasystem.milktea.common_android.ui.putActivity
@@ -105,8 +105,7 @@ object MFMDecorator {
                 //val emojiSpan = EmojiSpan(textView)
                 val emojiSpan: EmojiSpan<*>
                 emojiSpan = DrawableEmojiSpan(emojiAdapter)
-                Glide.with(textView)
-                    .asDrawable()
+                GlideApp.with(textView)
                     .load(emojiElement.emoji.url)
                     .override(textView.textSize.toInt())
                     .into(emojiSpan.target)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/emojis/EmojiHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/emojis/EmojiHelper.kt
@@ -12,7 +12,9 @@ object EmojiHelper{
     fun ImageView.setEmojiImage(customEmoji: Emoji){
         GlideApp.with(this.context)
             .load(customEmoji.url?: customEmoji.uri)
-            .centerCrop()
+                // FIXME: リダイレクトが発生する場合にcenterCropを使用すると不具合が発生する
+                // https://github.com/bumptech/glide/issues/4652
+//            .centerCrop()
             .into(this)
     }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/emojis/EmojiHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/emojis/EmojiHelper.kt
@@ -12,8 +12,7 @@ object EmojiHelper{
     fun ImageView.setEmojiImage(customEmoji: Emoji){
         GlideApp.with(this.context)
             .load(customEmoji.url?: customEmoji.uri)
-                // FIXME: リダイレクトが発生する場合にcenterCropを使用すると不具合が発生する
-                // https://github.com/bumptech/glide/issues/4652
+                // FIXME: webpの場合うまく表示できなくなる
 //            .centerCrop()
             .into(this)
     }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
@@ -70,7 +70,8 @@ object NoteReactionViewHelper {
 
             GlideApp.with(reactionImageTypeView.context)
                 .load(emoji.url ?: emoji.uri)
-                .fitCenter()
+                // FIXME: webpの場合エラーが発生してうまく表示できなくなってしまう
+//                .fitCenter()
                 .into(reactionImageTypeView)
         }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiChoicesAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiChoicesAdapter.kt
@@ -48,8 +48,7 @@ class EmojiChoicesAdapter(
             is EmojiType.CustomEmoji -> {
                 GlideApp.with(holder.binding.reactionImagePreview)
                     .load(item.emoji.url ?: item.emoji.uri)
-                        // FIXME: リダイレクトが発生する場合にcenterCropを使用すると不具合が発生する
-                        // https://github.com/bumptech/glide/issues/4652
+                        // FIXME: webpの場合うまく表示できなくなる
 //                    .centerCrop()
                     .into(holder.binding.reactionImagePreview)
                 holder.binding.reactionStringPreview.isVisible = false

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiChoicesAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiChoicesAdapter.kt
@@ -48,7 +48,9 @@ class EmojiChoicesAdapter(
             is EmojiType.CustomEmoji -> {
                 GlideApp.with(holder.binding.reactionImagePreview)
                     .load(item.emoji.url ?: item.emoji.uri)
-                    .centerCrop()
+                        // FIXME: リダイレクトが発生する場合にcenterCropを使用すると不具合が発生する
+                        // https://github.com/bumptech/glide/issues/4652
+//                    .centerCrop()
                     .into(holder.binding.reactionImagePreview)
                 holder.binding.reactionStringPreview.isVisible = false
                 holder.binding.reactionImagePreview.isVisible = true

--- a/settings.gradle
+++ b/settings.gradle
@@ -43,8 +43,8 @@ dependencyResolutionManagement {
             bundle('lifecycle', ['lifecycle-extenstions', 'lifecycle-viewmodel'])
 
 
-            library('glide-glide', 'com.github.bumptech.glide:glide:4.12.0')
-            library('glide-compiler', 'com.github.bumptech.glide:compiler:4.13.2')
+            library('glide-glide', 'com.github.bumptech.glide:glide:4.14.2')
+            library('glide-compiler', 'com.github.bumptech.glide:compiler:4.14.2')
             library('accompanist-glide', 'com.google.accompanist:accompanist-glide:0.14.0')
             library('animation-apng', 'com.github.penfeizhou.android.animation:apng:2.23.0')
 


### PR DESCRIPTION
## やったこと
Misskey v13で特定のカスタム絵文字が表示されない不具合を修正しました。
ただしGlideを更新したところ別の問題が発生するようになったので、
centerCrop等のコードを削除し、FIXMEコメントを追加しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1187 

