### PR TITLE
v13の破壊的変更の応急対応

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteDTO.kt
@@ -31,6 +31,8 @@ data class NoteDTO(
     @SerialName("visibleUserIds")
     val visibleUserIds: List<String>? = null,
 
+    val reactionEmojis: Map<String, String>? = null,
+
     val url: String? = null,
     val uri: String? = null,
 

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/UserDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/UserDTO.kt
@@ -34,6 +34,8 @@ data class UserDTO(
     val isAdmin: Boolean? = null,
     val avatarUrl: String? = null,
     val bannerUrl: String? = null,
+
+    @kotlinx.serialization.Transient
     val emojis: List<Emoji>? = null,
 
     val isFollowing: Boolean? = null,

--- a/modules/api/src/test/java/net/pantasystem/milktea/api/misskey/users/BaseUserDTOTest.kt
+++ b/modules/api/src/test/java/net/pantasystem/milktea/api/misskey/users/BaseUserDTOTest.kt
@@ -1,0 +1,34 @@
+package net.pantasystem.milktea.api.misskey.users
+
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+class BaseUserDTOTest {
+
+    val parser = Json {
+        ignoreUnknownKeys = true
+        this.useArrayPolymorphism
+    }
+
+
+    @Test
+    fun decodeFromV13() {
+        val json = """
+            {
+                "id": "93p88dgkeb",
+                "name": "テスト:blobcatgooglypencil:",
+                "username": "ringoringo",
+                "host": null,
+                "avatarUrl": "https://media.sushi.ski/files/thumbnail-31cd1772-507b-468d-9885-5f1f1b9fec1e.webp",
+                "avatarBlurhash": "",
+                "isBot": false,
+                "isCat": false,
+                "emojis": {},
+                "onlineStatus": "online"
+            }
+        """.trimIndent()
+
+        val result = parser.decodeFromString<UserDTO>(json)
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/MisskeyEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/MisskeyEntityConverters.kt
@@ -13,6 +13,7 @@ import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.channel.Channel
 import net.pantasystem.milktea.model.drive.FileProperty
 import net.pantasystem.milktea.model.drive.FilePropertyDataSource
+import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.gallery.GalleryPost
 import net.pantasystem.milktea.model.group.Group
 import net.pantasystem.milktea.model.group.InvitationId
@@ -173,7 +174,9 @@ fun NoteDTO.toNote(account: Account, nodeInfo: NodeInfo?): Note {
         viaMobile = this.viaMobile,
         visibility = visibility,
         localOnly = this.localOnly,
-        emojis = this.emojis,
+        emojis = (this.emojis ?: emptyList()) + (this.reactionEmojis?.map {
+            Emoji(name = it.key, uri = it.value, url = it.value)
+        } ?: emptyList()),
         app = this.app?.toModel(),
         fileIds = this.fileIds?.map { FileProperty.Id(account.accountId, it) },
         poll = this.poll?.toPoll(),


### PR DESCRIPTION
## やったこと
Userオブジェクトのemojisフィールドが復活したのは良いが
なぜか配列型ではなくオブジェクト型として復活してしまったため、
うまく読み取れず壊れるという事案が発生しこれにより、ログインの失敗やタイムラインの取得の失敗などの不具合が発生するようになった。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号




