### PR TITLE
アプリがバックグラウンドに遷移した時自動的にストリーミングとノートのキャプチャーを停止するようにした

### DIFF
--- a/modules/app_store/src/main/java/net/pantasystem/milktea/app_store/notes/TimelineStore.kt
+++ b/modules/app_store/src/main/java/net/pantasystem/milktea/app_store/notes/TimelineStore.kt
@@ -18,6 +18,7 @@ interface TimelineStore {
     val timelineState: Flow<PageableState<List<Note.Id>>>
     val relatedNotes: Flow<PageableState<List<NoteRelation>>>
     val receiveNoteQueue: SharedFlow<Note.Id>
+    val isActiveStreaming: Boolean
 
 
     suspend fun loadPrevious(): Result<Unit>
@@ -35,6 +36,9 @@ interface TimelineStore {
     fun onReceiveNote(noteId: Note.Id)
 
     fun latestReceiveNoteId(): Note.Id?
+
+    fun suspendStreaming()
+
 }
 
 sealed interface InitialLoadQuery {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
@@ -260,6 +260,8 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
         super.onResume()
 
         isShowing = true
+        mViewModel.onResume()
+
         currentPageableTimelineViewModel.setCurrentPageable(mPageable)
         try {
             mLinearLayoutManager.scrollToPosition(mViewModel.position)
@@ -270,8 +272,8 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
 
     override fun onPause() {
         super.onPause()
-
         isShowing = false
+        mViewModel.onPause()
         Log.d("TimelineFragment", "onPause")
     }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -7,11 +7,8 @@ import androidx.lifecycle.viewModelScope
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.plus
 import kotlinx.datetime.Instant
 import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.app_store.notes.InitialLoadQuery
@@ -112,6 +109,17 @@ class TimelineViewModel @AssistedInject constructor(
         viewModelScope
     )
 
+    private val noteStreamingCollector = NoteStreamingCollector(
+        accountStore = accountStore,
+        timelineStore = timelineStore,
+        coroutineScope = viewModelScope,
+        logger = logger,
+        currentAccountWatcher = currentAccountWatcher,
+        noteStreaming = noteStreaming,
+        pageable = pageable,
+    )
+    private var isActive = true
+
     init {
 
         viewModelScope.launch {
@@ -124,14 +132,15 @@ class TimelineViewModel @AssistedInject constructor(
             }
         }
 
-        accountStore.observeCurrentAccount.filterNotNull().distinctUntilChanged().flatMapLatest {
-            noteStreaming.connect(currentAccountWatcher::getAccount, pageable)
-        }.map {
-            timelineStore.onReceiveNote(it.id)
-        }.catch {
-            logger.error("receive not error", it)
-        }.launchIn(viewModelScope + Dispatchers.IO)
-
+        viewModelScope.launch {
+            (0..Int.MAX_VALUE).asFlow().map {
+                delay(10_000)
+            }.filter {
+                isActive && !timelineStore.isActiveStreaming
+            }.map {
+                timelineStore.loadFuture()
+            }.collect()
+        }
     }
 
 
@@ -166,6 +175,18 @@ class TimelineViewModel @AssistedInject constructor(
         }
     }
 
+
+
+    fun onResume() {
+        isActive = true
+        noteStreamingCollector.onResume()
+    }
+
+    fun onPause() {
+        isActive = false
+        timelineStore.suspendStreaming()
+        noteStreamingCollector.onSuspend()
+    }
 
 }
 
@@ -248,5 +269,42 @@ fun PageableState<List<PlaneNoteViewData>>.toList(): List<TimelineListItem> {
                 }
             )
         }
+    }
+}
+
+class NoteStreamingCollector(
+    val coroutineScope: CoroutineScope,
+    val timelineStore: TimelineStore,
+    val accountStore: AccountStore,
+    val noteStreaming: NoteStreaming,
+    val logger: Logger,
+    val pageable: Pageable,
+    val currentAccountWatcher: CurrentAccountWatcher,
+) {
+
+    private var job: Job? = null
+
+    fun onSuspend() {
+        synchronized(this) {
+            job?.cancel()
+            job = null
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun onResume() {
+        synchronized(this) {
+            if (job != null) {
+                return
+            }
+            job = accountStore.observeCurrentAccount.filterNotNull().distinctUntilChanged().flatMapLatest {
+                noteStreaming.connect(currentAccountWatcher::getAccount, pageable)
+            }.map {
+                timelineStore.onReceiveNote(it.id)
+            }.catch {
+                logger.error("receive not error", it)
+            }.launchIn(coroutineScope + Dispatchers.IO)
+        }
+
     }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -180,12 +180,18 @@ class TimelineViewModel @AssistedInject constructor(
     fun onResume() {
         isActive = true
         noteStreamingCollector.onResume()
+        viewModelScope.launch {
+            cache.captureNotes()
+        }
     }
 
     fun onPause() {
         isActive = false
         timelineStore.suspendStreaming()
         noteStreamingCollector.onSuspend()
+        viewModelScope.launch {
+            cache.suspendNoteCapture()
+        }
     }
 
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewDataCache.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewDataCache.kt
@@ -195,4 +195,23 @@ class PlaneNoteViewDataCache(
             ).load(note.urlPreviewLoadTaskCallback)
         }
     }
+
+    suspend fun suspendNoteCapture() {
+        lock.withLock {
+            cache.values.map {
+                it.job?.cancel()
+            }
+        }
+    }
+
+    suspend fun captureNotes() {
+        lock.withLock {
+            cache.values.filter {
+                it.job == null
+            }.map {
+                it.captureNotes()
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## やったこと
アプリがバックグラウンドに遷移したときに、自動的にストリーミングとノートのキャプチャーを停止するようにしました。
またアプリが復帰したときには自動的にキャプチャーを再開にするようにしました。
また復帰時にはストリーミングを再開するのではなく新しい投稿を定期的に取得し、
取得した新しい投稿の件数が一定数を下回る場合はストリーミングを再開するようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1287 



