### PR TITLE
リアクションピッカーの絵文字検索時の並び順を一致度順でソートするようにしました

### DIFF
--- a/modules/common/src/main/java/net/pantasystem/milktea/common/text/Levenshtein.kt
+++ b/modules/common/src/main/java/net/pantasystem/milktea/common/text/Levenshtein.kt
@@ -1,0 +1,25 @@
+package net.pantasystem.milktea.common.text
+
+import kotlin.math.min
+
+object LevenshteinDistance {
+    operator fun invoke(s1: String, s2: String): Int {
+        val dp = Array(s1.length + 1) { IntArray(s2.length + 1) }
+
+        for (i in 0..s1.length) {
+            for (j in 0..s2.length) {
+                if (i == 0) {
+                    dp[i][j] = j
+                } else if (j == 0) {
+                    dp[i][j] = i
+                } else {
+                    dp[i][j] = min(
+                        dp[i - 1][j - 1] + (if (s1[i - 1] == s2[j - 1]) 0 else 1),
+                        min(dp[i - 1][j], dp[i][j - 1]) + 1
+                    )
+                }
+            }
+        }
+        return dp[s1.length][s2.length]
+    }
+}

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/ReactionChoicesViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/ReactionChoicesViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import net.pantasystem.milktea.app_store.account.AccountStore
+import net.pantasystem.milktea.common.text.LevenshteinDistance
 import net.pantasystem.milktea.common_android.resource.StringSource
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.emoji.Emoji
@@ -190,6 +191,8 @@ data class ReactionSelectionUiState(
 
     val searchFilteredEmojis = meta?.emojis?.filterEmojiBy(keyword)?.map {
         EmojiType.CustomEmoji(it)
+    }?.sortedBy {
+        LevenshteinDistance(it.emoji.name, keyword)
     } ?: emptyList()
 }
 


### PR DESCRIPTION
## やったこと
リアクションピッカーの絵文字の検索結果の並び順を一致度順でソートするようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考
一致度検知のアルゴリズムがマルチバイト文字を考慮しているのか怪しい

## Issue番号
Closed #1200 


