### PR TITLE
Mastodonのスレッドを取得できるように実装

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -7,6 +7,7 @@ import net.pantasystem.milktea.api.mastodon.apps.AccessToken
 import net.pantasystem.milktea.api.mastodon.apps.App
 import net.pantasystem.milktea.api.mastodon.apps.CreateApp
 import net.pantasystem.milktea.api.mastodon.apps.ObtainToken
+import net.pantasystem.milktea.api.mastodon.context.ContextDTO
 import net.pantasystem.milktea.api.mastodon.emojis.TootEmojiDTO
 import net.pantasystem.milktea.api.mastodon.instance.Instance
 import net.pantasystem.milktea.api.mastodon.list.AddAccountsToList
@@ -233,4 +234,6 @@ interface MastodonAPI {
         @Query("min_id") minId: String? = null
     ): Response<List<MastodonAccountDTO>>
 
+    @GET("api/v1/statuses/{statusId}/context")
+    suspend fun getStatusesContext(@Path("statusId") statusId: String): Response<ContextDTO>
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/context/ContextDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/context/ContextDTO.kt
@@ -1,0 +1,9 @@
+package net.pantasystem.milktea.api.mastodon.context
+
+import net.pantasystem.milktea.api.mastodon.status.TootStatusDTO
+
+@kotlinx.serialization.Serializable
+data class ContextDTO (
+    val ancestors: List<TootStatusDTO>,
+    val descendants: List<TootStatusDTO>
+)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -183,14 +183,7 @@ class NoteRepositoryImpl @Inject constructor(
                 async {
                     try {
                         val account = accountMap.getValue(noteId.accountId)
-                        misskeyAPIProvider.get(account).showNote(
-                            NoteRequest(
-                                i = account.token,
-                                noteId = noteId.noteId,
-                            )
-                        ).throwIfHasError().body()?.let {
-                            noteDataSourceAdder.addNoteDtoToDataSource(account, it)
-                        }
+                        convertAndAdd(account, noteApiAdapter.showNote(noteId))
                     } catch (e: Throwable) {
                         if (e is APIError.NotFoundException) {
                             noteDataSource.delete(noteId)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -205,32 +205,62 @@ class NoteRepositoryImpl @Inject constructor(
     override suspend fun syncChildren(noteId: Note.Id): Result<Unit> = runCancellableCatching {
         withContext(ioDispatcher) {
             val account = getAccount.get(noteId.accountId)
-            val dtoList = misskeyAPIProvider.get(account).children(
-                NoteRequest(
-                    i = account.token,
-                    noteId = noteId.noteId,
-                    limit = 100,
-                )
-            ).throwIfHasError().body()!!
-            dtoList.map {
-                noteDataSourceAdder.addNoteDtoToDataSource(account, it)
+            when(account.instanceType) {
+                Account.InstanceType.MISSKEY -> {
+                    val dtoList = misskeyAPIProvider.get(account).children(
+                        NoteRequest(
+                            i = account.token,
+                            noteId = noteId.noteId,
+                            limit = 100,
+                        )
+                    ).throwIfHasError().body()!!
+                    dtoList.map {
+                        noteDataSourceAdder.addNoteDtoToDataSource(account, it)
+                    }
+                }
+                Account.InstanceType.MASTODON -> {
+                    val body = mastodonAPIProvider.get(account).getStatusesContext(noteId.noteId)
+                        .throwIfHasError()
+                        .body()
+                    requireNotNull(body).let {
+                        it.ancestors + it.descendants
+                    }.map {
+                        noteDataSourceAdder.addTootStatusDtoIntoDataSource(account, it)
+                    }
+                }
             }
+
         }
     }
 
     override suspend fun syncConversation(noteId: Note.Id): Result<Unit> = runCancellableCatching {
         withContext(ioDispatcher) {
             val account = getAccount.get(noteId.accountId)
-            val dtoList = misskeyAPIProvider.get(account).conversation(
-                NoteRequest(
-                    i = account.token,
-                    noteId = noteId.noteId,
+            when(account.instanceType) {
+                Account.InstanceType.MISSKEY -> {
+                    val dtoList = misskeyAPIProvider.get(account).conversation(
+                        NoteRequest(
+                            i = account.token,
+                            noteId = noteId.noteId,
 
-                    )
-            ).throwIfHasError().body()!!
-            dtoList.map {
-                noteDataSourceAdder.addNoteDtoToDataSource(account, it)
+                            )
+                    ).throwIfHasError().body()!!
+                    dtoList.map {
+                        noteDataSourceAdder.addNoteDtoToDataSource(account, it)
+                    }
+                }
+                Account.InstanceType.MASTODON -> {
+                    val body = mastodonAPIProvider.get(account).getStatusesContext(noteId.noteId)
+                        .throwIfHasError()
+                        .body()
+                    requireNotNull(body).let {
+                        it.ancestors + it.descendants
+                    }.map {
+                        noteDataSourceAdder.addTootStatusDtoIntoDataSource(account, it)
+                    }
+                }
             }
+
         }
     }
 


### PR DESCRIPTION
## やったこと
Mastodonのスレッドを取得できるように実装した。
またNoteのキャッシュ同期処理をMastodonでも動作するように実装した。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号

Closed #1307 

