### PR TITLE
ユーザー詳細画面でタイムラインを表示できるようにした

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -201,7 +201,8 @@ interface MastodonAPI {
 
     @GET("api/v1/accounts/{accountId}/statuses")
     suspend fun getAccountTimeline(
-        @Path("accountId") accountId: String, @Query("only_media") onlyMedia: Boolean = false,
+        @Path("accountId") accountId: String,
+        @Query("only_media") onlyMedia: Boolean? = false,
         @Query("max_id") maxId: String? = null,
         @Query("min_id") minId: String? = null,
         @Query("limit") limit: Int = 20,

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -102,7 +102,12 @@ interface MastodonAPI {
     suspend fun getAccount(@Path("accountId") accountId: String): Response<MastodonAccountDTO>
 
     @GET("api/v1/accounts/relationships")
-    suspend fun getAccountRelationships(@Query("id[]", encoded = true) ids: List<String>): Response<List<MastodonAccountRelationshipDTO>>
+    suspend fun getAccountRelationships(
+        @Query(
+            "id[]",
+            encoded = true
+        ) ids: List<String>
+    ): Response<List<MastodonAccountRelationshipDTO>>
 
     @POST("api/v1/accounts/{accountId}/follow")
     suspend fun follow(@Path("accountId") accountId: String): Response<MastodonAccountRelationshipDTO>
@@ -182,11 +187,25 @@ interface MastodonAPI {
     suspend fun deleteStatus(@Path("statusId") statusId: String): Response<TootStatusDTO>
 
     @POST("api/v1/polls/{pollId}/votes")
-    suspend fun voteOnPoll(@Path("pollId") pollId: String, @Field("choices[]", encoded = true) choices: List<Int>): Response<TootPollDTO>
+    suspend fun voteOnPoll(
+        @Path("pollId") pollId: String,
+        @Field("choices[]", encoded = true) choices: List<Int>
+    ): Response<TootPollDTO>
 
     @POST("api/v1/statuses/{statusId}/mute")
     suspend fun muteConversation(@Path("statusId") statusId: String): Response<TootStatusDTO>
 
     @POST("api/v1/statuses/{statusId}/unmute")
     suspend fun unmuteConversation(@Path("statusId") statusId: String): Response<TootStatusDTO>
+
+
+    @GET("api/v1/accounts/{accountId}/statuses")
+    suspend fun getAccountTimeline(
+        @Path("accountId") accountId: String, @Query("only_media") onlyMedia: Boolean = false,
+        @Query("max_id") maxId: String? = null,
+        @Query("min_id") minId: String? = null,
+        @Query("limit") limit: Int = 20,
+        @Query("exclude_reblogs") excludeReblogs: Boolean? = null,
+        @Query("exclude_replies") excludeReplies: Boolean? = null,
+    ): Response<List<TootStatusDTO>>
 }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/page/PageTypeHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/page/PageTypeHelper.kt
@@ -38,6 +38,7 @@ object PageTypeHelper{
             MASTODON_HOME_TIMELINE -> context.getString(R.string.home_timeline)
             MASTODON_HASHTAG_TIMELINE -> context.getString(R.string.tag)
             MASTODON_LIST_TIMELINE -> context.getString(R.string.list)
+            MASTODON_USER_TIMELINE -> context.getString(R.string.user)
         }
     }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/FavoriteNoteTimelinePagingStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/FavoriteNoteTimelinePagingStoreImpl.kt
@@ -16,7 +16,7 @@ import net.pantasystem.milktea.model.notes.Note
 
 
 
-class FavoriteNoteTimelinePagingStoreImpl(
+internal class FavoriteNoteTimelinePagingStoreImpl(
     val pageableTimeline: Pageable.Favorite,
     val noteAdder: NoteDataSourceAdder,
     val getAccount: suspend () -> Account,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/MastodonTimelineStorePagingStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/MastodonTimelineStorePagingStoreImpl.kt
@@ -14,7 +14,7 @@ import net.pantasystem.milktea.model.nodeinfo.NodeInfoRepository
 import net.pantasystem.milktea.model.notes.Note
 
 
-class MastodonTimelineStorePagingStoreImpl(
+internal class MastodonTimelineStorePagingStoreImpl(
     val pageableTimeline: Pageable.Mastodon,
     val mastodonAPIProvider: MastodonAPIProvider,
     val getAccount: suspend () -> Account,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/MastodonTimelineStorePagingStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/MastodonTimelineStorePagingStoreImpl.kt
@@ -141,7 +141,7 @@ class MastodonTimelineStorePagingStoreImpl(
             is Pageable.Mastodon.UserTimeline -> {
                 api.getAccountTimeline(
                     accountId = pageableTimeline.userId,
-                    onlyMedia = pageableTimeline.isOnlyMedia ?: false,
+                    onlyMedia = pageableTimeline.isOnlyMedia,
                     excludeReplies = pageableTimeline.excludeReplies,
                     excludeReblogs = pageableTimeline.excludeReblogs,
                     maxId = maxId,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteStreamingImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteStreamingImpl.kt
@@ -101,6 +101,7 @@ class NoteStreamingImpl @Inject constructor(
                                 ac
                             )
                         ).connectPublic().convertToNoteFromStatus(getAccount)
+                        else -> throw IllegalStateException("Global, Hybrid, Local, Homeは以外のStreamは対応していません。")
                     }
                 }
                 else -> throw IllegalStateException("Global, Hybrid, Local, Homeは以外のStreamは対応していません。")

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/TimelinePagingStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/TimelinePagingStoreImpl.kt
@@ -25,7 +25,7 @@ import net.pantasystem.milktea.model.notes.Note
 import retrofit2.Response
 
 
-class TimelinePagingStoreImpl(
+internal class TimelinePagingStoreImpl(
     private val pageableTimeline: Pageable,
     private val noteAdder: NoteDataSourceAdder,
     private val getAccount: suspend () -> Account,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/TimelineStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/TimelineStoreImpl.kt
@@ -82,7 +82,7 @@ class TimelineStoreImpl(
         get() = willAddNoteQueue
 
 
-    val pageableStore: TimelinePagingBase by lazy {
+    internal val pageableStore: TimelinePagingBase by lazy {
         when (pageableTimeline) {
             is Pageable.Favorite -> {
                 FavoriteNoteTimelinePagingStoreImpl(
@@ -138,7 +138,7 @@ class TimelineStoreImpl(
 
 
     override suspend fun loadFuture(): Result<Unit> {
-        return runCancellableCatching {
+        return runCancellableCatching<Unit> {
             val addedCount = when (val store = pageableStore) {
                 is TimelinePagingStoreImpl -> {
                     FuturePagingController(
@@ -174,7 +174,7 @@ class TimelineStoreImpl(
     }
 
     override suspend fun loadPrevious(): Result<Unit> {
-        return runCancellableCatching {
+        return runCancellableCatching<Unit> {
             when (val store = pageableStore) {
                 is TimelinePagingStoreImpl -> {
                     PreviousPagingController(
@@ -272,6 +272,6 @@ class TimelineStoreImpl(
 
 }
 
-sealed interface TimelinePagingBase : PaginationState<Note.Id>, StateLocker
+internal sealed interface TimelinePagingBase : PaginationState<Note.Id>, StateLocker
 
 interface StreamingReceivableStore : StateLocker

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
@@ -482,19 +482,19 @@ class UserTimelinePagerAdapterV2(
             is UserDetailTabType.MastodonMedia -> pageableFragmentFactory.create(
                 Pageable.Mastodon.UserTimeline(
                     tab.userId.id,
-                    excludeReplies = true,
+                    isOnlyMedia = true,
                 )
             )
             is UserDetailTabType.MastodonUserTimeline -> pageableFragmentFactory.create(
                 Pageable.Mastodon.UserTimeline(
                     tab.userId.id,
-                    excludeReplies = false,
+                    excludeReplies = true,
                 )
             )
             is UserDetailTabType.MastodonUserTimelineWithReplies -> pageableFragmentFactory.create(
                 Pageable.Mastodon.UserTimeline(
                     tab.userId.id,
-                    isOnlyMedia = true
+                    excludeReplies = false,
                 )
             )
         }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
@@ -479,6 +479,24 @@ class UserTimelinePagerAdapterV2(
                     includeReplies = true
                 )
             )
+            is UserDetailTabType.MastodonMedia -> pageableFragmentFactory.create(
+                Pageable.Mastodon.UserTimeline(
+                    tab.userId.id,
+                    excludeReplies = true,
+                )
+            )
+            is UserDetailTabType.MastodonUserTimeline -> pageableFragmentFactory.create(
+                Pageable.Mastodon.UserTimeline(
+                    tab.userId.id,
+                    excludeReplies = false,
+                )
+            )
+            is UserDetailTabType.MastodonUserTimelineWithReplies -> pageableFragmentFactory.create(
+                Pageable.Mastodon.UserTimeline(
+                    tab.userId.id,
+                    isOnlyMedia = true
+                )
+            )
         }
 
     }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
@@ -172,6 +172,14 @@ data class PageParams(
                         listId = requireNotNull(listId),
                     )
                 }
+                MASTODON_USER_TIMELINE -> {
+                    Pageable.Mastodon.UserTimeline(
+                        userId = requireNotNull(userId),
+                        isOnlyMedia = withFiles,
+                        excludeReblogs = includeMyRenotes?.not(),
+                        excludeReplies = includeReplies?.not()
+                    )
+                }
             }
         } catch (e: NullPointerException) {
             throw IllegalStateException("パラメーターに問題があります: $this")

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageType.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageType.kt
@@ -28,6 +28,7 @@ enum class PageType(val defaultName: String){
     MASTODON_HOME_TIMELINE("MastodonHomeTimeline"),
     MASTODON_HASHTAG_TIMELINE("MastodonHashtagTimeline"),
     MASTODON_LIST_TIMELINE("MastodonListTimeline"),
+    MASTODON_USER_TIMELINE("MastodonUserTimeline")
     //USER_PINは別
 }
 

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
@@ -320,6 +320,23 @@ sealed class Pageable : Serializable {
             }
         }
 
+        data class UserTimeline(
+            val userId: String,
+            val isOnlyMedia: Boolean? = null,
+            val excludeReplies: Boolean? = null,
+            val excludeReblogs: Boolean? = null,
+        ) : Mastodon() {
+            override fun toParams(): PageParams {
+                return PageParams(
+                    type = PageType.MASTODON_USER_TIMELINE,
+                    withFiles = isOnlyMedia,
+                    includeReplies = excludeReplies?.not(),
+                    includeMyRenotes = excludeReblogs?.not(),
+                    userId = userId
+                )
+            }
+        }
+
     }
 
 


### PR DESCRIPTION
## やったこと
Mastodonでもユーザ詳細画面でタイムラインを表示できるようにしました。
そのためにタブ種別を追加し、ページネーションのロジックも追加しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1309 


