### PR TITLE
タブ設定画面をMastodonに対応させました

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/tab/TabFragment.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/tab/TabFragment.kt
@@ -205,6 +205,7 @@ internal class TimelinePagerAdapter(
         oldRequestBaseSetting = requestBaseList
         requestBaseList = list
         if (requestBaseList != oldRequestBaseSetting) {
+            scrollableTopFragments.clear()
             notifyDataSetChanged()
         }
 

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/PageSettingActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/PageSettingActivity.kt
@@ -64,7 +64,7 @@ class PageSettingActivity : AppCompatActivity() {
 //
         mPageSettingViewModel.pageAddedEvent.observe(this) { pt ->
             when (pt) {
-                PageType.SEARCH, PageType.SEARCH_HASH -> startActivity(
+                PageType.SEARCH, PageType.SEARCH_HASH, PageType.MASTODON_HASHTAG_TIMELINE -> startActivity(
                     searchNavigation.newIntent(SearchNavType.SearchScreen())
                 )
                 PageType.USER -> {
@@ -76,7 +76,7 @@ class PageSettingActivity : AppCompatActivity() {
                         )
                     launchSearchAndSelectUserForAddUserTimelineTab.launch(intent)
                 }
-                PageType.USER_LIST -> startActivity(userListNavigation.newIntent(UserListArgs()))
+                PageType.USER_LIST, PageType.MASTODON_LIST_TIMELINE -> startActivity(userListNavigation.newIntent(UserListArgs()))
                 PageType.DETAIL -> startActivity(searchNavigation.newIntent(SearchNavType.SearchScreen()))
                 PageType.ANTENNA -> startActivity(antennaNavigation.newIntent(Unit))
                 PageType.USERS_GALLERY_POSTS -> {

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageSettingViewModel.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageSettingViewModel.kt
@@ -84,7 +84,7 @@ class PageSettingViewModel @Inject constructor(
                     PageType.NOTIFICATION,
                     PageType.FAVORITE,
                     PageType.MASTODON_LIST_TIMELINE,
-                    PageType.MASTODON_USER_TIMELINE,
+//                    PageType.MASTODON_USER_TIMELINE,
 
                 )
             }


### PR DESCRIPTION
## やったこと
Mastodonのタブ設定画面上に表示される候補をMastodonに対応させました。
またMisskeyの候補表示順を変更しよく使われているものを選びやすくしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1310 


