### PR TITLE
絵文字候補に表示されるカスタム絵文字が表示されない不具合を修正

### DIFF
--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/ReactionViewHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/ReactionViewHelper.kt
@@ -84,7 +84,6 @@ object ReactionViewHelper {
                 //Log.d("ReactionViewHelper", "カスタム絵文字を発見した: ${emoji}")
                 GlideApp.with(reactionImageView.context)
                     .load(emoji.url ?: emoji.uri)
-                    .centerCrop()
                     .into(reactionImageView)
                 reactionImageView.visibility = View.VISIBLE
                 reactionStringView.visibility = View.GONE
@@ -92,7 +91,7 @@ object ReactionViewHelper {
             } else {
                 Log.d("ReactionViewHelper", "emoji not found")
                 reactionImageView.visibility = View.GONE
-                reactionStringView.visibility = View.GONE
+                reactionStringView.visibility = View.VISIBLE
             }
 
         }


### PR DESCRIPTION
## やったこと
webpを表示時にcropするとうまく表示できない不具合がGlideにあるので、
cropしないようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1214 



