### PR TITLE
Mastodonのリストを表示できるようにしました

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -9,6 +9,9 @@ import net.pantasystem.milktea.api.mastodon.apps.CreateApp
 import net.pantasystem.milktea.api.mastodon.apps.ObtainToken
 import net.pantasystem.milktea.api.mastodon.emojis.TootEmojiDTO
 import net.pantasystem.milktea.api.mastodon.instance.Instance
+import net.pantasystem.milktea.api.mastodon.list.AddAccountsToList
+import net.pantasystem.milktea.api.mastodon.list.ListDTO
+import net.pantasystem.milktea.api.mastodon.list.RemoveAccountsFromList
 import net.pantasystem.milktea.api.mastodon.notification.MstNotificationDTO
 import net.pantasystem.milktea.api.mastodon.poll.TootPollDTO
 import net.pantasystem.milktea.api.mastodon.status.CreateStatus
@@ -209,4 +212,25 @@ interface MastodonAPI {
         @Query("exclude_reblogs") excludeReblogs: Boolean? = null,
         @Query("exclude_replies") excludeReplies: Boolean? = null,
     ): Response<List<TootStatusDTO>>
+
+
+    @GET("api/v1/lists")
+    suspend fun getMyLists(): Response<List<ListDTO>>
+
+    @GET("api/v1/lists/{listId}")
+    suspend fun getList(@Path("listId") listId: String): Response<ListDTO>
+
+    @POST("api/v1/lists/{listId}/accounts")
+    suspend fun addAccountsToList(@Path("listId") listId: String, @Body body: AddAccountsToList): Response<Unit>
+
+    @DELETE("api/v1/lists/{listId}/accounts")
+    suspend fun removeAccountsFromList(@Path("listId") listId: String, @Body body: RemoveAccountsFromList): Response<Unit>
+
+    @GET("api/v1/lists/{listId}")
+    suspend fun getAccountsInList(
+        @Path("listId") listId: String,
+        @Query("max_id") maxId: String? = null,
+        @Query("min_id") minId: String? = null
+    ): Response<List<MastodonAccountDTO>>
+
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/list/AddAccountsToList.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/list/AddAccountsToList.kt
@@ -1,0 +1,10 @@
+package net.pantasystem.milktea.api.mastodon.list
+
+import kotlinx.serialization.SerialName
+
+@kotlinx.serialization.Serializable
+data class AddAccountsToList(
+    @SerialName("account_ids") val accountIds: List<String>
+)
+
+typealias RemoveAccountsFromList = AddAccountsToList

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/list/ListDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/list/ListDTO.kt
@@ -1,0 +1,17 @@
+package net.pantasystem.milktea.api.mastodon.list
+
+import kotlinx.serialization.SerialName
+
+@kotlinx.serialization.Serializable
+data class ListDTO(
+    val id: String,
+    val title: String,
+    @SerialName("replies_policy") val repliesPolicy: RepliesPolicyType
+)  {
+    @kotlinx.serialization.Serializable
+    enum class RepliesPolicyType {
+        @SerialName("followed") Followed,
+        @SerialName("list") List,
+        @SerialName("none") None,
+    }
+}

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/list/ListDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/list/ListDTO.kt
@@ -1,6 +1,9 @@
 package net.pantasystem.milktea.api.mastodon.list
 
+import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.list.UserList
 
 @kotlinx.serialization.Serializable
 data class ListDTO(
@@ -13,5 +16,14 @@ data class ListDTO(
         @SerialName("followed") Followed,
         @SerialName("list") List,
         @SerialName("none") None,
+    }
+
+    fun toModel(account: Account): UserList {
+        return UserList(
+            id = UserList.Id(accountId = account.accountId, id),
+            createdAt = Instant.fromEpochMilliseconds(Long.MAX_VALUE),
+            name = title,
+            userIds = emptyList()
+        )
     }
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/media/TootMediaAttachment.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/media/TootMediaAttachment.kt
@@ -7,7 +7,7 @@ data class TootMediaAttachment(
     val id: String,
     val type: String,
     val url: String,
-    @SerialName("preview_url") val previewUrl: String,
+    @SerialName("preview_url") val previewUrl: String? = null,
     @SerialName("remote_url") val remoteUrl: String? = null,
     val description: String? = null,
     val blurhash: String? = null,

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/notification/MstNotificationDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/notification/MstNotificationDTO.kt
@@ -14,6 +14,7 @@ data class MstNotificationDTO(
     val account: MastodonAccountDTO,
     val status: TootStatusDTO? = null,
     val report: MstReportDTO? = null,
+    @SerialName("emoji_reaction") val emojiReaction: EmojiReaction? = null,
 ) {
     @kotlinx.serialization.Serializable
     enum class NotificationType {
@@ -49,6 +50,28 @@ data class MstNotificationDTO(
 
         @SerialName("emoji_reaction")
         EmojiReaction
+    }
+
+    @kotlinx.serialization.Serializable
+    data class EmojiReaction(
+        val name: String,
+        val count: Int,
+        val me: Boolean? = null,
+        val url: String? = null,
+        val domain: String?  = null,
+        @SerialName("static_url") val staticUrl: String? = null,
+    ) {
+        private val isCustomEmoji = url != null || staticUrl != null
+
+        val reaction = if (isCustomEmoji) {
+            if (domain == null) {
+                ":$name@.:"
+            } else {
+                ":$name@$domain:"
+            }
+        } else {
+            name
+        }
     }
 }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
@@ -38,7 +38,7 @@ fun TootPollDTO?.toPoll(): Poll? {
     }
 }
 
-fun TootMediaAttachment.toFileProperty(account: Account): FileProperty {
+fun TootMediaAttachment.toFileProperty(account: Account, isSensitive: Boolean): FileProperty {
     return FileProperty(
         id = FileProperty.Id(account.accountId, id),
         name = "",
@@ -47,6 +47,7 @@ fun TootMediaAttachment.toFileProperty(account: Account): FileProperty {
         md5 = null,
         size = null,
         url = url,
+        isSensitive = isSensitive,
         thumbnailUrl = previewUrl,
         blurhash = blurhash,
         comment = description,
@@ -58,7 +59,7 @@ fun TootStatusDTO.toNote(account: Account, nodeInfo: NodeInfo?): Note {
         id = Note.Id(account.accountId, id),
         text = this.content,
         cw = this.spoilerText.takeIf {
-            sensitive
+            it.isNotBlank()
         },
         userId = User.Id(account.accountId, this.account.id),
         replyId = this.inReplyToId?.let { Note.Id(account.accountId, this.inReplyToId!!) },
@@ -137,7 +138,7 @@ fun TootStatusDTO.pickEntities(
     users.add(user)
     files.addAll(
         mediaAttachments.map {
-            it.toFileProperty(account)
+            it.toFileProperty(account, sensitive)
         }
     )
     this.reblog?.pickEntities(account, notes, users, files, nodeInfo)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
@@ -217,7 +217,16 @@ fun MstNotificationDTO.toModel(a: Account, isRead: Boolean): Notification {
         MstNotificationDTO.NotificationType.AdminReport -> {
             TODO("通知種別${type}はまだ実装されていません")
         }
-        MstNotificationDTO.NotificationType.EmojiReaction -> TODO("通知種別${type}はまだ実装されていません")
+        MstNotificationDTO.NotificationType.EmojiReaction -> {
+            ReactionNotification(
+                id = id,
+                createdAt = createdAt,
+                isRead = isRead,
+                noteId = Note.Id(a.accountId, requireNotNull(status).id),
+                reaction = requireNotNull(emojiReaction).reaction,
+                userId = userId,
+            )
+        }
     }
 }
 fun Visibility(type: StatusVisibilityType, circleId: String? = null, visibilityEx: String? = null,): Visibility {

--- a/modules/features/userlist/src/main/java/net/pantasystem/milktea/userlist/UserListDetailActivity.kt
+++ b/modules/features/userlist/src/main/java/net/pantasystem/milktea/userlist/UserListDetailActivity.kt
@@ -136,7 +136,8 @@ class UserListDetailActivity : AppCompatActivity(), UserListEditorDialog.OnSubmi
                     },
                     onDeleteUserButtonClicked = {
                         mUserListDetailViewModel.pullUser(it.id)
-                    }
+                    },
+                    instanceType = account?.instanceType
                 )
 
             }

--- a/modules/features/userlist/src/main/java/net/pantasystem/milktea/userlist/compose/UserListDetailScreen.kt
+++ b/modules/features/userlist/src/main/java/net/pantasystem/milktea/userlist/compose/UserListDetailScreen.kt
@@ -19,6 +19,7 @@ import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.rememberPagerState
 import kotlinx.coroutines.launch
 import net.pantasystem.milktea.common_android_ui.PageableFragmentFactory
+import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.model.list.UserList
 import net.pantasystem.milktea.model.user.User
@@ -31,6 +32,7 @@ fun UserListDetailScreen(
     userList: UserList?,
     users: List<User>,
     accountHost: String?,
+    instanceType: Account.InstanceType?,
     isAddedTab: Boolean,
     onNavigateUp: () -> Unit,
     fragmentManager: FragmentManager,
@@ -125,7 +127,10 @@ fun UserListDetailScreen(
                         },
                         update = { frameLayout ->
                             val fragment = pageableFragmentFactory.create(
-                                Pageable.UserListTimeline(listId = listId.userListId)
+                                when(instanceType) {
+                                    Account.InstanceType.MASTODON -> Pageable.Mastodon.ListTimeline(listId.userListId)
+                                    else -> Pageable.UserListTimeline(listId = listId.userListId)
+                                }
                             )
                             val transaction = fragmentManager.beginTransaction()
                             transaction.replace(frameLayout.id, fragment)

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/antenna/AccountService.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/antenna/AccountService.kt
@@ -1,0 +1,31 @@
+package net.pantasystem.milktea.model.antenna
+
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.account.page.Page
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AccountService @Inject constructor(
+    val accountRepository: AccountRepository
+) {
+
+    suspend fun add(page: Page): Result<Unit> = runCancellableCatching {
+        val account: Account = accountRepository.get(page.accountId)
+            .getOrNull() ?: accountRepository.getCurrentAccount().getOrThrow()
+        val updated = account.copy(pages = account.pages.toMutableList().also { list ->
+            list.add(page)
+        })
+        accountRepository.add(updated, true).getOrThrow()
+    }
+
+    suspend fun remove(page: Page): Result<Unit> = runCancellableCatching {
+        val account = accountRepository.get(page.accountId)
+            .getOrNull() ?: accountRepository.getCurrentAccount().getOrThrow()
+        val updated = account.copy(pages = account.pages.filterNot { it.pageId == page.pageId })
+        accountRepository.add(updated, true).getOrThrow()
+    }
+
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/list/UserListTabToggleAddToTabUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/list/UserListTabToggleAddToTabUseCase.kt
@@ -1,0 +1,50 @@
+package net.pantasystem.milktea.model.list
+
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.model.UseCase
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.account.page.Page
+import net.pantasystem.milktea.model.account.page.Pageable
+import net.pantasystem.milktea.model.antenna.AccountService
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UserListTabToggleAddToTabUseCase @Inject constructor(
+    private val userListRepository: UserListRepository,
+    private val accountRepository: AccountRepository,
+    private val accountService: AccountService,
+): UseCase {
+
+    suspend operator fun invoke(listId: UserList.Id) = runCancellableCatching<Unit> {
+        val account = accountRepository.get(listId.accountId)
+            .getOrThrow()
+        val page = account.pages.firstOrNull {
+            it.pageParams.listId == listId.userListId
+        }
+
+        if (page == null) {
+            val userList = userListRepository.findOne(listId)
+            accountService.add(
+                Page(
+                    account.accountId,
+                    userList.name,
+                    weight = -1,
+                    pageable = when(account.instanceType) {
+                        Account.InstanceType.MISSKEY -> Pageable.UserListTimeline(
+                            listId.userListId
+                        )
+                        Account.InstanceType.MASTODON -> Pageable.Mastodon.ListTimeline(
+                            listId.userListId
+                        )
+                    }
+                )
+            )
+
+        } else {
+            accountService.remove(page)
+        }
+
+    }
+}


### PR DESCRIPTION
## やったこと
Mastodonのリストを一覧で表示できるようにしました。
またユーザリストをタブに追加できるようにしました。


## 動作確認


## スクリーンショット(任意)


## 備考
まだリストの作成と削除、更新、リストにユーザを追加する処理の実装はできていません。

## Issue番号
Closed #1309 

