### PR TITLE
バックグラウンド遷移時のストリーミングの挙動を設定から変えられるようにした　

### DIFF
--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
@@ -99,7 +99,13 @@ fun Config.Companion.from(map: Map<Keys, PrefType?>): Config {
         )?.value ?: DefaultConfig.config.isDriveUsingGridView,
         isEnableNotificationSound = map.getValue<PrefType.BoolPref>(
             Keys.IsEnableNotificationSound
-        )?.value ?: DefaultConfig.config.isEnableNotificationSound
+        )?.value ?: DefaultConfig.config.isEnableNotificationSound,
+        isStopStreamingApiWhenBackground = map.getValue<PrefType.BoolPref>(
+            Keys.IsStopStreamingApiWhenBackground
+        )?.value ?: DefaultConfig.config.isStopStreamingApiWhenBackground,
+        isStopNoteCaptureWhenBackground = map.getValue<PrefType.BoolPref>(
+            Keys.IsStopNoteCaptureWhenBackground
+        )?.value ?: DefaultConfig.config.isStopNoteCaptureWhenBackground,
     )
 }
 
@@ -177,6 +183,12 @@ fun Config.pref(key: Keys): PrefType {
         }
         Keys.IsEnableNotificationSound -> {
             PrefType.BoolPref(isEnableNotificationSound)
+        }
+        Keys.IsStopNoteCaptureWhenBackground -> {
+            PrefType.BoolPref(isStopNoteCaptureWhenBackground)
+        }
+        Keys.IsStopStreamingApiWhenBackground -> {
+            PrefType.BoolPref(isStopStreamingApiWhenBackground)
         }
     }
 }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
@@ -115,6 +115,14 @@ class ConfigKtTest {
                     config.isEnableNotificationSound,
                     (u as PrefType.BoolPref).value
                 )
+                Keys.IsStopNoteCaptureWhenBackground -> Assertions.assertEquals(
+                    config.isStopNoteCaptureWhenBackground,
+                    (u as PrefType.BoolPref).value
+                )
+                Keys.IsStopStreamingApiWhenBackground -> Assertions.assertEquals(
+                    config.isStopStreamingApiWhenBackground,
+                    (u as PrefType.BoolPref).value
+                )
             }
         }
     }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
@@ -76,6 +76,14 @@ class KeysKtTest {
                     "IsEnableNotificationSound",
                     key.str()
                 )
+                Keys.IsStopNoteCaptureWhenBackground -> Assertions.assertEquals(
+                    "IsStopNoteCaptureWhenBackground",
+                    key.str()
+                )
+                Keys.IsStopStreamingApiWhenBackground -> Assertions.assertEquals(
+                    "IsStopStreamingApiWhenBackground",
+                    key.str()
+                )
             }
         }
     }
@@ -83,8 +91,8 @@ class KeysKtTest {
 
     @Test
     fun checkAllKeysCount() {
-        Assertions.assertEquals(21, Keys.allKeys.size)
-        Assertions.assertEquals(21, Keys.allKeys.map { it.str() }.toSet().size)
+        Assertions.assertEquals(23, Keys.allKeys.size)
+        Assertions.assertEquals(23, Keys.allKeys.map { it.str() }.toSet().size)
     }
 
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -182,9 +182,13 @@ class TimelineViewModel @AssistedInject constructor(
 
     fun onResume() {
         isActive = true
-        noteStreamingCollector.onResume()
         viewModelScope.launch {
+            noteStreamingCollector.onResume()
             cache.captureNotes()
+            val config = configRepository.get().getOrNull()
+            if (config?.isStopStreamingApiWhenBackground == true) {
+                loadNew()
+            }
         }
     }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -25,6 +25,7 @@ import net.pantasystem.milktea.model.account.UnauthorizedException
 import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.model.notes.NoteStreaming
 import net.pantasystem.milktea.model.notes.muteword.WordFilterConfigRepository
+import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewDataCache
@@ -40,6 +41,7 @@ class TimelineViewModel @AssistedInject constructor(
     private val accountStore: AccountStore,
     private val wordFilterConfigRepository: WordFilterConfigRepository,
     planeNoteViewDataCacheFactory: PlaneNoteViewDataCache.Factory,
+    private val configRepository: LocalConfigRepository,
     @Assisted val account: Account?,
     @Assisted val accountId: Long? = account?.accountId,
     @Assisted val pageable: Pageable,
@@ -188,10 +190,15 @@ class TimelineViewModel @AssistedInject constructor(
 
     fun onPause() {
         isActive = false
-        timelineStore.suspendStreaming()
-        noteStreamingCollector.onSuspend()
         viewModelScope.launch {
-            cache.suspendNoteCapture()
+            val config = configRepository.get().getOrNull()
+            if (config?.isStopStreamingApiWhenBackground == true) {
+                timelineStore.suspendStreaming()
+                noteStreamingCollector.onSuspend()
+            }
+            if (config?.isStopNoteCaptureWhenBackground == true) {
+                cache.suspendNoteCapture()
+            }
         }
     }
 

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingMovementActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingMovementActivity.kt
@@ -39,7 +39,6 @@ import net.pantasystem.milktea.setting.SettingTitleTile
 import javax.inject.Inject
 
 
-
 @AndroidEntryPoint
 class SettingMovementActivity : AppCompatActivity() {
 
@@ -198,10 +197,38 @@ class SettingMovementActivity : AppCompatActivity() {
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .padding(horizontal = 16.dp),
-                                checked = currentConfigState.isEnableNotificationSound, onChanged = {
-                                    currentConfigState = currentConfigState.copy(isEnableNotificationSound = it)
+                                checked = currentConfigState.isEnableNotificationSound,
+                                onChanged = {
+                                    currentConfigState =
+                                        currentConfigState.copy(isEnableNotificationSound = it)
                                 }) {
                                 Text(stringResource(id = R.string.inapp_notification_sound))
+                            }
+                        }
+
+                        item {
+                            SettingTitleTile(text = stringResource(id = R.string.streaming))
+                            SwitchTile(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp),
+                                checked = currentConfigState.isStopStreamingApiWhenBackground,
+                                onChanged = {
+                                    currentConfigState =
+                                        currentConfigState.copy(isStopStreamingApiWhenBackground = it)
+                                }) {
+                                Text(stringResource(id = R.string.is_stop_timeline_streaming_when_background))
+                            }
+                            SwitchTile(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp),
+                                checked = currentConfigState.isStopNoteCaptureWhenBackground,
+                                onChanged = {
+                                    currentConfigState =
+                                        currentConfigState.copy(isStopNoteCaptureWhenBackground = it)
+                                }) {
+                                Text(stringResource(id = R.string.is_stop_note_capture_when_background))
                             }
                         }
                     }

--- a/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
+++ b/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
@@ -7,5 +7,8 @@
     <string name="overwrite_save">上書き保存</string>
     <string name="notification_sound">通知音</string>
     <string name="inapp_notification_sound">アプリ内通知音を有効にする</string>
+    <string name="streaming">自動更新</string>
+    <string name="is_stop_timeline_streaming_when_background">バックグラウンドでタイムラインを更新しない</string>
+    <string name="is_stop_note_capture_when_background">バックグラウンドでノートをキャプチャしない</string>
 
 </resources>

--- a/modules/features/setting/src/main/res/values-zh/strings.xml
+++ b/modules/features/setting/src/main/res/values-zh/strings.xml
@@ -7,5 +7,8 @@
     <string name="overwrite_save">覆盖保存</string>
     <string name="notification_sound">通知音</string>
     <string name="inapp_notification_sound">启用应用内通知音</string>
+    <string name="streaming">自動更新</string>
+    <string name="is_stop_timeline_streaming_when_background">在后台不更新时间线</string>
+    <string name="is_stop_note_capture_when_background">不要在后台捕捉笔记</string>
 
 </resources>

--- a/modules/features/setting/src/main/res/values/strings.xml
+++ b/modules/features/setting/src/main/res/values/strings.xml
@@ -7,4 +7,7 @@
     <string name="overwrite_save">Overwrite save</string>
     <string name="notification_sound">Notification Sound</string>
     <string name="inapp_notification_sound">Enable In-app notification sound</string>
+    <string name="streaming">Automatic updating</string>
+    <string name="is_stop_timeline_streaming_when_background">Do not update timeline when in background</string>
+    <string name="is_stop_note_capture_when_background">Do not capture notes in background</string>
 </resources>

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
@@ -44,6 +44,8 @@ data class IsAnalyticsCollectionEnabled(
  * @param isEnableInstanceTicker Instance Tickerの有無
  * @param isDriveUsingGridView 一覧表示時にグリッド表示を行うのか
  * @param isEnableNotificationSound アプリ内通知の通知音の有無
+ * @param isStopNoteCaptureWhenBackground バックグラウンド移行時にノートのキャプチャーを停止する
+ * @param isStopStreamingApiWhenBackground バックグルアンド移行時にストリーミングを中止する
  */
 data class Config(
     val isSimpleEditorEnabled: Boolean,
@@ -65,6 +67,8 @@ data class Config(
     val isEnableInstanceTicker: Boolean,
     val isDriveUsingGridView: Boolean,
     val isEnableNotificationSound: Boolean,
+    val isStopStreamingApiWhenBackground: Boolean,
+    val isStopNoteCaptureWhenBackground: Boolean,
 ) {
     companion object
 
@@ -114,6 +118,8 @@ object DefaultConfig {
         isEnableInstanceTicker = true,
         isDriveUsingGridView = false,
         isEnableNotificationSound = true,
+        isStopNoteCaptureWhenBackground = true,
+        isStopStreamingApiWhenBackground = true,
     )
 
     fun getRememberVisibilityConfig(accountId: Long): RememberVisibility.Remember {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
@@ -23,6 +23,8 @@ val Keys.Companion.allKeys by lazy {
         Keys.IsEnableInstanceTicker,
         Keys.IsDriveUsingGridView,
         Keys.IsEnableNotificationSound,
+        Keys.IsStopStreamingApiWhenBackground,
+        Keys.IsStopNoteCaptureWhenBackground,
     )
 }
 
@@ -64,6 +66,10 @@ sealed interface Keys {
 
     object IsEnableNotificationSound : Keys
 
+    object IsStopStreamingApiWhenBackground : Keys
+
+    object IsStopNoteCaptureWhenBackground : Keys
+
     companion object
 }
 
@@ -90,5 +96,7 @@ fun Keys.str(): String {
         is Keys.IsEnableInstanceTicker -> "IsEnableInstanceTicker"
         is Keys.IsDriveUsingGridView -> "IsDriveUsingGridView"
         is Keys.IsEnableNotificationSound -> "IsEnableNotificationSound"
+        is Keys.IsStopNoteCaptureWhenBackground -> "IsStopNoteCaptureWhenBackground"
+        is Keys.IsStopStreamingApiWhenBackground -> "IsStopStreamingApiWhenBackground"
     }
 }


### PR DESCRIPTION
## やったこと
バックグラウンド遷移時にストリーミングの挙動を設定から変えられるようにしました。
具体的にはノートのキャプチャーの停止の有無とタイムラインのストリーミングの停止の有無を設定から変更できるようにしました。
またタイムラインの自動更新をOFFにした時は画面が復帰した時に即座に新しい投稿を読み取りに行くようにしました。
## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1291 


