### PR TITLE
ノートのウォッチが削除された状態でも機能するようにしました

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteStateResponse.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteStateResponse.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class NoteStateResponse(
     val isFavorited: Boolean,
-    val isWatching: Boolean,
+    val isWatching: Boolean? = null,
     val isMutedThread: Boolean? = null,
 )

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -326,7 +326,10 @@ class NoteRepositoryImpl @Inject constructor(
                 NoteState(
                     isFavorited = it.isFavorited,
                     isMutedThread = it.isMutedThread,
-                    isWatching = it.isWatching
+                    isWatching = when(val watching = it.isWatching) {
+                        null -> NoteState.Watching.None
+                        else -> NoteState.Watching.Some(watching)
+                    }
                 )
             }
         }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteState.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteState.kt
@@ -9,8 +9,20 @@ data class NoteState(
     val isWatching: Watching,
     val isMutedThread: Boolean?
 ) {
+
+    /**
+     * isWatchingの状態を3値で表現する必要が出てきたため、sealed interfaceで表現している。
+     */
     sealed interface Watching {
+        /**
+         * APIから削除された状態で、JSONのフィールド上に存在しない。
+         */
         object None : Watching
+
+        /**
+         * API上にまだ存在している状態で、JSONのフィールド上に存在する。
+         * またその結果が isWatching に格納される。
+         */
         data class Some(val isWatching: Boolean) : Watching
     }
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteState.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteState.kt
@@ -1,7 +1,16 @@
 package net.pantasystem.milktea.model.notes
 
+/**
+ * お気に入りやスレッドのミュートの状態を表す。
+ * v13でノートのウォッチ機能が削除されたため、isWatchingのフィールドも無効(None)になる。
+ */
 data class NoteState(
     val isFavorited: Boolean,
-    val isWatching: Boolean,
+    val isWatching: Watching,
     val isMutedThread: Boolean?
-)
+) {
+    sealed interface Watching {
+        object None : Watching
+        data class Some(val isWatching: Boolean) : Watching
+    }
+}


### PR DESCRIPTION
## やったこと
isWatchingのフィールドが削除され
ノートの状態をうまくJSONデコードできなくなってしまっていたため
関連する機能(お気に入りの追加と削除、スレッドのミュートと解除)が機能しない状態になっていました。
そこでisWatchingのフィールドを３値で表現するようにし、
フィールドが存在しない状態と、フィールドが存在していてかつそのフィールドの状態を表現できるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1190


