### PR TITLE
Mastodonログイン時でもノート編集画面の最大文字数が反映されるように

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -174,4 +174,6 @@ interface MastodonAPI {
     ): Response<ScheduledStatus>
 
 
+    @GET("api/v1/statuses/{statusId}")
+    suspend fun getStatus(@Path("statusId") statusId: String): Response<TootStatusDTO>
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -176,4 +176,7 @@ interface MastodonAPI {
 
     @GET("api/v1/statuses/{statusId}")
     suspend fun getStatus(@Path("statusId") statusId: String): Response<TootStatusDTO>
+
+    @DELETE("api/v1/statuses/{statusId}")
+    suspend fun deleteStatus(@Path("statusId") statusId: String): Response<TootStatusDTO>
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -183,4 +183,10 @@ interface MastodonAPI {
 
     @POST("api/v1/polls/{pollId}/votes")
     suspend fun voteOnPoll(@Path("pollId") pollId: String, @Field("choices[]", encoded = true) choices: List<Int>): Response<TootPollDTO>
+
+    @POST("api/v1/statuses/{statusId}/mute")
+    suspend fun muteConversation(@Path("statusId") statusId: String): Response<TootStatusDTO>
+
+    @POST("api/v1/statuses/{statusId}/unmute")
+    suspend fun unmuteConversation(@Path("statusId") statusId: String): Response<TootStatusDTO>
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -10,6 +10,7 @@ import net.pantasystem.milktea.api.mastodon.apps.ObtainToken
 import net.pantasystem.milktea.api.mastodon.emojis.TootEmojiDTO
 import net.pantasystem.milktea.api.mastodon.instance.Instance
 import net.pantasystem.milktea.api.mastodon.notification.MstNotificationDTO
+import net.pantasystem.milktea.api.mastodon.poll.TootPollDTO
 import net.pantasystem.milktea.api.mastodon.status.CreateStatus
 import net.pantasystem.milktea.api.mastodon.status.ScheduledStatus
 import net.pantasystem.milktea.api.mastodon.status.TootStatusDTO
@@ -179,4 +180,7 @@ interface MastodonAPI {
 
     @DELETE("api/v1/statuses/{statusId}")
     suspend fun deleteStatus(@Path("statusId") statusId: String): Response<TootStatusDTO>
+
+    @POST("api/v1/polls/{pollId}/votes")
+    suspend fun voteOnPoll(@Path("pollId") pollId: String, @Field("choices[]", encoded = true) choices: List<Int>): Response<TootPollDTO>
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
@@ -106,6 +106,7 @@ fun TootStatusDTO.toNote(account: Account, nodeInfo: NodeInfo?): Note {
                 it.toModel()
             } ?: emptyList(),
             isFedibirdQuote = quote != null,
+            pollId = poll?.id
         ),
         nodeInfo = nodeInfo,
     )

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -2,7 +2,6 @@ package net.pantasystem.milktea.data.infrastructure.notes.impl
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
-import net.pantasystem.milktea.api.misskey.notes.DeleteNote
 import net.pantasystem.milktea.api.misskey.notes.NoteRequest
 import net.pantasystem.milktea.api.misskey.notes.mute.ToggleThreadMuteRequest
 import net.pantasystem.milktea.common.APIError
@@ -85,10 +84,7 @@ class NoteRepositoryImpl @Inject constructor(
 
     override suspend fun delete(noteId: Note.Id): Result<Unit> = runCancellableCatching{
         withContext(ioDispatcher) {
-            val account = getAccount.get(noteId.accountId)
-            misskeyAPIProvider.get(account).delete(
-                DeleteNote(i = account.token, noteId = noteId.noteId)
-            ).throwIfHasError()
+            noteApiAdapter.delete(noteId)
         }
     }
 

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/instance/InstanceInfoType.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/instance/InstanceInfoType.kt
@@ -17,4 +17,22 @@ sealed interface InstanceInfoType {
             is Misskey -> meta.uri
         }
     }
+
+    val maxNoteTextLength: Int get() {
+        return when(this) {
+            is Mastodon -> info.configuration?.statuses?.maxCharacters ?: 500
+            is Misskey -> meta.maxNoteTextLength ?: 3000
+        }
+    }
+
+    val maxFileCount: Int get() {
+        return when(this) {
+            is Mastodon -> info.configuration?.statuses?.maxMediaAttachments ?: 4
+            is Misskey -> if (meta.getVersion() >= Version("12.100.2")) {
+                16
+            } else {
+                4
+            }
+        }
+    }
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
@@ -65,6 +65,7 @@ data class Note(
             val tags: List<Tag>,
             val mentions: List<Mention>,
             val isFedibirdQuote: Boolean,
+            val pollId: String?,
         ) : Type {
             data class Tag(
                 val name: String,

--- a/modules/model/src/test/java/net/pantasystem/milktea/model/notes/NoteTest.kt
+++ b/modules/model/src/test/java/net/pantasystem/milktea/model/notes/NoteTest.kt
@@ -135,7 +135,8 @@ class NoteTest {
                 favoriteCount = null,
                 tags = listOf(),
                 mentions = listOf(),
-                isFedibirdQuote = true
+                isFedibirdQuote = true,
+                pollId = null,
             )
         )
         assertTrue(note.isQuote())
@@ -153,7 +154,8 @@ class NoteTest {
                 favoriteCount = null,
                 tags = listOf(),
                 mentions = listOf(),
-                isFedibirdQuote = false
+                isFedibirdQuote = false,
+                pollId = null
             )
         )
         assertFalse(note.isQuote())
@@ -171,7 +173,8 @@ class NoteTest {
                 favoriteCount = null,
                 tags = listOf(),
                 mentions = listOf(),
-                isFedibirdQuote = false
+                isFedibirdQuote = false,
+                pollId = null
             ),
             renoteId = Note.Id(0L, "id")
         )
@@ -191,7 +194,8 @@ class NoteTest {
                 favoriteCount = null,
                 tags = listOf(),
                 mentions = listOf(),
-                isFedibirdQuote = false
+                isFedibirdQuote = false,
+                pollId = null
             )
         )
         assertFalse(note.hasContent())


### PR DESCRIPTION
## やったこと
Mastodonログイン時でもノート編集画面の最大文字数が反映されるようにした。
また投稿の削除と投票もできるようにしました。
また投稿情報の取得処理をMastodonにも対応させました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1300 
Closed #1241 
Closed #1261


