### PR TITLE
v13.2.5でデータを取得できなくなる不具合を修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -199,7 +199,7 @@ dependencies {
 
 
 
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0"
+    implementation libs.kotlin.serialization
 
     implementation libs.wada811.databinding
 

--- a/app/src/test/java/jp/panta/misskeyandroidclient/api/notes/NoteDTOTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/api/notes/NoteDTOTest.kt
@@ -3,9 +3,9 @@ package jp.panta.misskeyandroidclient.api.notes
 
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
-import net.pantasystem.milktea.api.misskey.notes.EmojisType
+import net.pantasystem.milktea.api.misskey.emoji.EmojisType
+import net.pantasystem.milktea.api.misskey.emoji.TestNoteObject
 import net.pantasystem.milktea.api.misskey.notes.NoteDTO
-import net.pantasystem.milktea.api.misskey.notes.TestNoteObject
 import net.pantasystem.milktea.model.emoji.Emoji
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test

--- a/app/src/test/java/jp/panta/misskeyandroidclient/api/notes/NoteDTOTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/api/notes/NoteDTOTest.kt
@@ -3,7 +3,10 @@ package jp.panta.misskeyandroidclient.api.notes
 
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import net.pantasystem.milktea.api.misskey.notes.EmojisType
 import net.pantasystem.milktea.api.misskey.notes.NoteDTO
+import net.pantasystem.milktea.api.misskey.notes.TestNoteObject
+import net.pantasystem.milktea.model.emoji.Emoji
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -855,5 +858,58 @@ class NoteDTOTest {
         val noteDTO: List<NoteDTO> = builder.decodeFromString(jsonStr)
         Assertions.assertNotNull(noteDTO)
 
+    }
+
+    @Test
+    fun decodeArrayTypeEmoji() {
+        val builder = Json {
+            ignoreUnknownKeys = true
+        }
+        val json1 = """
+            [{"name": "hoge", "url": "https://example.com"}]
+        """.trimIndent()
+        val result = builder.decodeFromString<EmojisType>(json1)
+        Assertions.assertEquals(EmojisType.TypeArray(listOf(Emoji(name = "hoge", url = "https://example.com"))), result)
+
+    }
+
+    @Test
+    fun decodeObjectTypeEmoji() {
+        val builder = Json {
+            ignoreUnknownKeys = true
+        }
+        val json1 = """
+            {"hoge": "https://example.com", "piyo": "https://misskey.io"}
+        """.trimIndent()
+        val result = builder.decodeFromString<EmojisType>(json1)
+
+        Assertions.assertEquals(EmojisType.TypeObject(mapOf("hoge" to "https://example.com", "piyo" to "https://misskey.io")), result)
+    }
+
+    @Test
+    fun decodeFunckingObject() {
+        val builder = Json {
+            ignoreUnknownKeys = true
+        }
+        val json1 = """
+            {"emojis": [{"name": "hoge", "url": "https://example.com"}]}
+        """.trimIndent()
+        val result = builder.decodeFromString<TestNoteObject>(json1)
+        Assertions.assertEquals(TestNoteObject(EmojisType.TypeArray(
+            listOf(Emoji(name = "hoge", url = "https://example.com"))
+        )), result)
+    }
+
+    @Test
+    fun decodeEmptyObject() {
+        val builder = Json {
+            ignoreUnknownKeys = true
+        }
+        val json1 = """
+            {"emojis": {}}
+        """.trimIndent()
+        val result = builder.decodeFromString<TestNoteObject>(json1)
+
+        Assertions.assertEquals(TestNoteObject(EmojisType.TypeObject(emptyMap())), result)
     }
 }

--- a/app/src/test/java/jp/panta/misskeyandroidclient/streaming/StreamingEventTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/streaming/StreamingEventTest.kt
@@ -1,11 +1,7 @@
 package jp.panta.misskeyandroidclient.streaming
 
-import kotlinx.datetime.Clock
 import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import net.pantasystem.milktea.api.misskey.notes.NoteDTO
-import net.pantasystem.milktea.api.misskey.users.UserDTO
 import net.pantasystem.milktea.api_streaming.ChannelBody
 import net.pantasystem.milktea.api_streaming.ChannelEvent
 import net.pantasystem.milktea.api_streaming.StreamingEvent
@@ -15,73 +11,7 @@ import org.junit.jupiter.api.Test
 
 class StreamingEventTest {
 
-    @Test
-    fun testParseReceiveNote() {
 
-        val noteDTO = NoteDTO(
-            "piyo22",
-            Clock.System.now(),
-            "hogehoge",
-            null,
-            "piyo",
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            0,
-            null,
-            null,
-            0,
-            user = UserDTO(
-                "piyo",
-                "",
-                "",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                false,
-                isCat = false,
-                pinnedNoteIds = null,
-                pinnedNotes = null,
-                twoFactorEnabled = null,
-                isAdmin = null,
-                avatarUrl = null,
-                bannerUrl = null,
-                emojis = null,
-                isFollowing = null,
-                isFollowed = null,
-                isBlocking = null,
-                isMuted = null,
-                url = null
-            ),
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-
-
-        )
-        val se: StreamingEvent =
-            ChannelEvent(
-                ChannelBody.ReceiveNote(
-                    id = "hoge",
-                    body = noteDTO
-                )
-            )
-        println(Json.encodeToString(se))
-        assertTrue(true)
-    }
 
     @Test
     fun testDecodeJson() {

--- a/modules/api/build.gradle
+++ b/modules/api/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     androidTestImplementation libs.androidx.test.ext.junit
     androidTestImplementation libs.androidx.test.espresso.core
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0")
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0"
+    implementation libs.kotlin.serialization
     implementation libs.kotlin.datetime
 
 

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/emoji/EmojisType.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/emoji/EmojisType.kt
@@ -1,0 +1,80 @@
+package net.pantasystem.milktea.api.misskey.emoji
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import net.pantasystem.milktea.model.emoji.Emoji
+
+
+@kotlinx.serialization.Serializable(with = CustomEmojisTypeSerializer::class)
+sealed interface EmojisType {
+    @kotlinx.serialization.Serializable(with = TypeArraySerializer::class)
+    data class TypeArray(val emojis: List<Emoji>) : EmojisType
+
+    @kotlinx.serialization.Serializable(with = TypeObjectSerializer::class)
+    data class TypeObject(val emojis: Map<String, String>) : EmojisType
+
+    @kotlinx.serialization.Serializable
+    object None : EmojisType
+}
+
+@kotlinx.serialization.Serializable
+data class TestNoteObject(
+    @kotlinx.serialization.Serializable(with = CustomEmojisTypeSerializer::class) val emojis: EmojisType
+)
+
+
+
+class CustomEmojisTypeSerializer : JsonContentPolymorphicSerializer<EmojisType>(EmojisType::class) {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out EmojisType> {
+        if (element is JsonArray) {
+            println("element is JsonArray, value:${element}")
+            return TypeArraySerializer()
+        }
+        if (element is JsonObject) {
+            println("element is JsonObject")
+            return TypeObjectSerializer
+        }
+
+        println("element type is unknown:$element")
+
+        Int.serializer()
+        return EmojisType.None.serializer()
+    }
+
+}
+
+object TypeObjectSerializer : KSerializer<EmojisType.TypeObject> {
+    private val mapSerializer = MapSerializer(String.serializer(), String.serializer())
+    override val descriptor: SerialDescriptor = mapSerializer.descriptor
+    override fun deserialize(decoder: Decoder): EmojisType.TypeObject {
+        return EmojisType.TypeObject(mapSerializer.deserialize(decoder))
+    }
+
+    override fun serialize(encoder: Encoder, value: EmojisType.TypeObject) {
+        mapSerializer.serialize(encoder, value.emojis)
+    }
+}
+
+class TypeArraySerializer : KSerializer<EmojisType.TypeArray> {
+    private val listSerializer = ListSerializer(Emoji.serializer())
+    override val descriptor: SerialDescriptor = listSerializer.descriptor
+
+    override fun deserialize(decoder: Decoder): EmojisType.TypeArray {
+        return EmojisType.TypeArray(listSerializer.deserialize(decoder))
+    }
+
+    override fun serialize(encoder: Encoder, value: EmojisType.TypeArray) {
+        return listSerializer.serialize(encoder, value.emojis)
+    }
+}
+

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/emoji/EmojisType.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/emoji/EmojisType.kt
@@ -37,17 +37,12 @@ data class TestNoteObject(
 class CustomEmojisTypeSerializer : JsonContentPolymorphicSerializer<EmojisType>(EmojisType::class) {
     override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out EmojisType> {
         if (element is JsonArray) {
-            println("element is JsonArray, value:${element}")
             return TypeArraySerializer()
         }
         if (element is JsonObject) {
-            println("element is JsonObject")
             return TypeObjectSerializer
         }
 
-        println("element type is unknown:$element")
-
-        Int.serializer()
         return EmojisType.None.serializer()
     }
 

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteDTO.kt
@@ -41,6 +41,7 @@ data class NoteDTO(
     @SerialName("reactions")
     val reactionCounts: LinkedHashMap<String, Int>? = null,
 
+    @kotlinx.serialization.Transient
     @SerialName("emojis") val emojis: List<Emoji>? = null,
 
     @SerialName("repliesCount")

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteDTO.kt
@@ -3,7 +3,19 @@ package net.pantasystem.milktea.api.misskey.notes
 
 import kotlinx.datetime.Instant
 import kotlinx.datetime.serializers.InstantIso8601Serializer
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import net.pantasystem.milktea.api.misskey.auth.App
 import net.pantasystem.milktea.api.misskey.drive.FilePropertyDTO
 import net.pantasystem.milktea.api.misskey.users.UserDTO
@@ -41,8 +53,8 @@ data class NoteDTO(
     @SerialName("reactions")
     val reactionCounts: LinkedHashMap<String, Int>? = null,
 
-    @kotlinx.serialization.Transient
-    @SerialName("emojis") val emojis: List<Emoji>? = null,
+    @kotlinx.serialization.Serializable(with = CustomEmojisTypeSerializer::class)
+    @SerialName("emojis") val rawEmojis: EmojisType? = null,
 
     @SerialName("repliesCount")
     val replyCount: Int,
@@ -67,7 +79,17 @@ data class NoteDTO(
     val channelId: String? = null,
 
     val app: App? = null
-) : Serializable
+) : Serializable {
+
+    val emojiList: List<Emoji>? = when(rawEmojis) {
+        EmojisType.None -> null
+        is EmojisType.TypeArray -> rawEmojis.emojis
+        is EmojisType.TypeObject -> rawEmojis.emojis.map {
+            Emoji(name = it.key, url = it.value, uri = it.value)
+        }
+        null -> null
+    }
+}
 
 
 @kotlinx.serialization.Serializable(with = NoteVisibilityTypeSerializer::class)
@@ -77,4 +99,66 @@ enum class NoteVisibilityType {
 
 object NoteVisibilityTypeSerializer : EnumIgnoreUnknownSerializer<NoteVisibilityType>(NoteVisibilityType.values(), NoteVisibilityType.Public)
 
+@kotlinx.serialization.Serializable(with = CustomEmojisTypeSerializer::class)
+sealed interface EmojisType {
+    @kotlinx.serialization.Serializable(with = TypeArraySerializer::class)
+    data class TypeArray(val emojis: List<Emoji>) : EmojisType
+
+    @kotlinx.serialization.Serializable(with = TypeObjectSerializer::class)
+    data class TypeObject(val emojis: Map<String, String>) : EmojisType
+
+    @kotlinx.serialization.Serializable
+    object None : EmojisType
+}
+
+@kotlinx.serialization.Serializable
+data class TestNoteObject(
+    @kotlinx.serialization.Serializable(with = CustomEmojisTypeSerializer::class) val emojis: EmojisType
+)
+
+
+
+class CustomEmojisTypeSerializer : JsonContentPolymorphicSerializer<EmojisType>(EmojisType::class) {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out EmojisType> {
+        if (element is JsonArray) {
+            println("element is JsonArray, value:${element}")
+            return TypeArraySerializer()
+        }
+        if (element is JsonObject) {
+            println("element is JsonObject")
+            return TypeObjectSerializer
+        }
+
+        println("element type is unknown:$element")
+
+        Int.serializer()
+        return EmojisType.None.serializer()
+    }
+
+}
+
+object TypeObjectSerializer : KSerializer<EmojisType.TypeObject> {
+    val mapSerializer = MapSerializer(String.serializer(), String.serializer())
+    override val descriptor: SerialDescriptor = mapSerializer.descriptor
+    override fun deserialize(decoder: Decoder): EmojisType.TypeObject {
+        return EmojisType.TypeObject(mapSerializer.deserialize(decoder))
+    }
+
+    override fun serialize(encoder: Encoder, value: EmojisType.TypeObject) {
+        mapSerializer.serialize(encoder, value.emojis)
+    }
+}
+
+class TypeArraySerializer : KSerializer<EmojisType.TypeArray> {
+    val listSerializer = ListSerializer(Emoji.serializer())
+    override val descriptor: SerialDescriptor = listSerializer.descriptor
+
+    override fun deserialize(decoder: Decoder): EmojisType.TypeArray {
+        return EmojisType.TypeArray(listSerializer.deserialize(decoder))
+    }
+
+    override fun serialize(encoder: Encoder, value: EmojisType.TypeArray) {
+        return listSerializer.serialize(encoder, value.emojis)
+    }
+}
 

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/UserDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/UserDTO.kt
@@ -4,8 +4,8 @@ package net.pantasystem.milktea.api.misskey.users
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.SerialName
-import net.pantasystem.milktea.api.misskey.notes.CustomEmojisTypeSerializer
-import net.pantasystem.milktea.api.misskey.notes.EmojisType
+import net.pantasystem.milktea.api.misskey.emoji.CustomEmojisTypeSerializer
+import net.pantasystem.milktea.api.misskey.emoji.EmojisType
 import net.pantasystem.milktea.api.misskey.notes.NoteDTO
 import net.pantasystem.milktea.model.emoji.Emoji
 import java.io.Serializable
@@ -82,15 +82,5 @@ data class UserDTO(
 
     @kotlinx.serialization.Serializable
     data class FieldDTO(val name: String, val value: String)
-
-    val displayUserName: String
-        get() = "@" + this.userName + if (this.host == null) {
-            ""
-        } else {
-            "@" + this.host
-        }
-
-    val displayName: String
-        get() = name ?: userName
 
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/UserDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/UserDTO.kt
@@ -4,6 +4,8 @@ package net.pantasystem.milktea.api.misskey.users
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.SerialName
+import net.pantasystem.milktea.api.misskey.notes.CustomEmojisTypeSerializer
+import net.pantasystem.milktea.api.misskey.notes.EmojisType
 import net.pantasystem.milktea.api.misskey.notes.NoteDTO
 import net.pantasystem.milktea.model.emoji.Emoji
 import java.io.Serializable
@@ -35,8 +37,8 @@ data class UserDTO(
     val avatarUrl: String? = null,
     val bannerUrl: String? = null,
 
-    @kotlinx.serialization.Transient
-    val emojis: List<Emoji>? = null,
+    @kotlinx.serialization.Serializable(with = CustomEmojisTypeSerializer::class)
+    @SerialName("emojis") val rawEmojis: EmojisType? = null,
 
     val isFollowing: Boolean? = null,
     val isFollowed: Boolean? = null,
@@ -68,6 +70,15 @@ data class UserDTO(
         val softwareVersion: String? = null,
         val themeColor: String? = null,
     )
+
+    val emojiList: List<Emoji>? = when(rawEmojis) {
+        EmojisType.None -> null
+        is EmojisType.TypeArray -> rawEmojis.emojis
+        is EmojisType.TypeObject -> rawEmojis.emojis.map {
+            Emoji(name = it.key, url = it.value, uri = it.value)
+        }
+        null -> null
+    }
 
     @kotlinx.serialization.Serializable
     data class FieldDTO(val name: String, val value: String)

--- a/modules/api/src/test/java/net/pantasystem/milktea/api/misskey/users/BaseUserDTOTest.kt
+++ b/modules/api/src/test/java/net/pantasystem/milktea/api/misskey/users/BaseUserDTOTest.kt
@@ -2,6 +2,8 @@ package net.pantasystem.milktea.api.misskey.users
 
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import net.pantasystem.milktea.api.misskey.emoji.EmojisType
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class BaseUserDTOTest {
@@ -30,5 +32,6 @@ class BaseUserDTOTest {
         """.trimIndent()
 
         val result = parser.decodeFromString<UserDTO>(json)
+        Assertions.assertEquals(EmojisType.TypeObject(emptyMap()), result.rawEmojis)
     }
 }

--- a/modules/api_streaming/build.gradle
+++ b/modules/api_streaming/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     // define any required OkHttp artifacts without version
     implementation("com.squareup.okhttp3:okhttp")
     implementation("com.squareup.okhttp3:logging-interceptor")
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0"
+    implementation libs.kotlin.serialization
     implementation libs.kotlin.datetime
 
     testImplementation libs.junit.jupiter.api

--- a/modules/common/build.gradle
+++ b/modules/common/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     //retrofit
     implementation "com.squareup.retrofit2:retrofit:$retrofit"
 
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0"
+    implementation libs.kotlin.serialization
 
     testImplementation libs.junit.jupiter.api
     testRuntimeOnly libs.junit.jupiter.engine

--- a/modules/data/build.gradle
+++ b/modules/data/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$retrofit"
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0")
 
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0"
+    implementation libs.kotlin.serialization
 
     //Kotlin coroutines用ライブラリ(async, await)
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/MisskeyEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/MisskeyEntityConverters.kt
@@ -174,7 +174,7 @@ fun NoteDTO.toNote(account: Account, nodeInfo: NodeInfo?): Note {
         viaMobile = this.viaMobile,
         visibility = visibility,
         localOnly = this.localOnly,
-        emojis = (this.emojis ?: emptyList()) + (this.reactionEmojis?.map {
+        emojis = (this.emojiList ?: emptyList()) + (this.reactionEmojis?.map {
             Emoji(name = it.key, uri = it.value, url = it.value)
         } ?: emptyList()),
         app = this.app?.toModel(),
@@ -361,7 +361,7 @@ fun UserDTO.toUser(account: Account, isDetail: Boolean = false): User {
         return User.Detail(
             id = User.Id(account.accountId, this.id),
             avatarUrl = this.avatarUrl,
-            emojis = this.emojis ?: emptyList(),
+            emojis = this.emojiList ?: emptyList(),
             isBot = this.isBot,
             isCat = this.isCat,
             name = this.name,
@@ -404,7 +404,7 @@ fun UserDTO.toUser(account: Account, isDetail: Boolean = false): User {
         return User.Simple(
             id = User.Id(account.accountId, this.id),
             avatarUrl = this.avatarUrl,
-            emojis = this.emojis ?: emptyList(),
+            emojis = this.emojiList ?: emptyList(),
             isBot = this.isBot,
             isCat = this.isCat,
             name = this.name,

--- a/modules/features/setting/build.gradle
+++ b/modules/features/setting/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     implementation libs.flexbox
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation "com.squareup.retrofit2:retrofit:$retrofit"
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0"
+    implementation libs.kotlin.serialization
 
     testImplementation libs.junit.jupiter.api
     testRuntimeOnly libs.junit.jupiter.engine

--- a/modules/model/build.gradle
+++ b/modules/model/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     kaptTest libs.hilt.compiler
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0"
+    implementation libs.kotlin.serialization
 
     testImplementation libs.junit.jupiter.api
     testRuntimeOnly libs.junit.jupiter.engine

--- a/settings.gradle
+++ b/settings.gradle
@@ -84,6 +84,8 @@ dependencyResolutionManagement {
             library("junit-jupiter-engine", "org.junit.jupiter:junit-jupiter-engine:5.7.0")
 
             library("okhttp-sse", "com.squareup.okhttp3:okhttp-sse:4.10.0")
+
+            library("kotlin-serialization", "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0")
         }
     }
 }


### PR DESCRIPTION
## やったこと
v13.2.5でUserとNoteにemojisフィールドが復活したが、
v12の頃は配列で帰ってきていたものがオブジェクトとして返ってくるようになってしまったために、
うまくJSONをデコードできず処理ができなくなるという問題が発生していた。
そこでSerializerなどを自作したりすることによってデコードできるようにした。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



