### PR TITLE
Mastodonに投稿できるようにした

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -10,6 +10,8 @@ import net.pantasystem.milktea.api.mastodon.apps.ObtainToken
 import net.pantasystem.milktea.api.mastodon.emojis.TootEmojiDTO
 import net.pantasystem.milktea.api.mastodon.instance.Instance
 import net.pantasystem.milktea.api.mastodon.notification.MstNotificationDTO
+import net.pantasystem.milktea.api.mastodon.status.CreateStatus
+import net.pantasystem.milktea.api.mastodon.status.ScheduledStatus
 import net.pantasystem.milktea.api.mastodon.status.TootStatusDTO
 import retrofit2.Response
 import retrofit2.http.*
@@ -161,6 +163,15 @@ interface MastodonAPI {
         @Query("account_id") accountId: String? = null,
     ): Response<List<MstNotificationDTO>>
 
+    @POST("api/v1/statuses")
+    suspend fun createStatus(
+        @Body body: CreateStatus
+    ): Response<TootStatusDTO>
+
+    @POST("api/v1/status")
+    suspend fun createScheduledStatus(
+        @Body body: CreateStatus,
+    ): Response<ScheduledStatus>
 
 
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/CreateStatus.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/CreateStatus.kt
@@ -1,0 +1,28 @@
+package net.pantasystem.milktea.api.mastodon.status
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import net.pantasystem.milktea.model.notes.poll.CreatePoll
+
+@kotlinx.serialization.Serializable
+data class CreateStatus(
+    val status: String,
+    @SerialName("media_ids") val mediaIds: List<String>,
+    val poll: CreatePoll? = null,
+    @SerialName("in_reply_to_id") val inReplyToId: String? = null,
+    val sensitive: Boolean = false,
+    @SerialName("spoiler_text") val spoilerText: String? = null,
+    val visibility: String = "public",
+    val language: String,
+    @SerialName("scheduled_at") val scheduledAt: Instant? = null
+) {
+
+    @kotlinx.serialization.Serializable
+    data class CreatePoll(
+        val options: List<String>,
+        @SerialName("expires_in") val expiresIn: Boolean,
+        val multiple: Boolean = false,
+        @SerialName("hide_totals") val hideTotals: Boolean = false,
+
+    )
+}

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/CreateStatus.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/CreateStatus.kt
@@ -2,7 +2,6 @@ package net.pantasystem.milktea.api.mastodon.status
 
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
-import net.pantasystem.milktea.model.notes.poll.CreatePoll
 
 @kotlinx.serialization.Serializable
 data class CreateStatus(
@@ -13,14 +12,14 @@ data class CreateStatus(
     val sensitive: Boolean = false,
     @SerialName("spoiler_text") val spoilerText: String? = null,
     val visibility: String = "public",
-    val language: String,
+    val language: String? = null,
     @SerialName("scheduled_at") val scheduledAt: Instant? = null
 ) {
 
     @kotlinx.serialization.Serializable
     data class CreatePoll(
         val options: List<String>,
-        @SerialName("expires_in") val expiresIn: Boolean,
+        @SerialName("expires_in") val expiresIn: Int,
         val multiple: Boolean = false,
         @SerialName("hide_totals") val hideTotals: Boolean = false,
 

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/ScheduledStatus.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/ScheduledStatus.kt
@@ -1,0 +1,29 @@
+package net.pantasystem.milktea.api.mastodon.status
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import net.pantasystem.milktea.api.mastodon.media.TootMediaAttachment
+
+@kotlinx.serialization.Serializable
+data class ScheduledStatus(
+    val id: String,
+    @SerialName("scheduled_at") val scheduledAt: Instant,
+    val params: Params,
+    @SerialName("media_attachments") val mediaAttachments: List<TootMediaAttachment>? = null
+) {
+
+    @kotlinx.serialization.Serializable
+    data class Params(
+        val text: String,
+        val poll: CreateStatus.CreatePoll? = null,
+        @SerialName("media_ids") val mediaIds: List<String>? = null,
+        val sensitive: Boolean? = null,
+        @SerialName("spoiler_text") val spoilerText: String? = null,
+        val visibility: String,
+        @SerialName("in_reply_to_id") val inReplyToId: String? = null,
+        val language: String? = null,
+        @SerialName("application_id") val applicationId: Int? = null,
+        @SerialName("scheduled_at") val scheduledAt: Instant? = null,
+        @SerialName("with_rate_limit") val withRateLimit: Boolean? = null,
+    )
+}

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/TootStatusDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/TootStatusDTO.kt
@@ -92,9 +92,9 @@ data class TootStatusDTO(
 
         val reaction = if (isCustomEmoji) {
             if (domain == null) {
-                "$name@."
+                ":$name@.:"
             } else {
-                "$name@$domain"
+                ":$name@$domain:"
             }
         } else {
             name

--- a/modules/api_streaming/src/main/java/net/pantasystem/milktea/api_streaming/mastodon/StreamingAPIImpl.kt
+++ b/modules/api_streaming/src/main/java/net/pantasystem/milktea/api_streaming/mastodon/StreamingAPIImpl.kt
@@ -198,6 +198,7 @@ class StreamingAPIImpl(
             logger.debug("onOpen")
             synchronized(listenersMap) {
                 if (connections[connectType] != null) {
+                    logger.debug("既に接続済みのコネクションが存在するため接続解除 type:$connectType")
                     connections[connectType]?.cancel()
                 }
                 isWaitingConnections.remove(connectType)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteApiAdapter.kt
@@ -1,0 +1,88 @@
+package net.pantasystem.milktea.data.infrastructure.notes.impl
+
+import kotlinx.datetime.Clock
+import net.pantasystem.milktea.api.mastodon.status.CreateStatus
+import net.pantasystem.milktea.api.mastodon.status.TootStatusDTO
+import net.pantasystem.milktea.api.misskey.notes.NoteDTO
+import net.pantasystem.milktea.common.Logger
+import net.pantasystem.milktea.common.mapCancellableCatching
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.common.throwIfHasError
+import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
+import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.data.infrastructure.drive.FileUploaderProvider
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.drive.FilePropertyDataSource
+import net.pantasystem.milktea.model.notes.CreateNote
+import net.pantasystem.milktea.model.notes.type4Mastodon
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NoteApiAdapter @Inject constructor(
+    val accountRepository: AccountRepository,
+    val misskeyAPIProvider: MisskeyAPIProvider,
+    val mastodonAPIProvider: MastodonAPIProvider,
+    val loggerFactory: Logger.Factory,
+    val filePropertyDataSource: FilePropertyDataSource,
+    private val uploader: FileUploaderProvider,
+
+    ) {
+
+    suspend fun create(createNote: CreateNote): NoteCreatedResultType {
+        return when(createNote.author.instanceType) {
+            Account.InstanceType.MISSKEY -> {
+                val task = PostNoteTask(
+                    createNote,
+                    createNote.author,
+                    loggerFactory,
+                    filePropertyDataSource
+                )
+                val result = runCancellableCatching {
+                    task.execute(
+                        uploader.get(createNote.author)
+                    ) ?: throw IllegalStateException("ファイルのアップロードに失敗しました")
+                }.mapCancellableCatching {
+                    misskeyAPIProvider.get(createNote.author).create(it).throwIfHasError()
+                        .body()?.createdNote
+                }.onFailure {
+                    loggerFactory.create("NoteApiAdapter").error("create note error", it)
+                }
+
+                val noteDTO = result.getOrThrow()
+                NoteCreatedResultType.Misskey(requireNotNull(noteDTO))
+            }
+            Account.InstanceType.MASTODON -> {
+                // TODO: 画像投稿処理を追加する
+                val body = mastodonAPIProvider.get(createNote.author).createStatus(
+                    CreateStatus(
+                        status = createNote.text ?: "",
+                        mediaIds = emptyList(),
+                        inReplyToId = createNote.replyId?.noteId,
+                        spoilerText = createNote.cw,
+                        sensitive = createNote.cw != null,
+                        visibility = createNote.visibility.type4Mastodon(),
+                        poll = createNote.poll?.let { poll ->
+                            CreateStatus.CreatePoll(
+                                options = poll.choices,
+                                multiple = poll.multiple,
+                                expiresIn = poll.expiresAt?.let {
+                                    (it - Clock.System.now().toEpochMilliseconds()) / 1000
+                                }?.toInt() ?: (5 * 60),
+                            )
+                        },
+                    )
+                ).throwIfHasError().body()
+                NoteCreatedResultType.Mastodon(requireNotNull(body))
+            }
+        }
+    }
+
+
+}
+
+sealed interface NoteCreatedResultType {
+    data class Misskey(val note: NoteDTO) : NoteCreatedResultType
+    data class Mastodon(val status: TootStatusDTO) : NoteCreatedResultType
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -12,7 +12,6 @@ import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
 import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
-import net.pantasystem.milktea.data.infrastructure.drive.FileUploaderProvider
 import net.pantasystem.milktea.data.infrastructure.notes.NoteDataSourceAdder
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.GetAccount
@@ -29,12 +28,11 @@ class NoteRepositoryImpl @Inject constructor(
     val userDataSource: UserDataSource,
     val noteDataSource: NoteDataSource,
     val filePropertyDataSource: FilePropertyDataSource,
-    private val uploader: FileUploaderProvider,
     val misskeyAPIProvider: MisskeyAPIProvider,
     val mastodonAPIProvider: MastodonAPIProvider,
     val noteDataSourceAdder: NoteDataSourceAdder,
     val getAccount: GetAccount,
-    val noteApiAdapter: NoteApiAdapter,
+    private val noteApiAdapter: NoteApiAdapter,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ) : NoteRepository {
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -5,7 +5,10 @@ import kotlinx.coroutines.flow.Flow
 import net.pantasystem.milktea.api.misskey.notes.DeleteNote
 import net.pantasystem.milktea.api.misskey.notes.NoteRequest
 import net.pantasystem.milktea.api.misskey.notes.mute.ToggleThreadMuteRequest
-import net.pantasystem.milktea.common.*
+import net.pantasystem.milktea.common.APIError
+import net.pantasystem.milktea.common.Logger
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
 import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
@@ -31,6 +34,7 @@ class NoteRepositoryImpl @Inject constructor(
     val mastodonAPIProvider: MastodonAPIProvider,
     val noteDataSourceAdder: NoteDataSourceAdder,
     val getAccount: GetAccount,
+    val noteApiAdapter: NoteApiAdapter,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ) : NoteRepository {
 
@@ -39,26 +43,14 @@ class NoteRepositoryImpl @Inject constructor(
 
     override suspend fun create(createNote: CreateNote): Result<Note> = runCancellableCatching {
         withContext(ioDispatcher) {
-            val task = PostNoteTask(
-                createNote,
-                createNote.author,
-                loggerFactory,
-                filePropertyDataSource
-            )
-            val result = runCancellableCatching {
-                task.execute(
-                    uploader.get(createNote.author)
-                ) ?: throw IllegalStateException("ファイルのアップロードに失敗しました")
-            }.mapCancellableCatching {
-                misskeyAPIProvider.get(createNote.author).create(it).throwIfHasError()
-                    .body()?.createdNote
-            }.onFailure {
-                logger.error("create note error", it)
+            when(val result = noteApiAdapter.create(createNote)) {
+                is NoteCreatedResultType.Mastodon -> {
+                    noteDataSourceAdder.addTootStatusDtoIntoDataSource(createNote.author, result.status)
+                }
+                is NoteCreatedResultType.Misskey -> {
+                    noteDataSourceAdder.addNoteDtoToDataSource(createNote.author, result.note)
+                }
             }
-
-            val noteDTO = result.getOrThrow()
-            require(noteDTO != null)
-            noteDataSourceAdder.addNoteDtoToDataSource(createNote.author, noteDTO)
         }
     }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/streaming/StreamingAPIProvider.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/streaming/StreamingAPIProvider.kt
@@ -6,6 +6,7 @@ import net.pantasystem.milktea.api_streaming.mastodon.StreamingAPIImpl
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.model.account.Account
 import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -30,7 +31,7 @@ class StreamingAPIProvider @Inject constructor(
             streaming = StreamingAPIImpl(
                 host = account.getHost(),
                 token = account.token,
-                okHttpClient = OkHttpClient.Builder().addInterceptor {
+                okHttpClient = OkHttpClient.Builder().readTimeout(1, TimeUnit.HOURS).addInterceptor {
                     val request = it.request()
                     val newReq = request.newBuilder()
                         .header("Authorization", "Bearer ${account.token}")

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/notes/NoteEventReducerKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/notes/NoteEventReducerKtTest.kt
@@ -1,6 +1,7 @@
 package net.pantasystem.milktea.data.infrastructure.notes
 
 import net.pantasystem.milktea.api_streaming.NoteUpdated
+import net.pantasystem.milktea.api_streaming.mastodon.EmojiReaction
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.notes.Note
@@ -222,4 +223,88 @@ class NoteEventReducerKtTest {
         )
     }
 
+
+    @Test
+    fun onEmojiReacted_GiveAddMyReaction() {
+        val note = Note.make(
+            id = Note.Id(0L, "1"),
+            text = "",
+            userId = User.Id(0L, "2"),
+            reactionCounts = listOf(
+                ReactionCount("watasimo", 1),
+            ),
+            myReaction = null
+        )
+        val updated = note.onEmojiReacted(
+            account, EmojiReaction(
+                name = "watasimo",
+                count = 2,
+                url = null,
+                staticUrl = null,
+                domain = null,
+                accountIds = listOf("test"),
+                statusId = "1"
+            )
+        )
+        Assertions.assertEquals("watasimo", updated.myReaction)
+        Assertions.assertEquals(updated.reactionCounts, listOf(
+            ReactionCount("watasimo", 2)
+        ))
+    }
+
+    @Test
+    fun onEmojiReacted_Unreacted() {
+        val note = Note.make(
+            id = Note.Id(0L, "1"),
+            text = "",
+            userId = User.Id(0L, "2"),
+            reactionCounts = listOf(
+                ReactionCount("watasimo", 2),
+            ),
+            myReaction = "watasimo"
+        )
+        val updated = note.onEmojiReacted(
+            account, EmojiReaction(
+                name = "watasimo",
+                count = 1,
+                url = null,
+                staticUrl = null,
+                domain = null,
+                accountIds = listOf(),
+                statusId = "1"
+            )
+        )
+        Assertions.assertEquals(null, updated.myReaction)
+        Assertions.assertEquals(updated.reactionCounts, listOf(
+            ReactionCount("watasimo", 1)
+        ))
+    }
+
+    @Test
+    fun onEmojiReacted_WhenApplied() {
+        val note = Note.make(
+            id = Note.Id(0L, "1"),
+            text = "",
+            userId = User.Id(0L, "2"),
+            reactionCounts = listOf(
+                ReactionCount("watasimo", 2),
+            ),
+            myReaction = "watasimo"
+        )
+        val updated = note.onEmojiReacted(
+            account, EmojiReaction(
+                name = "watasimo",
+                count = 2,
+                url = null,
+                staticUrl = null,
+                domain = null,
+                accountIds = listOf("test"),
+                statusId = "1"
+            )
+        )
+        Assertions.assertEquals("watasimo", updated.myReaction)
+        Assertions.assertEquals(updated.reactionCounts, listOf(
+            ReactionCount("watasimo", 2)
+        ))
+    }
 }


### PR DESCRIPTION
## やったこと
Mastodonに投稿できるようにしました。
またStreaming API周りの実装にすぐにタイムアウトしてしまう不具合があったので合わせて修正しました。
また同一リアクションが2種類のリアクションとして増殖してしまう不具合を修正しました。

## 動作確認


## スクリーンショット(任意)


## 備考
- 画像の投稿処理などはまだ実装できていません。
- スケジュール投稿の実装はまだできていません。

## Issue番号
Closed #1232 



