### PR TITLE
削除して編集を実装

### DIFF
--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
@@ -109,6 +109,7 @@ fun TootStatusDTO.toNote(account: Account, nodeInfo: NodeInfo?): Note {
             isFedibirdQuote = quote != null,
             pollId = poll?.id,
             isSensitive = sensitive,
+            pureText = text
         ),
         nodeInfo = nodeInfo,
     )

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -80,7 +80,11 @@ class NoteRepositoryImpl @Inject constructor(
 
     override suspend fun delete(noteId: Note.Id): Result<Unit> = runCancellableCatching{
         withContext(ioDispatcher) {
-            noteApiAdapter.delete(noteId)
+            val account = getAccount.get(noteId.accountId)
+            when(val result = noteApiAdapter.delete(noteId)) {
+                is DeleteNoteResultType.Mastodon -> noteDataSourceAdder.addTootStatusDtoIntoDataSource(account, result.status)
+                DeleteNoteResultType.Misskey -> Unit
+            }
         }
     }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -78,12 +78,13 @@ class NoteRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun delete(noteId: Note.Id): Result<Unit> = runCancellableCatching{
+    override suspend fun delete(noteId: Note.Id): Result<Note> = runCancellableCatching{
         withContext(ioDispatcher) {
             val account = getAccount.get(noteId.accountId)
+            val note = find(noteId).getOrThrow()
             when(val result = noteApiAdapter.delete(noteId)) {
                 is DeleteNoteResultType.Mastodon -> noteDataSourceAdder.addTootStatusDtoIntoDataSource(account, result.status)
-                DeleteNoteResultType.Misskey -> Unit
+                DeleteNoteResultType.Misskey -> note
             }
         }
     }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenoteViewModel.kt
@@ -12,7 +12,6 @@ import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common.ResultState
 import net.pantasystem.milktea.common.StateContent
 import net.pantasystem.milktea.common.asLoadingStateFlow
-import net.pantasystem.milktea.model.notes.NoteRelationGetter
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.notes.*
@@ -218,7 +217,7 @@ sealed interface RenoteActionResultEvent {
         val accounts: List<Long>
     ) : RenoteActionResultEvent
 
-    data class UnRenote(val result: Result<Unit>, val noteId: Note.Id) : RenoteActionResultEvent
+    data class UnRenote(val result: Result<Note>, val noteId: Note.Id) : RenoteActionResultEvent
 }
 
 private fun NoteRelation.canRenote(account: Account, user: User): Boolean {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/DeleteAndEditUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/DeleteAndEditUseCase.kt
@@ -1,0 +1,26 @@
+package net.pantasystem.milktea.model.notes
+
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.model.UseCase
+import net.pantasystem.milktea.model.notes.draft.DraftNote
+import net.pantasystem.milktea.model.notes.draft.DraftNoteRepository
+import net.pantasystem.milktea.model.notes.draft.toDraftNote
+import javax.inject.Inject
+
+class DeleteAndEditUseCase @Inject constructor(
+    val noteRepository: NoteRepository,
+    val noteRelationGetter: NoteRelationGetter,
+    val draftNoteRepository: DraftNoteRepository,
+) : UseCase {
+
+    suspend operator fun invoke(id: Note.Id): Result<DraftNote> = runCancellableCatching {
+        val relation = noteRelationGetter.get(id).getOrThrow()
+        val result = noteRepository.delete(id).getOrThrow()
+        val draftNote = when(val r = requireNotNull(relation)) {
+            is NoteRelation.Normal -> r.copy(
+                note = result
+            )
+        }.toDraftNote()
+        draftNoteRepository.save(draftNote).getOrThrow()
+    }
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
@@ -67,7 +67,8 @@ data class Note(
             val isFedibirdQuote: Boolean,
             val pollId: String?,
             val isSensitive: Boolean?,
-        ) : Type {
+            val pureText: String?,
+            ) : Type {
             data class Tag(
                 val name: String,
                 val url: String,

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/NoteRepository.kt
@@ -5,7 +5,7 @@ import net.pantasystem.milktea.model.notes.poll.Poll
 
 interface NoteRepository {
 
-    suspend fun delete(noteId: Note.Id): Result<Unit>
+    suspend fun delete(noteId: Note.Id): Result<Note>
 
     suspend fun create(createNote: CreateNote): Result<Note>
 

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/draft/DraftNote.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/draft/DraftNote.kt
@@ -89,7 +89,7 @@ fun NoteRelation.toDraftNote(): DraftNote {
         visibleUserIds = this.note.visibleUserIds?.map {
             it.id
         },
-        text = this.note.text,
+        text = (this.note.type as? Note.Type.Mastodon)?.pureText ?: this.note.text,
         cw = this.note.cw,
         draftFiles = this.files?.map {
             DraftNoteFile.Remote(it)

--- a/modules/model/src/test/java/net/pantasystem/milktea/model/notes/NoteTest.kt
+++ b/modules/model/src/test/java/net/pantasystem/milktea/model/notes/NoteTest.kt
@@ -138,6 +138,7 @@ class NoteTest {
                 isFedibirdQuote = true,
                 pollId = null,
                 isSensitive = null,
+                pureText = null
             )
         )
         assertTrue(note.isQuote())
@@ -158,6 +159,7 @@ class NoteTest {
                 isFedibirdQuote = false,
                 pollId = null,
                 isSensitive = null,
+                pureText = null
             )
         )
         assertFalse(note.isQuote())
@@ -178,6 +180,7 @@ class NoteTest {
                 isFedibirdQuote = false,
                 pollId = null,
                 isSensitive = null,
+                pureText = null
             ),
             renoteId = Note.Id(0L, "id")
         )
@@ -199,7 +202,8 @@ class NoteTest {
                 mentions = listOf(),
                 isFedibirdQuote = false,
                 pollId = null,
-                isSensitive = null
+                isSensitive = null,
+                pureText = null,
             )
         )
         assertFalse(note.hasContent())


### PR DESCRIPTION
## やったこと
削除して編集をMastodonでも動作するように実装しました。
Mastodonの仕様に合わせてNoteRepositoryのdeleteメソッドの戻り値をNoteにするようにしました。
また削除して編集の処理をUseCaseに切り出すようにし、
成功した時は下書きとして保存するようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1322




