### PR TITLE
最近したリアクションが重複しないようにした

### DIFF
--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/history/ReactionHistoryDao.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/history/ReactionHistoryDao.kt
@@ -7,18 +7,30 @@ import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
 
 @Dao
-interface ReactionHistoryDao{
+interface ReactionHistoryDao {
 
     @Query("select * from reaction_history")
-    suspend fun findAll() : List<ReactionHistoryRecord>?
+    suspend fun findAll(): List<ReactionHistoryRecord>?
 
     @Query("select reaction, count(reaction) as reaction_count from reaction_history where instance_domain=:instanceDomain group by reaction order by reaction_count desc limit :limit")
-    suspend fun sumReactions(instanceDomain: String, limit: Int) : List<ReactionHistoryCountRecord>
+    suspend fun sumReactions(instanceDomain: String, limit: Int): List<ReactionHistoryCountRecord>
 
     @Query("select reaction, count(reaction) as reaction_count from reaction_history where instance_domain=:instanceDomain group by reaction order by reaction_count desc limit :limit")
-    fun observeSumReactions(instanceDomain: String, limit: Int) : Flow<List<ReactionHistoryCountRecord>>
+    fun observeSumReactions(
+        instanceDomain: String,
+        limit: Int
+    ): Flow<List<ReactionHistoryCountRecord>>
 
-    @Query("select * from reaction_history where instance_domain=:instanceDomain order by id desc limit :limit")
+    @Query("""
+        select * from reaction_history as r1 
+            where exists(
+                select 1 from(
+                    select max(id) as id from reaction_history 
+                        where instance_domain = :instanceDomain group by reaction, instance_domain
+                ) r2 where r1.id = r2.id
+            ) 
+        order by id desc limit :limit
+    """)
     fun observeRecentlyUsed(instanceDomain: String, limit: Int): Flow<List<ReactionHistoryRecord>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)


### PR DESCRIPTION
## やったこと
重複レコードを排除して、最近リアクションが重複しないようにしました。
また重複(reaction, instance_domain)を排除するときに、最新のレコードを優先して残すようにしました。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1194 


