### PR TITLE
Mastodonのテキストを表示できるようにした

### DIFF
--- a/app/src/test/java/jp/panta/misskeyandroidclient/mfm/MFMParserTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/mfm/MFMParserTest.kt
@@ -1,5 +1,6 @@
 package jp.panta.misskeyandroidclient.mfm
 
+import net.pantasystem.milktea.common_android.mfm.ElementType
 import net.pantasystem.milktea.common_android.mfm.MFMParser
 import net.pantasystem.milktea.model.emoji.Emoji
 import org.junit.jupiter.api.Assertions

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/TootStatusDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/TootStatusDTO.kt
@@ -7,6 +7,7 @@ import net.pantasystem.milktea.api.mastodon.emojis.TootEmojiDTO
 import net.pantasystem.milktea.api.mastodon.media.TootMediaAttachment
 import net.pantasystem.milktea.api.mastodon.poll.TootPollDTO
 import net.pantasystem.milktea.model.emoji.Emoji
+import net.pantasystem.milktea.model.notes.Note
 
 @kotlinx.serialization.Serializable
 data class TootStatusDTO(
@@ -48,13 +49,29 @@ data class TootStatusDTO(
         val username: String,
         val url: String,
         val acct: String,
-    )
+    ) {
+        fun toModel(): Note.Type.Mastodon.Mention {
+            return Note.Type.Mastodon.Mention(
+                id = id,
+                username = username,
+                url = url,
+                acct = acct
+            )
+        }
+    }
 
     @kotlinx.serialization.Serializable
     data class Tag(
         val name: String,
         val url: String,
-    )
+    ) {
+        fun toModel(): Note.Type.Mastodon.Tag {
+            return Note.Type.Mastodon.Tag(
+                name = name,
+                url = url,
+            )
+        }
+    }
 
 
     @kotlinx.serialization.Serializable

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/TextType.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/TextType.kt
@@ -1,0 +1,44 @@
+package net.pantasystem.milktea.common_android
+
+import androidx.core.text.HtmlCompat
+import jp.panta.misskeyandroidclient.mfm.Root
+import net.pantasystem.milktea.common_android.html.MastodonHTML
+import net.pantasystem.milktea.common_android.html.MastodonHTMLParser
+import net.pantasystem.milktea.common_android.mfm.MFMParser
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.emoji.Emoji
+import net.pantasystem.milktea.model.notes.NoteRelation
+
+sealed interface TextType {
+    data class Misskey(val root: Root?) : TextType
+    data class Mastodon(val html: MastodonHTML) : TextType
+}
+
+fun getTextType(account: Account, note: NoteRelation, instanceEmojis: List<Emoji>): TextType? {
+    return when (account.instanceType) {
+        Account.InstanceType.MISSKEY -> {
+            note.note.text?.let {
+                TextType.Misskey(
+                    MFMParser.parse(
+                        note.note.text, (note.note.emojis ?: emptyList()) + instanceEmojis,
+                        userHost = note.user
+                            .host,
+                        accountHost = account.getHost()
+                    )
+                )
+            }
+        }
+        Account.InstanceType.MASTODON -> {
+            note.note.text?.let {
+                TextType.Mastodon(
+                    MastodonHTMLParser.parse(
+                        it, note.note.emojis ?: emptyList(), userHost = note.user
+                            .host,
+                        accountHost = account.getHost()
+                    )
+                )
+            }
+        }
+    }
+
+}

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/TextType.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/TextType.kt
@@ -1,17 +1,21 @@
 package net.pantasystem.milktea.common_android
 
-import androidx.core.text.HtmlCompat
 import jp.panta.misskeyandroidclient.mfm.Root
 import net.pantasystem.milktea.common_android.html.MastodonHTML
 import net.pantasystem.milktea.common_android.html.MastodonHTMLParser
 import net.pantasystem.milktea.common_android.mfm.MFMParser
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.emoji.Emoji
+import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.NoteRelation
 
 sealed interface TextType {
     data class Misskey(val root: Root?) : TextType
-    data class Mastodon(val html: MastodonHTML) : TextType
+    data class Mastodon(
+        val html: MastodonHTML,
+        val mentions: List<Note.Type.Mastodon.Mention>,
+        val tags: List<Note.Type.Mastodon.Tag>
+    ) : TextType
 }
 
 fun getTextType(account: Account, note: NoteRelation, instanceEmojis: List<Emoji>): TextType? {
@@ -30,12 +34,15 @@ fun getTextType(account: Account, note: NoteRelation, instanceEmojis: List<Emoji
         }
         Account.InstanceType.MASTODON -> {
             note.note.text?.let {
+                val option = note.note.type as? Note.Type.Mastodon
                 TextType.Mastodon(
                     MastodonHTMLParser.parse(
                         it, note.note.emojis ?: emptyList(), userHost = note.user
                             .host,
                         accountHost = account.getHost()
-                    )
+                    ),
+                    tags = option?.tags ?: emptyList(),
+                    mentions = option?.mentions ?: emptyList()
                 )
             }
         }

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/html/MastodonHTML.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/html/MastodonHTML.kt
@@ -1,0 +1,33 @@
+package net.pantasystem.milktea.common_android.html
+
+import android.text.Spanned
+import androidx.core.text.parseAsHtml
+import net.pantasystem.milktea.model.emoji.CustomEmojiParsedResult
+import net.pantasystem.milktea.model.emoji.CustomEmojiParser
+import net.pantasystem.milktea.model.emoji.Emoji
+
+data class MastodonHTML(
+    val spanned: Spanned,
+    val parserResult: CustomEmojiParsedResult,
+    val accountHost: String?,
+)
+
+object MastodonHTMLParser {
+    fun parse(
+        text: String,
+        emojis: List<Emoji>? = emptyList(),
+        userHost: String? = null,
+        accountHost: String? = null
+    ): MastodonHTML {
+        val spanned = text.replace("<br> ", "<br>&nbsp;")
+            .replace("<br /> ", "<br />&nbsp;")
+            .replace("<br/> ", "<br/>&nbsp;")
+            .replace("  ", "&nbsp;&nbsp;").parseAsHtml()
+        val result = CustomEmojiParser.parse(sourceHost = userHost, text = spanned.toString(), emojis = emojis)
+        return MastodonHTML(
+            spanned = spanned,
+            result,
+            accountHost = accountHost,
+        )
+    }
+}

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/html/MastodonHTML.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/html/MastodonHTML.kt
@@ -22,7 +22,7 @@ object MastodonHTMLParser {
         val spanned = text.replace("<br> ", "<br>&nbsp;")
             .replace("<br /> ", "<br />&nbsp;")
             .replace("<br/> ", "<br/>&nbsp;")
-            .replace("  ", "&nbsp;&nbsp;").parseAsHtml()
+            .replace("  ", "&nbsp;&nbsp;").parseAsHtml().trim() as Spanned
         val result = CustomEmojiParser.parse(sourceHost = userHost, text = spanned.toString(), emojis = emojis)
         return MastodonHTML(
             spanned = spanned,

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/html/MastodonHTML.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/html/MastodonHTML.kt
@@ -23,7 +23,11 @@ object MastodonHTMLParser {
             .replace("<br /> ", "<br />&nbsp;")
             .replace("<br/> ", "<br/>&nbsp;")
             .replace("  ", "&nbsp;&nbsp;").parseAsHtml().trim() as Spanned
-        val result = CustomEmojiParser.parse(sourceHost = userHost, text = spanned.toString(), emojis = emojis)
+        val result = CustomEmojiParser.parse(
+            sourceHost = userHost,
+            text = spanned.toString(),
+            emojis = emojis
+        )
         return MastodonHTML(
             spanned = spanned,
             result,

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Element.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Element.kt
@@ -1,4 +1,4 @@
-package jp.panta.misskeyandroidclient.mfm
+package net.pantasystem.milktea.common_android.mfm
 
 import java.io.Serializable
 

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/ElementType.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/ElementType.kt
@@ -1,4 +1,4 @@
-package jp.panta.misskeyandroidclient.mfm
+package net.pantasystem.milktea.common_android.mfm
 
 enum class ElementType(val elementClass: ElementClass) {
     QUOTE(ElementClass.QUOTE),

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/EmojiElement.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/EmojiElement.kt
@@ -1,5 +1,7 @@
 package jp.panta.misskeyandroidclient.mfm
 
+import net.pantasystem.milktea.common_android.mfm.ElementType
+import net.pantasystem.milktea.common_android.mfm.Leaf
 import net.pantasystem.milktea.model.emoji.Emoji
 
 class EmojiElement(

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/HashTag.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/HashTag.kt
@@ -1,5 +1,8 @@
 package jp.panta.misskeyandroidclient.mfm
 
+import net.pantasystem.milktea.common_android.mfm.ElementType
+import net.pantasystem.milktea.common_android.mfm.Leaf
+
 class HashTag(
     override val start: Int,
     override val end: Int,

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Leaf.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Leaf.kt
@@ -1,5 +1,5 @@
-package jp.panta.misskeyandroidclient.mfm
+package net.pantasystem.milktea.common_android.mfm
 
-abstract class Leaf : Element{
+abstract class Leaf : Element {
     abstract val text: String
 }

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Link.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Link.kt
@@ -1,5 +1,8 @@
 package jp.panta.misskeyandroidclient.mfm
 
+import net.pantasystem.milktea.common_android.mfm.ElementType
+import net.pantasystem.milktea.common_android.mfm.Leaf
+
 class Link(
     override val text: String,
     override val start: Int,

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMContract.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMContract.kt
@@ -1,5 +1,7 @@
 package jp.panta.misskeyandroidclient.mfm
 
+import net.pantasystem.milktea.common_android.mfm.ElementType
+
 /**
  * タグの判別ロジック、正規表現、判別用データなどをここに実装する
  */

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
@@ -414,11 +414,11 @@ object MFMParser {
 
             return EmojiElement(
                 emoji,
-                tagName,
+                subStr,
                 start = position + matcher.start(),
                 end = position + matcher.end(),
-                insideStart = position + matcher.start(1),
-                insideEnd = position + matcher.end(1)
+                insideStart = position + matcher.start(),
+                insideEnd = position + matcher.end()
             )
         }
 

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Mention.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Mention.kt
@@ -1,5 +1,8 @@
 package jp.panta.misskeyandroidclient.mfm
 
+import net.pantasystem.milktea.common_android.mfm.ElementType
+import net.pantasystem.milktea.common_android.mfm.Leaf
+
 class Mention(
     override val start: Int,
     override val end: Int,

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Node.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Node.kt
@@ -1,5 +1,8 @@
 package jp.panta.misskeyandroidclient.mfm
 
+import net.pantasystem.milktea.common_android.mfm.Element
+import net.pantasystem.milktea.common_android.mfm.ElementType
+
 open class Node(
     override val start: Int,
     override val end: Int,

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Root.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Root.kt
@@ -1,5 +1,7 @@
 package jp.panta.misskeyandroidclient.mfm
 
+import net.pantasystem.milktea.common_android.mfm.ElementType
+
 class Root(
     val sourceText: String
 ) : Node(0, sourceText.length, 0, sourceText.length, ElementType.ROOT){

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Search.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Search.kt
@@ -1,5 +1,8 @@
 package jp.panta.misskeyandroidclient.mfm
 
+import net.pantasystem.milktea.common_android.mfm.ElementType
+import net.pantasystem.milktea.common_android.mfm.Leaf
+
 class Search(
     override val text: String,
     override val start: Int,

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Text.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Text.kt
@@ -1,5 +1,8 @@
 package jp.panta.misskeyandroidclient.mfm
 
+import net.pantasystem.milktea.common_android.mfm.ElementType
+import net.pantasystem.milktea.common_android.mfm.Leaf
+
 class Text(
     override val text: String,
     override val start: Int,

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/CustomEmojiDecorator.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/CustomEmojiDecorator.kt
@@ -63,5 +63,26 @@ class CustomEmojiDecorator {
 
         return builder
     }
+
+    fun decorate(spanned: Spanned, accountHost: String?, result: CustomEmojiParsedResult, view: View): Spanned {
+
+        val emojiAdapter = EmojiAdapter(view)
+        val builder = SpannableStringBuilder(spanned)
+
+        result.emojis.filter {
+            HostWithVersion.isOverV13(accountHost) || it.result is EmojiResolvedType.Resolved
+        }.map {
+            val span = DrawableEmojiSpan(emojiAdapter)
+            GlideApp.with(view)
+                .asDrawable()
+                .load(it.result.getUrl(accountHost))
+                .into(span.target)
+            builder.setSpan(span, it.start, it.end, 0)
+        }
+
+
+        return builder
+    }
+
 }
 

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
@@ -1,17 +1,25 @@
 package net.pantasystem.milktea.common_android_ui
 
+import android.app.Activity
 import android.text.Spannable
 import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
+import android.text.style.URLSpan
+import android.util.Log
+import android.view.MotionEvent
 import android.widget.TextView
 import androidx.core.text.getSpans
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.load.resource.gif.GifDrawable
 import com.github.penfeizhou.animation.apng.APNGDrawable
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.android.internal.managers.FragmentComponentManager
 import jp.panta.misskeyandroidclient.mfm.Root
 import net.pantasystem.milktea.common_android.TextType
 import net.pantasystem.milktea.common_android.mfm.MFMParser
 import net.pantasystem.milktea.common_android.ui.text.CustomEmojiDecorator
 import net.pantasystem.milktea.common_android.ui.text.DrawableEmojiSpan
+import net.pantasystem.milktea.common_navigation.UserDetailNavigationArgs
 import net.pantasystem.milktea.model.emoji.Emoji
 
 object DecorateTextHelper {
@@ -47,7 +55,6 @@ object DecorateTextHelper {
     @JvmStatic
     fun TextView.decorate(textType: TextType?) {
         textType ?: return
-        this.movementMethod = LinkMovementMethod.getInstance()
         stopDrawableAnimations(this)
         when (textType) {
             is TextType.Mastodon -> {
@@ -57,8 +64,39 @@ object DecorateTextHelper {
                     textType.html.parserResult,
                     this
                 )
+                this.movementMethod = ClickListenableLinkMovementMethod { url ->
+                    val tag = textType.tags.firstOrNull {
+                        it.url == url || it.url == url.lowercase()
+                    }
+                    val mention = textType.mentions.firstOrNull {
+                        it.url == url
+                    }
+                    Log.d("DecorateTextHelper", "clicked url:$url, tag:$tag, mention:$mention, tags:${textType.tags}")
+                    val activity = FragmentComponentManager.findActivity(context) as Activity
+                    val navigationEntryPoint = EntryPointAccessors.fromActivity(
+                        activity,
+                        NavigationEntryPointForBinding::class.java
+                    )
+                    when {
+                        tag != null -> {
+                            // FIXME: タグの場合うまく動作しないケースがある
+                            // 原因としてTagオブジェクトに入っているURLとHTML上に表示されているURLが異なるから
+                            false
+                        }
+                        mention != null -> {
+                            val intent = navigationEntryPoint
+                                .userDetailNavigation()
+                                .newIntent(UserDetailNavigationArgs.UserName(userName = mention.acct))
+                            context.startActivity(intent)
+                            true
+                        }
+                        else -> false
+                    }
+
+                }
             }
             is TextType.Misskey -> {
+                this.movementMethod = LinkMovementMethod.getInstance()
                 val node = textType.root ?: return
                 this.text = MFMDecorator.decorate(this, node)
             }
@@ -75,5 +113,28 @@ object DecorateTextHelper {
             ?: return
         this.movementMethod = LinkMovementMethod.getInstance()
         this.text = MFMDecorator.decorate(this, node)
+    }
+}
+
+
+class ClickListenableLinkMovementMethod(private val onClick: ((url: String) -> Boolean)) :
+    LinkMovementMethod() {
+    override fun onTouchEvent(widget: TextView, buffer: Spannable, event: MotionEvent): Boolean {
+        val url = getUrl(widget, buffer, event)
+        return when {
+            event.action == MotionEvent.ACTION_UP && url != null && onClick(url) -> true
+            else -> super.onTouchEvent(widget, buffer, event)
+        }
+    }
+
+    companion object {
+        private fun getUrl(widget: TextView, buffer: Spannable, event: MotionEvent): String? {
+            val x = event.x.toInt() - widget.totalPaddingLeft + widget.scrollX
+            val y = event.y.toInt() - widget.totalPaddingTop + widget.scrollY
+            val off =
+                widget.layout.run { getOffsetForHorizontal(getLineForVertical(y), x.toFloat()) }
+            return (buffer.getSpans(off, off, ClickableSpan::class.java)
+                .getOrNull(0) as? URLSpan)?.url
+        }
     }
 }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
@@ -8,18 +8,19 @@ import androidx.databinding.BindingAdapter
 import com.bumptech.glide.load.resource.gif.GifDrawable
 import com.github.penfeizhou.animation.apng.APNGDrawable
 import jp.panta.misskeyandroidclient.mfm.Root
+import net.pantasystem.milktea.common_android.TextType
 import net.pantasystem.milktea.common_android.mfm.MFMParser
+import net.pantasystem.milktea.common_android.ui.text.CustomEmojiDecorator
 import net.pantasystem.milktea.common_android.ui.text.DrawableEmojiSpan
 import net.pantasystem.milktea.model.emoji.Emoji
 
 object DecorateTextHelper {
 
 
-
     @BindingAdapter("textNode")
     @JvmStatic
-    fun TextView.decorate(node: Root?){
-        node?: return
+    fun TextView.decorate(node: Root?) {
+        node ?: return
         this.movementMethod = LinkMovementMethod.getInstance()
         stopDrawableAnimations(this)
         this.text = MFMDecorator.decorate(this, node)
@@ -30,7 +31,7 @@ object DecorateTextHelper {
         if (beforeText is Spannable) {
             val drawableEmojiSpans = beforeText.getSpans<DrawableEmojiSpan>()
             drawableEmojiSpans.forEach {
-                when(val imageDrawable = it.imageDrawable) {
+                when (val imageDrawable = it.imageDrawable) {
                     is GifDrawable -> {
                         imageDrawable.stop()
                     }
@@ -42,11 +43,34 @@ object DecorateTextHelper {
         }
     }
 
+    @BindingAdapter("textTypeSource")
+    @JvmStatic
+    fun TextView.decorate(textType: TextType?) {
+        textType ?: return
+        this.movementMethod = LinkMovementMethod.getInstance()
+        stopDrawableAnimations(this)
+        when (textType) {
+            is TextType.Mastodon -> {
+                this.text = CustomEmojiDecorator().decorate(
+                    textType.html.spanned,
+                    textType.html.accountHost,
+                    textType.html.parserResult,
+                    this
+                )
+            }
+            is TextType.Misskey -> {
+                val node = textType.root ?: return
+                this.text = MFMDecorator.decorate(this, node)
+            }
+        }
+
+    }
+
     @BindingAdapter("sourceText", "emojis")
     @JvmStatic
-    fun TextView.decorateWithLowPerformance(sourceText: String?, emojis: List<Emoji>?){
-        sourceText?: return
-        emojis?: return
+    fun TextView.decorateWithLowPerformance(sourceText: String?, emojis: List<Emoji>?) {
+        sourceText ?: return
+        emojis ?: return
         val node = MFMParser.parse(sourceText, emojis)
             ?: return
         this.movementMethod = LinkMovementMethod.getInstance()

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
@@ -20,6 +20,7 @@ import net.pantasystem.milktea.common_android.mfm.MFMParser
 import net.pantasystem.milktea.common_android.ui.text.CustomEmojiDecorator
 import net.pantasystem.milktea.common_android.ui.text.DrawableEmojiSpan
 import net.pantasystem.milktea.common_navigation.UserDetailNavigationArgs
+import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.emoji.Emoji
 
 object DecorateTextHelper {
@@ -104,12 +105,14 @@ object DecorateTextHelper {
 
     }
 
-    @BindingAdapter("sourceText", "emojis")
+    @BindingAdapter("sourceText", "emojis", "account", "host")
     @JvmStatic
-    fun TextView.decorateWithLowPerformance(sourceText: String?, emojis: List<Emoji>?) {
+    fun TextView.decorateWithLowPerformance(sourceText: String?, emojis: List<Emoji>?, account: Account?, host: String?) {
         sourceText ?: return
         emojis ?: return
-        val node = MFMParser.parse(sourceText, emojis)
+        account ?: return
+        host ?: return
+        val node = MFMParser.parse(sourceText, emojis, accountHost = account.getHost(), userHost = host)
             ?: return
         this.movementMethod = LinkMovementMethod.getInstance()
         this.text = MFMDecorator.decorate(this, node)

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
@@ -16,6 +16,9 @@ import dagger.hilt.android.internal.managers.FragmentComponentManager
 import jp.panta.misskeyandroidclient.mfm.*
 import net.pantasystem.milktea.common.glide.GlideApp
 import net.pantasystem.milktea.common_android.R
+import net.pantasystem.milktea.common_android.mfm.Element
+import net.pantasystem.milktea.common_android.mfm.ElementType
+import net.pantasystem.milktea.common_android.mfm.Leaf
 import net.pantasystem.milktea.common_android.ui.Activities
 import net.pantasystem.milktea.common_android.ui.putActivity
 import net.pantasystem.milktea.common_android.ui.text.DrawableEmojiSpan

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
@@ -20,7 +20,6 @@ import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.internal.managers.FragmentComponentManager
 import jp.panta.misskeyandroidclient.mfm.*
 import net.pantasystem.milktea.common.glide.GlideApp
-import net.pantasystem.milktea.common_android.R
 import net.pantasystem.milktea.common_android.mfm.Element
 import net.pantasystem.milktea.common_android.mfm.ElementType
 import net.pantasystem.milktea.common_android.mfm.Leaf
@@ -37,9 +36,22 @@ import java.lang.ref.WeakReference
 object MFMDecorator {
 
 
-    fun decorate(textView: TextView, node: Root, skipEmojis: SkipEmojiHolder = SkipEmojiHolder(), retryCounter: Int = 0): Spanned{
+    fun decorate(
+        textView: TextView,
+        node: Root,
+        skipEmojis: SkipEmojiHolder = SkipEmojiHolder(),
+        retryCounter: Int = 0
+    ): Spanned {
         val emojiAdapter = EmojiAdapter(textView)
-        return Visitor(WeakReference(textView), node, node, emojiAdapter, skipEmojis, retryCounter).decorate()
+        textView.setTag(R.id.TEXT_VIEW_MFM_TAG_ID, node.sourceText)
+        return Visitor(
+            WeakReference(textView),
+            node,
+            node,
+            emojiAdapter,
+            skipEmojis,
+            retryCounter
+        ).decorate()
             ?: SpannedString(node.sourceText)
     }
 
@@ -53,7 +65,7 @@ object MFMDecorator {
         private val emojiAdapter: EmojiAdapter,
         private val skipEmojis: SkipEmojiHolder,
         private val retryCounter: Int,
-    ){
+    ) {
         private var position = 0
         private val spannableStringBuilder = SpannableStringBuilder()
 
@@ -62,10 +74,17 @@ object MFMDecorator {
          * parent のchildElementsをここで処理する
          * @return 担当した要素（Element）のspannableStringBuilderの最終的なポジション
          */
-        fun decorate(): Spanned?{
-            if(parent is Node){
-                parent.childElements.forEach{ ele ->
-                    val spanned = Visitor(textView, root, ele, emojiAdapter, skipEmojis, retryCounter).decorate()
+        fun decorate(): Spanned? {
+            if (parent is Node) {
+                parent.childElements.forEach { ele ->
+                    val spanned = Visitor(
+                        textView,
+                        root,
+                        ele,
+                        emojiAdapter,
+                        skipEmojis,
+                        retryCounter
+                    ).decorate()
                         ?: closeErrorElement(ele)
                     spannableStringBuilder.append(spanned)
                     position += spanned.length - 1
@@ -73,10 +92,10 @@ object MFMDecorator {
             }
 
             // parentを装飾してしまう
-            return try{
+            return try {
                 // 自己がLeafであればparentの情報から装飾され、自己がNodeであればstartとpositionをもとに装飾される
                 decorate(parent)
-            }catch(e: Exception){
+            } catch (e: Exception) {
                 // 子要素の処理がすべて無駄になることになってしまうがとりあえずはこうする
                 null
             }
@@ -85,14 +104,14 @@ object MFMDecorator {
         }
 
 
-        private fun closeErrorElement(element: Element): Spanned{
+        private fun closeErrorElement(element: Element): Spanned {
             return SpannableString(root.sourceText.substring(element.start, element.end))
         }
 
-        private fun decorate(element: Element): Spanned?{
-            return when(element){
+        private fun decorate(element: Element): Spanned? {
+            return when (element) {
                 is Leaf ->
-                    when(element){
+                    when (element) {
                         is Text -> decorateText(element)
                         is EmojiElement -> decorateEmoji(element)
                         is Search -> decorateSearch(element)
@@ -101,7 +120,7 @@ object MFMDecorator {
                         is HashTag -> decorateHashTag(element)
                         else -> null
                     }
-                is Node ->{
+                is Node -> {
                     decorateNode()
                     spannableStringBuilder
                 }
@@ -110,12 +129,12 @@ object MFMDecorator {
 
         }
 
-        private fun decorateEmoji(emojiElement: EmojiElement): Spanned{
+        private fun decorateEmoji(emojiElement: EmojiElement): Spanned {
             val spanned = SpannableString(emojiElement.text)
             if (skipEmojis.contains(emojiElement.emoji)) {
                 return SpannableString(":${emojiElement.text}:")
             }
-            textView.get()?.let{ textView ->
+            textView.get()?.let { textView ->
                 //val emojiSpan = EmojiSpan(textView)
                 val emojiSpan: EmojiSpan<*>
                 emojiSpan = DrawableEmojiSpan(emojiAdapter)
@@ -130,10 +149,18 @@ object MFMDecorator {
                             isFirstResource: Boolean
                         ): Boolean {
                             val t = this@Visitor.textView.get()
-                            if (t != null && !skipEmojis.contains(emojiElement.emoji)) {
+                            if (t != null && !skipEmojis.contains(emojiElement.emoji) && t.getTag(R.id.TEXT_VIEW_MFM_TAG_ID) == root.sourceText) {
                                 if (retryCounter < 100) {
-                                    Log.d("MFMDecorator", "リソースの読み取りに失敗したので排除する textView exists:${this@Visitor.textView.get() != null}, ${t.text}")
-                                    t.text = decorate(t, node = root, skipEmojis = skipEmojis.add(emojiElement.emoji), retryCounter + 1)
+                                    Log.d(
+                                        "MFMDecorator",
+                                        "リソースの読み取りに失敗したので排除する textView exists:${this@Visitor.textView.get() != null}, ${t.text}"
+                                    )
+                                    t.text = decorate(
+                                        t,
+                                        node = root,
+                                        skipEmojis = skipEmojis.add(emojiElement.emoji),
+                                        retryCounter + 1
+                                    )
                                 }
                             }
 
@@ -157,59 +184,68 @@ object MFMDecorator {
             return spanned
         }
 
-        private fun decorateText(text: Text): Spanned{
+        private fun decorateText(text: Text): Spanned {
             return SpannedString(text.text)
         }
 
-        private fun decorateSearch(search: Search): Spanned{
+        private fun decorateSearch(search: Search): Spanned {
             val intent = Intent(Intent.ACTION_SEARCH)
             //intent.setClassName("com.google.android.googlequicksearchbox",  "com.google.android.googlequicksearchbox.SearchActivity")
             intent.putExtra(SearchManager.QUERY, search.text)
-            return makeClickableSpan("${search.text}  ${(textView.get()?.context?.getString(R.string.search)?: "Search")}", intent)
+            return makeClickableSpan(
+                "${search.text}  ${(textView.get()?.context?.getString(R.string.search) ?: "Search")}",
+                intent
+            )
         }
 
-        private fun decorateMention(mention: Mention): Spanned{
-            return textView.get()?.let{ textView ->
+        private fun decorateMention(mention: Mention): Spanned {
+            return textView.get()?.let { textView ->
 
                 val activity = FragmentComponentManager.findActivity(textView.context) as Activity
-                val intent = EntryPointAccessors.fromActivity(activity, NavigationEntryPointForBinding::class.java)
+                val intent = EntryPointAccessors.fromActivity(
+                    activity,
+                    NavigationEntryPointForBinding::class.java
+                )
                     .userDetailNavigation()
                     .newIntent(UserDetailNavigationArgs.UserName(userName = mention.text))
                 intent.putActivity(Activities.ACTIVITY_IN_APP)
 
 
                 makeClickableSpan(mention.text, intent)
-            }?: closeErrorElement(mention)
+            } ?: closeErrorElement(mention)
 
         }
 
-        private fun decorateLink(link: Link): Spanned{
+        private fun decorateLink(link: Link): Spanned {
             return makeClickableSpan(link.text, Intent(Intent.ACTION_VIEW, Uri.parse(link.url)))
         }
 
 
-        private fun decorateHashTag(hashTag: HashTag): Spanned{
-            return textView.get()?.let{ textView ->
+        private fun decorateHashTag(hashTag: HashTag): Spanned {
+            return textView.get()?.let { textView ->
                 val activity = FragmentComponentManager.findActivity(textView.context) as Activity
 
-                val navigation = EntryPointAccessors.fromActivity(activity, NavigationEntryPointForBinding::class.java)
+                val navigation = EntryPointAccessors.fromActivity(
+                    activity,
+                    NavigationEntryPointForBinding::class.java
+                )
                 val intent = navigation.searchNavigation()
                     .newIntent(SearchNavType.ResultScreen(hashTag.text))
 //
                 makeClickableSpan(hashTag.text, intent)
-            }?: closeErrorElement(hashTag)
+            } ?: closeErrorElement(hashTag)
 
         }
 
-        private fun makeClickableSpan(text: String, intent: Intent): SpannableString{
+        private fun makeClickableSpan(text: String, intent: Intent): SpannableString {
             val spanned = SpannableString(text)
             spanned.setSpan(
-                object : ClickableSpan(){
+                object : ClickableSpan() {
                     override fun onClick(p0: View) {
                         textView.get()?.context?.startActivity(intent)
 
                     }
-                },0, text.length, 0
+                }, 0, text.length, 0
             )
             return spanned
         }
@@ -217,51 +253,50 @@ object MFMDecorator {
         /**
          * 最後に一度だけ実行すること
          */
-        private fun decorateNode(){
-            fun setSpan(any: Any){
+        private fun decorateNode() {
+            fun setSpan(any: Any) {
                 spannableStringBuilder.setSpan(any, 0, spannableStringBuilder.length, 0)
             }
 
-            if(parent is Node){
-                when(parent.elementType){
-                    ElementType.QUOTE ->{
+            if (parent is Node) {
+                when (parent.elementType) {
+                    ElementType.QUOTE -> {
                         setSpan(QuoteSpan())
                     }
-                    ElementType.BOLD ->{
+                    ElementType.BOLD -> {
                         setSpan(StyleSpan(Typeface.BOLD))
                     }
-                    ElementType.ITALIC ->{
+                    ElementType.ITALIC -> {
                         setSpan(StyleSpan(Typeface.ITALIC))
                     }
-                    ElementType.CENTER ->{
+                    ElementType.CENTER -> {
                         setSpan(AlignmentSpan.Standard(Layout.Alignment.ALIGN_CENTER))
                     }
-                    ElementType.STRIKE ->{
+                    ElementType.STRIKE -> {
                         setSpan(StrikethroughSpan())
                     }
-                    ElementType.CODE ->{
+                    ElementType.CODE -> {
                         setSpan(BackgroundColorSpan(Color.parseColor("#000000")))
                         setSpan(ForegroundColorSpan(Color.WHITE))
                     }
-                    ElementType.TITLE ->{
+                    ElementType.TITLE -> {
                         spannableStringBuilder.append("\n")
                         setSpan(RelativeSizeSpan(1.5F))
                         setSpan(AlignmentSpan.Standard(Layout.Alignment.ALIGN_CENTER))
                     }
-                    ElementType.SMALL ->{
+                    ElementType.SMALL -> {
                         setSpan(RelativeSizeSpan(0.6F))
                     }
-                    ElementType.ROOT ->{
+                    ElementType.ROOT -> {
 
                     }
-                    else ->{
+                    else -> {
                         Log.d("MFMDecorator", "error:${parent.elementType}")
                     }
                 }
             }
 
         }
-
 
 
     }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
@@ -132,7 +132,7 @@ object MFMDecorator {
         private fun decorateEmoji(emojiElement: EmojiElement): Spanned {
             val spanned = SpannableString(emojiElement.text)
             if (skipEmojis.contains(emojiElement.emoji)) {
-                return SpannableString(":${emojiElement.text}:")
+                return spanned
             }
             textView.get()?.let { textView ->
                 //val emojiSpan = EmojiSpan(textView)

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
@@ -151,10 +151,6 @@ object MFMDecorator {
                             val t = this@Visitor.textView.get()
                             if (t != null && !skipEmojis.contains(emojiElement.emoji) && t.getTag(R.id.TEXT_VIEW_MFM_TAG_ID) == root.sourceText) {
                                 if (retryCounter < 100) {
-                                    Log.d(
-                                        "MFMDecorator",
-                                        "リソースの読み取りに失敗したので排除する textView exists:${this@Visitor.textView.get() != null}, ${t.text}"
-                                    )
                                     t.text = decorate(
                                         t,
                                         node = root,

--- a/modules/common_android_ui/src/main/res/values/tags.xml
+++ b/modules/common_android_ui/src/main/res/values/tags.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="TEXT_VIEW_MFM_TAG_ID" type="id" />
+</resources>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
@@ -95,6 +95,12 @@ fun TootStatusDTO.toNote(account: Account, nodeInfo: NodeInfo?): Note {
             bookmarked = bookmarked,
             muted = muted,
             favoriteCount = favouritesCount,
+            tags = tags?.map {
+                it.toModel()
+            } ?: emptyList(),
+            mentions = mentions?.map {
+                it.toModel()
+            } ?: emptyList()
         ),
         nodeInfo = nodeInfo,
     )

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/emojis/EmojiPickerFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/emojis/EmojiPickerFragment.kt
@@ -23,6 +23,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.launch
+import net.pantasystem.milktea.model.notes.reaction.LegacyReaction
+import net.pantasystem.milktea.model.notes.reaction.Reaction
 import net.pantasystem.milktea.model.notes.reaction.ReactionSelection
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.FragmentEmojiPickerBinding
@@ -56,7 +58,12 @@ class EmojiPickerFragment : Fragment(R.layout.fragment_emoji_picker), ReactionSe
             recyclerView = binding.reactionChoicesViewPager,
             searchWordTextField = binding.searchReactionEditText,
             onReactionSelected = {
-                onSelect(it)
+                val selected = if (Reaction(it).isCustomEmojiFormat()) {
+                    it
+                } else {
+                    LegacyReaction.reactionMap[it] ?: it
+                }
+                onSelect(selected)
             },
             onSearchEmojiTextFieldEntered = {
                 onSelect(it)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.onEach
 import net.pantasystem.milktea.app_store.notes.NoteTranslationStore
 import net.pantasystem.milktea.common.ResultState
+import net.pantasystem.milktea.common_android.getTextType
 import net.pantasystem.milktea.common_android.mfm.MFMParser
 import net.pantasystem.milktea.common_android.resource.StringSource
 import net.pantasystem.milktea.model.account.Account
@@ -74,12 +75,7 @@ open class PlaneNoteViewData(
     }
 
 
-    val textNode = MFMParser.parse(
-        toShowNote.note.text, (toShowNote.note.emojis ?: emptyList()) + instanceEmojis,
-        userHost = toShowNote.user
-            .host,
-        accountHost = account.getHost()
-    )
+    val textNode = getTextType(account, toShowNote, instanceEmojis)
 
     val translateState: LiveData<ResultState<Translation?>?> =
         this.noteTranslationStore.state(toShowNote.note.id).asLiveData()
@@ -94,7 +90,7 @@ open class PlaneNoteViewData(
         FilePreviewSource.Remote(AppFile.Remote(it.id), it)
     }?.filter {
         it.aboutMediaType == AboutMediaType.IMAGE || it.aboutMediaType == AboutMediaType.VIDEO
-    }?: emptyList()
+    } ?: emptyList()
     val media = MediaViewData(previewableFiles)
 
     val isOnlyVisibleRenoteStatusMessage = MutableLiveData<Boolean>(false)
@@ -153,17 +149,14 @@ open class PlaneNoteViewData(
     val subNote: NoteRelation? = toShowNote.renote
 
     val subNoteAvatarUrl = subNote?.user?.avatarUrl
-    val subNoteTextNode = MFMParser.parse(
-        subNote?.note?.text,
-        (subNote?.note?.emojis ?: emptyList()) + instanceEmojis,
-        accountHost = account.getHost(),
-        userHost = subNote?.user?.host
-    )
+    val subNoteTextNode = subNote?.let {
+        getTextType(account, it, instanceEmojis)
+    }
 
     val subCw = subNote?.note?.cw
     val subCwNode = MFMParser.parse(
         subNote?.note?.cw,
-        (subNote?.note?.emojis?: emptyList()) + instanceEmojis,
+        (subNote?.note?.emojis ?: emptyList()) + instanceEmojis,
         accountHost = account.getHost(),
         userHost = subNote?.user?.host
     )
@@ -241,3 +234,4 @@ open class PlaneNoteViewData(
     }
 
 }
+

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewDataCache.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewDataCache.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.plus
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import net.pantasystem.milktea.app_store.notes.NoteTranslationStore
+import net.pantasystem.milktea.common_android.TextType
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.instance.MetaRepository
 import net.pantasystem.milktea.model.notes.*
@@ -186,7 +187,7 @@ class PlaneNoteViewDataCache(
     }
 
     private suspend fun loadUrlPreview(note: PlaneNoteViewData) {
-        note.textNode?.getUrls()?.let { urls ->
+        (note.textNode as? TextType.Misskey?)?.root?.getUrls()?.let { urls ->
             UrlPreviewLoadTask(
                 GetUrlPreviewStore.invoke(getAccount.invoke()),
                 urls,

--- a/modules/features/note/src/main/res/layout/item_detail_note.xml
+++ b/modules/features/note/src/main/res/layout/item_detail_note.xml
@@ -157,7 +157,7 @@
                         android:layout_height="wrap_content"
                         android:textSize="15sp"
                         android:visibility='@{note.text == null ? View.GONE : View.VISIBLE}'
-                        app:textNode="@{note.textNode}"
+                        textTypeSource="@{note.textNode}"
                         tools:text="aoiwefjowiaejiowajefihawoefoiawehfioawheoifawoiefioawejfowaoeifjawoiejfoaw" />
 
                 <include
@@ -295,7 +295,7 @@
                             android:layout_below="@+id/subContentFoldingButton"
                             android:textSize="15sp"
                             android:visibility="@{SafeUnbox.unboxBool(note.subContentFolding) ? View.GONE : View.VISIBLE }"
-                            app:textNode="@{note.subNoteTextNode}"
+                            textTypeSource="@{note.subNoteTextNode}"
                             tools:text="aowjfoiwajehofijawioefjioawejfiowajeiofhawoifahwoiefwaioe" />
 
                     <include

--- a/modules/features/note/src/main/res/layout/item_has_reply_to_note.xml
+++ b/modules/features/note/src/main/res/layout/item_has_reply_to_note.xml
@@ -127,7 +127,7 @@
                                 android:textSize="15sp"
                                 tools:text="aoiwefjowiaejiowajefihawoefoiawehfioawheoifawoiefioawejfowaoeifjawoiejfoaw"
                                 android:visibility='@{hasReplyToNote.replyTo.text == null ? View.GONE : View.VISIBLE}'
-                                app:textNode="@{hasReplyToNote.replyTo.textNode}"
+                                textTypeSource="@{hasReplyToNote.replyTo.textNode}"
                                 />
 
                     </RelativeLayout>

--- a/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
+++ b/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
@@ -183,7 +183,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:textSize="15sp"
-                            app:textNode="@{note.textNode}"
+                            textTypeSource="@{note.textNode}"
                             tools:text="aoiwefjowiaejiowajefihawoefoiawehfioawheoifawoiefioawejfowaoeifjawoiejfoaw"
                             android:visibility='@{note.text == null ? View.GONE : View.VISIBLE}'
 
@@ -339,7 +339,7 @@
                                 android:textSize="15sp"
                                 android:id="@+id/subNoteText"
                                 tools:text="aowjfoiwajehofijawioefjioawejfiowajeiofhawoifahwoiefwaioe"
-                                app:textNode="@{note.subNoteTextNode}"
+                                textTypeSource="@{note.subNoteTextNode}"
                                 app:layout_constraintTop_toBottomOf="@id/subContentFoldingButton"
                                 app:layout_constraintStart_toStartOf="parent"
                                 android:visibility="@{ note.subContentFolding || note.subNote.note.text == null ? View.GONE : View.VISIBLE }"/>

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -188,7 +188,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:textSize="15sp"
-                            app:textNode="@{note.textNode}"
+                            textTypeSource="@{note.textNode}"
                             tools:text="aoiwefjowiaejiowajefihawoefoiawehfioawheoifawoiefioawejfowaoeifjawoiejfoaw"
                             android:visibility='@{note.text == null ? View.GONE : View.VISIBLE}'
 
@@ -342,7 +342,7 @@
                                 android:textSize="15sp"
                                 android:id="@+id/subNoteText"
                                 tools:text="aowjfoiwajehofijawioefjioawejfiowajeiofhawoifahwoiefwaioe"
-                                app:textNode="@{note.subNoteTextNode}"
+                                textTypeSource="@{note.subNoteTextNode}"
                                 app:layout_constraintTop_toBottomOf="@id/subContentFoldingButton"
                                 app:layout_constraintStart_toStartOf="parent"
                                 android:visibility="@{ note.subContentFolding || note.subNote.note.text == null ? View.GONE : View.VISIBLE }"/>

--- a/modules/features/user/src/main/res/layout/activity_user_detail.xml
+++ b/modules/features/user/src/main/res/layout/activity_user_detail.xml
@@ -188,6 +188,8 @@
                             android:layout_height="wrap_content"
                             android:layout_alignStart="@id/avatarIcon"
                             app:sourceText="@{userViewModel.user.info.description}"
+                            app:account="@{userViewModel.account}"
+                            app:host="@{userViewModel.user.host}"
                             app:emojis="@{userViewModel.user.emojis}"
                             tools:text="awoijfoiwaehfoaiwehfoiawjefoiawjefiojawioefjioawhfoiawehfoiawef"
                             android:layout_marginEnd="16dp"

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
@@ -62,10 +62,23 @@ data class Note(
             val bookmarked: Boolean?,
             val muted: Boolean?,
             val favoriteCount: Int?,
-        ) : Type
+            val tags: List<Tag>,
+            val mentions: List<Mention>,
+        ) : Type {
+            data class Tag(
+                val name: String,
+                val url: String,
+            )
+            data class Mention(
+                val id: String,
+                val username: String,
+                val url: String,
+                val acct: String,
+            )
+        }
     }
 
-    companion object;
+    companion object
 
     val isMastodon: Boolean = type is Type.Mastodon
     val isMisskey: Boolean = type is Type.Misskey


### PR DESCRIPTION
## やったこと
Mastodonのテキストを表示できるようにしました。
Misskeyの絵文字を表示する時に読み込みに失敗した絵文字はそのままテキストとして表示するようにしました。
プロフィール表示時に説明欄の絵文字が表示されない問題を修正しました。

## 動作確認


## スクリーンショット(任意)


## 備考
Mastodon時にハッシュタグをクリックしてもまだうまく動作しないですが別タスクで対応予定です。

## Issue番号
Closed #1245 
