### PR TITLE
表示しているユーザが自分の情報の場合はフォロー・フォロー解除ボタンを表示しないようにした

### DIFF
--- a/modules/features/search/src/main/java/net/pantasystem/milktea/search/explore/ExploreFragment.kt
+++ b/modules/features/search/src/main/java/net/pantasystem/milktea/search/explore/ExploreFragment.kt
@@ -88,6 +88,7 @@ class ExploreFragment : Fragment() {
                                             userDetail = content.rawContent[i],
                                             isUserNameMain = false,
                                             accountHost = account?.getHost(),
+                                            myId = account?.remoteId,
                                             onAction = ::onAction
                                         )
                                     }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/UserDetailCard.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/UserDetailCard.kt
@@ -42,6 +42,7 @@ fun UserDetailCard(
     userDetail: User.Detail,
     isUserNameMain: Boolean,
     accountHost: String?,
+    myId: String?,
     onAction: (UserDetailCardAction) -> Unit,
 ) {
     Card(
@@ -98,16 +99,18 @@ fun UserDetailCard(
                 )
             }
 
-            UserStateActionButton(
-                userState = userDetail.followState,
-                modifier = Modifier.constrainAs(actionButton) {
-                    end.linkTo(parent.end, margin = 8.dp)
-                    top.linkTo(parent.top, margin = 8.dp)
-                },
-                onClick = {
-                    onAction(UserDetailCardAction.ToggleFollow(userDetail.id))
-                }
-            )
+            if (myId != userDetail.id.id) {
+                UserStateActionButton(
+                    userState = userDetail.followState,
+                    modifier = Modifier.constrainAs(actionButton) {
+                        end.linkTo(parent.end, margin = 8.dp)
+                        top.linkTo(parent.top, margin = 8.dp)
+                    },
+                    onClick = {
+                        onAction(UserDetailCardAction.ToggleFollow(userDetail.id))
+                    }
+                )
+            }
 
 
             Image(
@@ -282,6 +285,7 @@ fun Preview_UserDetail() {
             isFollower = true,
         ),
         isUserNameMain = true,
-        accountHost = "misskey.io"
+        accountHost = "misskey.io",
+        myId = null,
     ) {}
 }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/UserDetailCardList.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/UserDetailCardList.kt
@@ -34,6 +34,7 @@ fun UserDetailCardList(
     pageableState: ResultState<List<User.Id>>,
     users: List<User.Detail>,
     accountHost: String?,
+    myId: String?,
     isUserNameMain: Boolean,
     onAction: (UserDetailCardListAction) -> Unit,
 ) {
@@ -54,10 +55,11 @@ fun UserDetailCardList(
                         UserDetailCard(
                             userDetail = users[i],
                             isUserNameMain = isUserNameMain,
+                            accountHost = accountHost,
+                            myId = myId,
                             onAction = {
                                 onAction(UserDetailCardListAction.CardAction(it))
                             },
-                            accountHost = accountHost,
                         )
                     }
                 }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/UserDetailCardPageableList.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/UserDetailCardPageableList.kt
@@ -39,6 +39,7 @@ fun UserDetailCardPageableList(
     users: List<User.Detail>,
     isUserNameMain: Boolean,
     accountHost: String?,
+    myId: String?,
     onAction: (UserDetailCardPageableListAction) -> Unit,
 ) {
     val scrollController = rememberLazyListState()
@@ -70,6 +71,7 @@ fun UserDetailCardPageableList(
                                 onAction(UserDetailCardPageableListAction.CardAction(it))
                             },
                             accountHost = accountHost,
+                            myId = myId,
                         )
                     }
                     item {

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/screen/FollowFollowerScreen.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/compose/screen/FollowFollowerScreen.kt
@@ -158,6 +158,7 @@ private fun Pager(
                     users = uiState.followUsers,
                     isUserNameMain = false,
                     accountHost = uiState.accountHost,
+                    myId = uiState.myId,
                     onAction = { action ->
                         onAction(LoadType.Follow, action)
                     }
@@ -169,6 +170,7 @@ private fun Pager(
                     users = uiState.followerUsers,
                     isUserNameMain = false,
                     accountHost = uiState.accountHost,
+                    myId = uiState.myId,
                     onAction = { action ->
                         onAction(LoadType.Follower, action)
                     }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/search/SearchUserFragment.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/search/SearchUserFragment.kt
@@ -62,6 +62,7 @@ class SearchUserFragment : Fragment() {
                         users = users,
                         isUserNameMain = false,
                         accountHost = account?.getHost(),
+                        myId = account?.remoteId,
                         onAction = ::onAction
                     )
                 }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/FollowFollowerViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/FollowFollowerViewModel.kt
@@ -98,6 +98,7 @@ class FollowFollowerViewModel @AssistedInject constructor(
             followUsers = follows,
             followerUsersState = followerState,
             followUsersState = followState,
+            myId = a?.remoteId,
         )
     }.stateIn(
         viewModelScope,
@@ -141,6 +142,7 @@ enum class LoadType {
 data class FollowFollowerUiState(
     val user: User? = null,
     val accountHost: String? = null,
+    val myId: String? = null,
     val followUsers: List<User.Detail> = emptyList(),
     val followerUsers: List<User.Detail> = emptyList(),
     val followerUsersState: PageableState<List<User.Id>> = PageableState.Loading.Init(),


### PR DESCRIPTION
## やったこと
見つけるの画面やフォローフォロワーの一覧画面に自分の情報が表示された時
本来表示されるべきではないフォロー・フォロワーボタンが表示されてしまう不具合が発生していたのを修正しました。

## 動作確認
エミュレータにて動作することを確認

## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1312 

