### PR TITLE
Mastodon時はDrive関連のリンクを表示しないようにした

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/ChangeNavMenuVisibilityFromAPIVersion.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/ChangeNavMenuVisibilityFromAPIVersion.kt
@@ -17,6 +17,7 @@ internal class ChangeNavMenuVisibilityFromAPIVersion(
             menu.findItem(R.id.nav_channel).isVisible = enableFeatures.contains(FeatureType.Channel)
             menu.findItem(R.id.nav_gallery).isVisible = enableFeatures.contains(FeatureType.Gallery)
             menu.findItem(R.id.nav_group).isVisible = enableFeatures.contains(FeatureType.Group)
+            menu.findItem(R.id.nav_drive).isVisible = enableFeatures.contains(FeatureType.Drive)
         }
     }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/FeatureEnablesImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/FeatureEnablesImpl.kt
@@ -10,6 +10,7 @@ import net.pantasystem.milktea.model.instance.MetaRepository
 import net.pantasystem.milktea.model.instance.Version
 import net.pantasystem.milktea.model.nodeinfo.NodeInfo
 import net.pantasystem.milktea.model.nodeinfo.NodeInfoRepository
+import net.pantasystem.milktea.model.nodeinfo.getVersion
 import java.net.URL
 import javax.inject.Inject
 
@@ -20,34 +21,29 @@ class FeatureEnablesImpl @Inject constructor(
     @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ): FeatureEnables {
     override suspend fun isEnable(instanceDomain: String, type: FeatureType, default: Boolean): Boolean {
-        return withContext(ioDispatcher) {
-            val meta = metaRepository.find(instanceDomain).getOrNull()?: return@withContext default
-            val nodeInfo = nodeInfoRepository.find(URL(instanceDomain).host).getOrNull() ?: return@withContext default
-            when(type) {
-                FeatureType.Gallery -> meta.getVersion() >= Version("12.75.0")
-                FeatureType.Channel -> meta.getVersion() >= Version("12")
-                FeatureType.Group -> meta.getVersion() >= Version("11")
-                FeatureType.Antenna -> meta.getVersion() >= Version("12.75.0")
-                FeatureType.UserReactionHistory -> meta.getVersion() >= Version("12")
-                FeatureType.Drive -> nodeInfo.type is NodeInfo.SoftwareType.Misskey
-                FeatureType.Bookmark -> nodeInfo.type is NodeInfo.SoftwareType.Mastodon
-            }
+        val features = enableFeatures(instanceDomain)
+        return if (features.isEmpty()) {
+            default
+        } else {
+            features.contains(type)
         }
     }
 
     override suspend fun enableFeatures(instanceDomain: String): Set<FeatureType> {
         return withContext(ioDispatcher) {
-            val meta = metaRepository.find(instanceDomain).getOrNull()?: return@withContext emptySet()
-            val nodeInfo = nodeInfoRepository.find(URL(instanceDomain).host).getOrNull()
-
+            val meta = metaRepository.find(instanceDomain).getOrNull()
+            val nodeInfo = nodeInfoRepository.find(URL(instanceDomain).host).getOrNull() ?: return@withContext emptySet()
+            val version = meta?.getVersion() ?: nodeInfo.type.getVersion()
+            val isMisskey = meta != null || nodeInfo.type is NodeInfo.SoftwareType.Misskey
+            val isMastodon = nodeInfo.type is NodeInfo.SoftwareType.Mastodon
             setOfNotNull(
-                if (meta.getVersion() >= Version("12.75.0")) FeatureType.Gallery else null,
-                if (meta.getVersion() >= Version("12")) FeatureType.Channel else null,
-                if (meta.getVersion() >= Version("11")) FeatureType.Group else null,
-                if (meta.getVersion() >= Version("12.75.0")) FeatureType.Antenna else null,
-                if (meta.getVersion() >= Version("12")) FeatureType.UserReactionHistory else null,
-                if (nodeInfo?.type is NodeInfo.SoftwareType.Misskey) FeatureType.Drive else null,
-                if (nodeInfo?.type is NodeInfo.SoftwareType.Mastodon) FeatureType.Bookmark else null,
+                if (isMisskey && version >= Version("12.75.0")) FeatureType.Gallery else null,
+                if (isMisskey && version >= Version("12")) FeatureType.Channel else null,
+                if (isMisskey && version >= Version("11")) FeatureType.Group else null,
+                if (isMisskey && version >= Version("12.75.0")) FeatureType.Antenna else null,
+                if (isMisskey && version >= Version("12")) FeatureType.UserReactionHistory else null,
+                if (isMisskey) FeatureType.Drive else null,
+                if (isMastodon) FeatureType.Bookmark else null,
             )
         }
     }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/FeatureEnablesImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/FeatureEnablesImpl.kt
@@ -8,22 +8,29 @@ import net.pantasystem.milktea.model.instance.FeatureEnables
 import net.pantasystem.milktea.model.instance.FeatureType
 import net.pantasystem.milktea.model.instance.MetaRepository
 import net.pantasystem.milktea.model.instance.Version
+import net.pantasystem.milktea.model.nodeinfo.NodeInfo
+import net.pantasystem.milktea.model.nodeinfo.NodeInfoRepository
+import java.net.URL
 import javax.inject.Inject
 
 class FeatureEnablesImpl @Inject constructor(
     val misskeyAPIProvider: MisskeyAPIProvider,
     val metaRepository: MetaRepository,
+    val nodeInfoRepository: NodeInfoRepository,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ): FeatureEnables {
     override suspend fun isEnable(instanceDomain: String, type: FeatureType, default: Boolean): Boolean {
         return withContext(ioDispatcher) {
             val meta = metaRepository.find(instanceDomain).getOrNull()?: return@withContext default
+            val nodeInfo = nodeInfoRepository.find(URL(instanceDomain).host).getOrNull() ?: return@withContext default
             when(type) {
                 FeatureType.Gallery -> meta.getVersion() >= Version("12.75.0")
                 FeatureType.Channel -> meta.getVersion() >= Version("12")
                 FeatureType.Group -> meta.getVersion() >= Version("11")
                 FeatureType.Antenna -> meta.getVersion() >= Version("12.75.0")
                 FeatureType.UserReactionHistory -> meta.getVersion() >= Version("12")
+                FeatureType.Drive -> nodeInfo.type is NodeInfo.SoftwareType.Misskey
+                FeatureType.Bookmark -> nodeInfo.type is NodeInfo.SoftwareType.Mastodon
             }
         }
     }
@@ -31,12 +38,16 @@ class FeatureEnablesImpl @Inject constructor(
     override suspend fun enableFeatures(instanceDomain: String): Set<FeatureType> {
         return withContext(ioDispatcher) {
             val meta = metaRepository.find(instanceDomain).getOrNull()?: return@withContext emptySet()
+            val nodeInfo = nodeInfoRepository.find(URL(instanceDomain).host).getOrNull()
+
             setOfNotNull(
                 if (meta.getVersion() >= Version("12.75.0")) FeatureType.Gallery else null,
                 if (meta.getVersion() >= Version("12")) FeatureType.Channel else null,
                 if (meta.getVersion() >= Version("11")) FeatureType.Group else null,
                 if (meta.getVersion() >= Version("12.75.0")) FeatureType.Antenna else null,
                 if (meta.getVersion() >= Version("12")) FeatureType.UserReactionHistory else null,
+                if (nodeInfo?.type is NodeInfo.SoftwareType.Misskey) FeatureType.Drive else null,
+                if (nodeInfo?.type is NodeInfo.SoftwareType.Mastodon) FeatureType.Bookmark else null,
             )
         }
     }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
@@ -25,10 +25,7 @@ import net.pantasystem.milktea.model.drive.UpdateFileProperty
 import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.file.AppFile
 import net.pantasystem.milktea.model.file.FilePreviewSource
-import net.pantasystem.milktea.model.instance.InstanceInfo
-import net.pantasystem.milktea.model.instance.InstanceInfoRepository
-import net.pantasystem.milktea.model.instance.MetaRepository
-import net.pantasystem.milktea.model.instance.Version
+import net.pantasystem.milktea.model.instance.*
 import net.pantasystem.milktea.model.notes.*
 import net.pantasystem.milktea.model.notes.draft.DraftNoteRepository
 import net.pantasystem.milktea.model.notes.draft.DraftNoteService
@@ -60,6 +57,7 @@ class NoteEditorViewModel @Inject constructor(
     private val createNoteWorkerExecutor: CreateNoteWorkerExecutor,
     private val accountRepository: AccountRepository,
     private val localConfigRepository: LocalConfigRepository,
+    private val featureEnables: FeatureEnables,
     private val noteRelationGetter: NoteRelationGetter,
     private val instanceInfoRepository: InstanceInfoRepository,
     private val savedStateHandle: SavedStateHandle,
@@ -138,6 +136,10 @@ class NoteEditorViewModel @Inject constructor(
             initialValue = 1500
         )
 
+
+    val enableFeatures = currentAccount.filterNotNull().map {
+        featureEnables.enableFeatures(it.normalizedInstanceDomain)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
 
     val maxFileCount = currentAccount.filterNotNull().mapNotNull {
         metaRepository.get(it.normalizedInstanceDomain)?.getVersion()

--- a/modules/features/note/src/main/res/layout/fragment_note_editor.xml
+++ b/modules/features/note/src/main/res/layout/fragment_note_editor.xml
@@ -11,6 +11,7 @@
                 type="net.pantasystem.milktea.common_android_ui.account.viewmodel.AccountViewModel" />
         <import type="android.view.View"/>
         <import type="net.pantasystem.milktea.common_android.ui.SafeUnbox" />
+        <import type="net.pantasystem.milktea.model.instance.FeatureType" />
     </data>
     <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
@@ -209,7 +210,8 @@
                     android:adjustViewBounds="true"
                     tools:ignore="ContentDescription"
                     android:layout_margin="4dp"
-                    app:tint="?attr/normalIconTint" />
+                    app:tint="?attr/normalIconTint"
+                    android:visibility="@{ viewModel.enableFeatures.contains(FeatureType.Drive) ? View.VISIBLE : View.GONE }"/>
 
             <ImageButton
                     android:id="@+id/makePoll"

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/instance/FeatureEnables.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/instance/FeatureEnables.kt
@@ -1,10 +1,15 @@
 package net.pantasystem.milktea.model.instance
 
 interface FeatureEnables {
-    suspend fun isEnable(instanceDomain: String, type: FeatureType, default: Boolean = true): Boolean
+    suspend fun isEnable(
+        instanceDomain: String,
+        type: FeatureType,
+        default: Boolean = true
+    ): Boolean
+
     suspend fun enableFeatures(instanceDomain: String): Set<FeatureType>
 }
 
 enum class FeatureType {
-    Gallery, Channel, Group, Antenna, UserReactionHistory,
+    Gallery, Channel, Group, Antenna, UserReactionHistory, Drive, Bookmark
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/nodeinfo/NodeInfo.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/nodeinfo/NodeInfo.kt
@@ -1,5 +1,7 @@
 package net.pantasystem.milktea.model.nodeinfo
 
+import net.pantasystem.milktea.model.instance.Version
+
 
 data class NodeInfo(
     val host: String,
@@ -53,4 +55,8 @@ data class NodeInfo(
         "fedibird" -> SoftwareType.Mastodon.Fedibird(version = software.version, name = software.name)
         else -> SoftwareType.Other(version = software.version, name = software.name)
     }
+}
+
+fun NodeInfo.SoftwareType.getVersion(): Version {
+    return Version(this.version)
 }


### PR DESCRIPTION
## やったこと
Mastodon時はDrive関連のリンクを表示しないようにしました。
それに伴い機能有効判定クラスであるFeatureEnablesの実装クラスの判定ロジックを変更し
具体的にはソフトウェア種別を読み取ったり、一部重複コードを排除するようにしました。
またリンクを表示しないようにした箇所としては、ノートの編集画面とメイン画面のNavigationDrawerの項目です。
## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1279 


