### PR TITLE
Misskey ioでファイルアップロードに失敗する不具合を修正

### DIFF
--- a/modules/data/build.gradle
+++ b/modules/data/build.gradle
@@ -111,6 +111,7 @@ dependencies {
 
     testImplementation libs.junit.jupiter.api
     testRuntimeOnly libs.junit.jupiter.engine
+    implementation "androidx.exifinterface:exifinterface:1.3.5"
 }
 
 kapt {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/InputStreamRequestBody.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/InputStreamRequestBody.kt
@@ -1,0 +1,23 @@
+package net.pantasystem.milktea.data.infrastructure.drive
+
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody
+import okio.BufferedSink
+import okio.source
+import java.io.InputStream
+
+internal class InputStreamRequestBody(
+    val type: String,
+    val inputStream: InputStream,
+) : RequestBody() {
+    override fun contentType(): MediaType {
+        return type.toMediaType()
+    }
+
+    override fun writeTo(sink: BufferedSink) {
+        inputStream.source().use {
+            sink.writeAll(it)
+        }
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/OkHttpDriveFileUploader.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/OkHttpDriveFileUploader.kt
@@ -1,12 +1,8 @@
 package net.pantasystem.milktea.data.infrastructure.drive
 
 import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.graphics.Matrix
 import android.net.Uri
 import android.util.Log
-import androidx.exifinterface.media.ExifInterface
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import net.pantasystem.milktea.api.misskey.OkHttpClientProvider
@@ -14,10 +10,10 @@ import net.pantasystem.milktea.api.misskey.drive.FilePropertyDTO
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.drive.FileProperty
 import net.pantasystem.milktea.model.file.AppFile
-import okhttp3.*
-import okhttp3.MediaType.Companion.toMediaType
-import okio.BufferedSink
-import okio.source
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
 import java.io.InputStream
 import java.net.URL
 import java.util.concurrent.TimeUnit
@@ -173,89 +169,4 @@ class OkHttpDriveFileUploader(
 
 }
 
-private class UriRequestBody(
-    val uri: Uri,
-    val context: Context,
-) : RequestBody() {
-    override fun contentType(): MediaType? {
-        val type = context.contentResolver.getType(uri)
-        return type?.toMediaType()
-    }
 
-
-    override fun writeTo(sink: BufferedSink) {
-        context.contentResolver.openInputStream(uri)?.use { inputStream ->
-
-            val type = context.contentResolver.getType(uri)
-            if (type?.startsWith("image") == true
-                && (type.split("/").getOrNull(1)?.let {
-                    it == "jpeg" || it == "jpg"
-                } == true)
-            ) {
-
-                val bitmap =
-                    rotateImageIfRequired(BitmapFactory.decodeStream(inputStream), uri)
-                bitmap.compress(Bitmap.CompressFormat.JPEG, 100, sink.outputStream())
-
-            } else {
-                sink.writeAll(inputStream.source())
-            }
-        }
-    }
-
-    /**
-     * 与えられたBitmapを元ファイルのExif情報を元に回転させる処理
-     */
-    private fun rotateImageIfRequired(bitmap: Bitmap, uri: Uri): Bitmap {
-        context.contentResolver.openFileDescriptor(uri, "r").use {
-            val fileDescriptor = it!!.fileDescriptor
-            val exif = ExifInterface(fileDescriptor)
-
-            Log.d(
-                "OkHttpFileUploader", "回転情報: ${
-                    exif.getAttributeInt(
-                        ExifInterface.TAG_ORIENTATION,
-                        ExifInterface.ORIENTATION_NORMAL
-                    )
-                }"
-            )
-            return when (exif.getAttributeInt(
-                ExifInterface.TAG_ORIENTATION,
-                ExifInterface.ORIENTATION_NORMAL
-            )) {
-                ExifInterface.ORIENTATION_ROTATE_90 -> rotateImage(bitmap, 90)
-                ExifInterface.ORIENTATION_ROTATE_180 -> rotateImage(bitmap, 180)
-                ExifInterface.ORIENTATION_ROTATE_270 -> rotateImage(bitmap, 270)
-                else -> bitmap
-            }
-        }
-
-
-    }
-
-    /**
-     * 回転状態に基づきBitmapを回転させる
-     */
-    private fun rotateImage(bitmap: Bitmap, degree: Int): Bitmap {
-        val matrix = Matrix()
-        matrix.postRotate(degree.toFloat())
-        val rotated = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
-        bitmap.recycle()
-        return rotated
-    }
-}
-
-private class InputStreamRequestBody(
-    val type: String,
-    val inputStream: InputStream,
-) : RequestBody() {
-    override fun contentType(): MediaType {
-        return type.toMediaType()
-    }
-
-    override fun writeTo(sink: BufferedSink) {
-        inputStream.source().use {
-            sink.writeAll(it)
-        }
-    }
-}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/UriRequestBody.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/UriRequestBody.kt
@@ -5,7 +5,6 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.net.Uri
-import android.util.Log
 import androidx.exifinterface.media.ExifInterface
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/UriRequestBody.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/UriRequestBody.kt
@@ -1,0 +1,79 @@
+package net.pantasystem.milktea.data.infrastructure.drive
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.net.Uri
+import android.util.Log
+import androidx.exifinterface.media.ExifInterface
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody
+import okio.BufferedSink
+import okio.source
+
+
+internal class UriRequestBody(
+    val uri: Uri,
+    val context: Context,
+) : RequestBody() {
+    override fun contentType(): MediaType? {
+        val type = context.contentResolver.getType(uri)
+        return type?.toMediaType()
+    }
+
+
+    override fun writeTo(sink: BufferedSink) {
+        context.contentResolver.openInputStream(uri)?.use { inputStream ->
+
+            val type = context.contentResolver.getType(uri)
+            if (type?.startsWith("image") == true
+                && (type.split("/").getOrNull(1)?.let {
+                    it == "jpeg" || it == "jpg"
+                } == true)
+            ) {
+
+                val bitmap =
+                    rotateImageIfRequired(BitmapFactory.decodeStream(inputStream), uri)
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 100, sink.outputStream())
+
+            } else {
+                sink.writeAll(inputStream.source())
+            }
+        }
+    }
+
+    /**
+     * 与えられたBitmapを元ファイルのExif情報を元に回転させる処理
+     */
+    private fun rotateImageIfRequired(bitmap: Bitmap, uri: Uri): Bitmap {
+        context.contentResolver.openFileDescriptor(uri, "r").use {
+            val fileDescriptor = it!!.fileDescriptor
+            val exif = ExifInterface(fileDescriptor)
+
+            return when (exif.getAttributeInt(
+                ExifInterface.TAG_ORIENTATION,
+                ExifInterface.ORIENTATION_NORMAL
+            )) {
+                ExifInterface.ORIENTATION_ROTATE_90 -> rotateImage(bitmap, 90)
+                ExifInterface.ORIENTATION_ROTATE_180 -> rotateImage(bitmap, 180)
+                ExifInterface.ORIENTATION_ROTATE_270 -> rotateImage(bitmap, 270)
+                else -> bitmap
+            }
+        }
+
+
+    }
+
+    /**
+     * 回転状態に基づきBitmapを回転させる
+     */
+    private fun rotateImage(bitmap: Bitmap, degree: Int): Bitmap {
+        val matrix = Matrix()
+        matrix.postRotate(degree.toFloat())
+        val rotated = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+        bitmap.recycle()
+        return rotated
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/UriRequestBody.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/UriRequestBody.kt
@@ -36,6 +36,7 @@ internal class UriRequestBody(
                 val bitmap =
                     rotateImageIfRequired(BitmapFactory.decodeStream(inputStream), uri)
                 bitmap.compress(Bitmap.CompressFormat.JPEG, 100, sink.outputStream())
+                bitmap.recycle()
 
             } else {
                 sink.writeAll(inputStream.source())


### PR DESCRIPTION
## やったこと
Misskey ioでファイルアップロードに失敗する不具合を修正しました。
修正前に調査したところ、失敗するパターンとしてExif情報が含まれるJPEGファイルのアップロードをしようとすると
Cloudflareに弾かれてしまいアップロードに失敗することが発覚しました。
そこでアップロード前にファイル種別がJPEGであれば、Bitmapに変換しExif情報を削除するようにしました。
また全Exif情報を削除してしまうと回転情報が失われてしまうので、Exif情報の回転情報を元に
Bitmapを回転させるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1228 



