### PR TITLE
ユーザーのミュートとブロック機能を実装しました

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -118,7 +118,7 @@ interface MastodonAPI {
     @POST("api/v1/accounts/{accountId}/block")
     suspend fun blockAccount(@Path("accountId") accountId: String): Response<MastodonAccountRelationshipDTO>
 
-    @POST("api/v1/accounts/{accountId/unblock")
+    @POST("api/v1/accounts/{accountId}/unblock")
     suspend fun unblockAccount(@Path("accountId") accountId: String): Response<MastodonAccountRelationshipDTO>
 
 

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -2,6 +2,7 @@ package net.pantasystem.milktea.api.mastodon
 
 import net.pantasystem.milktea.api.mastodon.accounts.MastodonAccountDTO
 import net.pantasystem.milktea.api.mastodon.accounts.MastodonAccountRelationshipDTO
+import net.pantasystem.milktea.api.mastodon.accounts.MuteAccountRequest
 import net.pantasystem.milktea.api.mastodon.apps.AccessToken
 import net.pantasystem.milktea.api.mastodon.apps.App
 import net.pantasystem.milktea.api.mastodon.apps.CreateApp
@@ -107,5 +108,13 @@ interface MastodonAPI {
         @Query("min_id") minId: String? = null,
         @Query("max_id") maxId: String? = null
     ): Response<List<TootStatusDTO>>
+
+    @POST("api/v1/accounts/{accountId}/mute")
+    suspend fun muteAccount(@Path("accountId") accountId: String, @Body body: MuteAccountRequest): Response<MastodonAccountRelationshipDTO>
+
+    @POST("api/v1/accounts/{accountId}/unmute")
+    suspend fun unmuteAccount(@Path("accountId") accountId: String): Response<MastodonAccountRelationshipDTO>
+
+
 
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -115,6 +115,12 @@ interface MastodonAPI {
     @POST("api/v1/accounts/{accountId}/unmute")
     suspend fun unmuteAccount(@Path("accountId") accountId: String): Response<MastodonAccountRelationshipDTO>
 
+    @POST("api/v1/accounts/{accountId}/block")
+    suspend fun blockAccount(@Path("accountId") accountId: String): Response<MastodonAccountRelationshipDTO>
+
+    @POST("api/v1/accounts/{accountId/unblock")
+    suspend fun unblockAccount(@Path("accountId") accountId: String): Response<MastodonAccountRelationshipDTO>
+
 
 
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/accounts/MuteAccountRequest.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/accounts/MuteAccountRequest.kt
@@ -1,5 +1,6 @@
 package net.pantasystem.milktea.api.mastodon.accounts
 
+@kotlinx.serialization.Serializable
 data class MuteAccountRequest(
     val duration: Long = 0L,
     val notifications: Boolean = true

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/accounts/MuteAccountRequest.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/accounts/MuteAccountRequest.kt
@@ -1,0 +1,6 @@
+package net.pantasystem.milktea.api.mastodon.accounts
+
+data class MuteAccountRequest(
+    val duration: Long = 0L,
+    val notifications: Boolean = true
+)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
@@ -1,5 +1,9 @@
 package net.pantasystem.milktea.data.infrastructure.user
 
+import kotlinx.datetime.Clock
+import net.pantasystem.milktea.api.mastodon.accounts.MastodonAccountRelationshipDTO
+import net.pantasystem.milktea.api.mastodon.accounts.MuteAccountRequest
+import net.pantasystem.milktea.api.misskey.users.CreateMuteUserRequest
 import net.pantasystem.milktea.api.misskey.users.RequestUser
 import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
@@ -9,6 +13,7 @@ import net.pantasystem.milktea.data.infrastructure.toUserRelated
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.mute.CreateMute
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -76,4 +81,40 @@ class UserApiAdapter @Inject constructor(
                 .isSuccessful
         }
     }
+
+    suspend fun muteUser(createMute: CreateMute): MuteUserResult {
+        val account = accountRepository.get(createMute.userId.accountId).getOrThrow()
+        return when(account.instanceType) {
+            Account.InstanceType.MISSKEY -> {
+                require(createMute.notifications == null) {
+                    "Misskey does not support notifications mute account parameter"
+                }
+                misskeyAPIProvider.get(account).muteUser(
+                    CreateMuteUserRequest(
+                        i = account.token,
+                        userId = createMute.userId.id,
+                        expiresAt = createMute.expiresAt?.toEpochMilliseconds()
+                    )
+                ).throwIfHasError()
+                MuteUserResult.Misskey
+            }
+            Account.InstanceType.MASTODON -> {
+                val body = mastodonAPIProvider.get(account).muteAccount(
+                    createMute.userId.id,
+                    MuteAccountRequest(
+                        duration = createMute.expiresAt?.let {
+                            Clock.System.now().epochSeconds - it.epochSeconds
+                        } ?: 0,
+                        notifications = createMute.notifications ?: true
+                    )
+                ).throwIfHasError().body()
+                MuteUserResult.Mastodon(requireNotNull(body))
+            }
+        }
+    }
+}
+
+sealed interface MuteUserResult {
+    object Misskey : MuteUserResult
+    data class Mastodon(val relationship: MastodonAccountRelationshipDTO) : MuteUserResult
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/mute/CreateMute.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/mute/CreateMute.kt
@@ -3,7 +3,13 @@ package net.pantasystem.milktea.model.user.mute
 import kotlinx.datetime.Instant
 import net.pantasystem.milktea.model.user.User
 
+/**
+ * @param userId ミュートする対象のUserのId
+ * @param expiresAt ミュートの期限
+ * @param notifications Mastodonのためのパラメータで、ミュートしたユーザからの通知の有無を指定できる
+ */
 data class CreateMute(
     val userId: User.Id,
     val expiresAt: Instant? = null,
+    val notifications: Boolean? = null
 )


### PR DESCRIPTION
## やったこと
Msatodonのミュートとブロック機能を実装しました。

## 動作確認
- [x] Misskeyのミュートとブロック機能が動作することを確認
- [x] Mastodonでミュートとブロック機能が動作することを確認

## スクリーンショット(任意)


## 備考
Mastodonにはミュート時にそのユーザの通知までミュートするかしないかを決定することができますが、
UI上ではまだ実装していません。

## Issue番号
Closed #1264 
Closed #1265 


