### PR TITLE
Calckeyの一押しタイムラインを表示できるようにした

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/di/module/AccountModule.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/di/module/AccountModule.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import jp.panta.misskeyandroidclient.impl.PageDefaultStringsOnAndroid
 import net.pantasystem.milktea.model.account.MakeDefaultPagesUseCase
+import net.pantasystem.milktea.model.nodeinfo.NodeInfoRepository
 import javax.inject.Singleton
 
 @Module
@@ -18,10 +19,12 @@ object AccountModule {
     @Provides
     @Singleton
     fun provideMakeDefaultPagesUseCase(
-        @ApplicationContext context: Context
+        @ApplicationContext context: Context,
+        nodeInfoRepository: NodeInfoRepository,
     ) : MakeDefaultPagesUseCase {
         return MakeDefaultPagesUseCase(
-            PageDefaultStringsOnAndroid(context)
+            PageDefaultStringsOnAndroid(context),
+            nodeInfoRepository,
         )
     }
 }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/impl/PageDefaultStringsOnAndroid.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/impl/PageDefaultStringsOnAndroid.kt
@@ -14,4 +14,6 @@ class PageDefaultStringsOnAndroid(val context: Context) :
         get() = context.getString(R.string.hybrid_timeline)
     override val localTimeline: String
         get() = context.getString(R.string.local_timeline)
+    override val recommendedTimeline: String
+        get() = context.getString(R.string.calckey_recomended_timeline)
 }

--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/tab/TabFragment.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/tab/TabFragment.kt
@@ -23,14 +23,13 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.common.glide.GlideApp
-import net.pantasystem.milktea.common.ui.ScrollableTop
 import net.pantasystem.milktea.common.ui.ToolbarSetter
 import net.pantasystem.milktea.common_android_ui.PageableFragmentFactory
 import net.pantasystem.milktea.model.account.page.Page
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class TabFragment : Fragment(R.layout.fragment_tab), ScrollableTop {
+class TabFragment : Fragment(R.layout.fragment_tab) {
 
     companion object {
         private const val PAGES = "pages"
@@ -137,24 +136,6 @@ class TabFragment : Fragment(R.layout.fragment_tab), ScrollableTop {
         super.onDestroyView()
         mPagerAdapter.onDestroy()
     }
-    
-    
-
-    override fun showTop() {
-        showTopCurrentFragment()
-    }
-
-    private fun showTopCurrentFragment() {
-        try {
-            mPagerAdapter.scrollableTopFragments.forEach {
-                it.showTop()
-            }
-        } catch (_: UninitializedPropertyAccessException) {
-
-        }
-
-    }
-
 
 }
 
@@ -167,7 +148,6 @@ internal class TimelinePagerAdapter(
     private var oldRequestBaseSetting = requestBaseList
 
 
-    val scrollableTopFragments = ArrayList<ScrollableTop>()
     private val mFragments = ArrayList<Fragment>()
 
     override fun getCount(): Int {
@@ -178,9 +158,6 @@ internal class TimelinePagerAdapter(
         val item = requestBaseList[position]
         val fragment = pageableFragmentFactory.create(item)
 
-        if (fragment is ScrollableTop) {
-            scrollableTopFragments.add(fragment)
-        }
         mFragments.add(fragment)
         return fragment
     }
@@ -205,7 +182,6 @@ internal class TimelinePagerAdapter(
         oldRequestBaseSetting = requestBaseList
         requestBaseList = list
         if (requestBaseList != oldRequestBaseSetting) {
-            scrollableTopFragments.clear()
             notifyDataSetChanged()
         }
 
@@ -213,7 +189,6 @@ internal class TimelinePagerAdapter(
 
     fun onDestroy() {
         mFragments.clear()
-        scrollableTopFragments.clear()
     }
 
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
@@ -183,7 +183,8 @@ interface MisskeyAPI {
     @POST("api/notes/mentions")
     suspend fun mentions(@Body noteRequest: NoteRequest): Response<List<NoteDTO>?>
 
-
+    @POST("api/notes/recommended-timeline")
+    suspend fun getCalckeyRecommendedTimeline(@Body noteRequest: NoteRequest): Response<List<NoteDTO>?>
 
     //drive
     @POST("api/drive/files")

--- a/modules/common/src/main/java/net/pantasystem/milktea/common/ui/ScrollableTop.kt
+++ b/modules/common/src/main/java/net/pantasystem/milktea/common/ui/ScrollableTop.kt
@@ -1,5 +1,0 @@
-package net.pantasystem.milktea.common.ui
-
-interface ScrollableTop {
-    fun showTop()
-}

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/page/PageTypeHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/page/PageTypeHelper.kt
@@ -39,6 +39,7 @@ object PageTypeHelper{
             MASTODON_HASHTAG_TIMELINE -> context.getString(R.string.tag)
             MASTODON_LIST_TIMELINE -> context.getString(R.string.list)
             MASTODON_USER_TIMELINE -> context.getString(R.string.user)
+            CALCKEY_RECOMMENDED_TIMELINE -> context.getString(R.string.calckey_recomended_timeline)
         }
     }
 }

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -422,5 +422,6 @@
     <string name="visibility_personal">自分限定</string>
     <string name="visibility_limited">サークル</string>
     <string name="visibility_mutual">相互フォロー</string>
+    <string name="calckey_recomended_timeline">一押し</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -419,5 +419,6 @@
     <string name="visibility_personal">自我限制</string>
     <string name="visibility_limited">圆圈</string>
     <string name="visibility_mutual">相互关注</string>
+    <string name="calckey_recomended_timeline">推荐的</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -412,5 +412,6 @@
     <string name="visibility_personal">Personal</string>
     <string name="visibility_limited">Circle</string>
     <string name="visibility_mutual">Mutual Follow</string>
+    <string name="calckey_recomended_timeline">Recommended</string>
 
 </resources>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/TimelinePagingStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/TimelinePagingStoreImpl.kt
@@ -127,6 +127,7 @@ internal class TimelinePagingStoreImpl(
                 is Pageable.SearchByTag -> api::searchByTag
                 is Pageable.Featured -> api::featured
                 is Pageable.Mention -> api::mentions
+                is Pageable.CalckeyRecommendedTimeline -> api::getCalckeyRecommendedTimeline
                 is Pageable.Antenna -> {
                     if (api is MisskeyAPIV12) {
                         (api)::antennasNotes

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
@@ -23,7 +23,6 @@ import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.app_store.setting.SettingStore
 import net.pantasystem.milktea.common.ui.ApplyMenuTint
 import net.pantasystem.milktea.common.ui.PageableView
-import net.pantasystem.milktea.common.ui.ScrollableTop
 import net.pantasystem.milktea.common_navigation.AuthorizationArgs
 import net.pantasystem.milktea.common_navigation.AuthorizationNavigation
 import net.pantasystem.milktea.common_navigation.UserDetailNavigation
@@ -41,8 +40,7 @@ import net.pantasystem.milktea.note.viewmodel.NotesViewModel
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view), ScrollableTop,
-    PageableView {
+class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view), PageableView {
 
     companion object {
 
@@ -300,10 +298,5 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
         }
     }
 
-    override fun showTop() {
-        if (lifecycle.currentState == Lifecycle.State.RESUMED) {
-            mLinearLayoutManager.scrollToPosition(0)
-        }
-    }
 
 }

--- a/modules/features/note/src/main/res/layout/fragment_emoji_picker.xml
+++ b/modules/features/note/src/main/res/layout/fragment_emoji_picker.xml
@@ -47,21 +47,35 @@
 
         </com.google.android.material.tabs.TabLayout>
 
-
-        <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/reaction_choices_view_pager"
+        <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_below="@id/reaction_choices_tab"
-                android:visibility="@{ emojiPickerViewModel.uiState.isSearchMode ? View.GONE : View.VISIBLE }"
-                />
+                android:orientation="vertical"
+                android:layout_below="@id/reaction_choices_tab">
+            <androidx.core.widget.NestedScrollView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent">
+                <androidx.appcompat.widget.LinearLayoutCompat
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content">
+                    <androidx.recyclerview.widget.RecyclerView
+                            android:id="@+id/reaction_choices_view_pager"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:layout_below="@id/reaction_choices_tab"
+                            android:visibility="@{ emojiPickerViewModel.uiState.isSearchMode ? View.GONE : View.VISIBLE }"
+                            />
 
-        <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/searchSuggestionsView"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_below="@id/reaction_choices_tab"
-                android:visibility="@{ emojiPickerViewModel.uiState.isSearchMode ? View.VISIBLE : View.GONE }"
-                />
+                    <androidx.recyclerview.widget.RecyclerView
+                            android:id="@+id/searchSuggestionsView"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:layout_below="@id/reaction_choices_tab"
+                            android:visibility="@{ emojiPickerViewModel.uiState.isSearchMode ? View.VISIBLE : View.GONE }"
+                            />
+                </androidx.appcompat.widget.LinearLayoutCompat>
+            </androidx.core.widget.NestedScrollView>
+        </LinearLayout>
+
     </RelativeLayout>
 </layout>

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationFragment.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationFragment.kt
@@ -17,7 +17,6 @@ import com.wada811.databinding.dataBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import net.pantasystem.milktea.app_store.setting.SettingStore
-import net.pantasystem.milktea.common.ui.ScrollableTop
 import net.pantasystem.milktea.common_navigation.UserDetailNavigation
 import net.pantasystem.milktea.common_viewmodel.CurrentPageableTimelineViewModel
 import net.pantasystem.milktea.common_viewmodel.ScrollToTopViewModel
@@ -31,7 +30,7 @@ import javax.inject.Inject
 
 
 @AndroidEntryPoint
-class NotificationFragment : Fragment(R.layout.fragment_notification), ScrollableTop {
+class NotificationFragment : Fragment(R.layout.fragment_notification) {
 
 
     lateinit var mLinearLayoutManager: LinearLayoutManager
@@ -141,7 +140,4 @@ class NotificationFragment : Fragment(R.layout.fragment_notification), Scrollabl
         }
     }
 
-    override fun showTop() {
-        mLinearLayoutManager.scrollToPosition(0)
-    }
 }

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageSettingViewModel.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageSettingViewModel.kt
@@ -15,6 +15,7 @@ import net.pantasystem.milktea.common_android.eventbus.EventBus
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.page.*
 import net.pantasystem.milktea.model.instance.Version
+import net.pantasystem.milktea.model.nodeinfo.NodeInfo
 import net.pantasystem.milktea.model.nodeinfo.NodeInfoRepository
 import net.pantasystem.milktea.model.nodeinfo.getVersion
 import net.pantasystem.milktea.model.user.User
@@ -44,6 +45,7 @@ class PageSettingViewModel @Inject constructor(
     val pageTypes = account.filterNotNull().map {
         val nodeInfo = nodeInfoRepository.find(it.getHost()).getOrNull()
         val version = nodeInfo?.type?.getVersion() ?: Version("0")
+        val isCalckey = nodeInfo?.type is NodeInfo.SoftwareType.Misskey.Calckey
         when(it.instanceType) {
             Account.InstanceType.MISSKEY -> {
                 listOfNotNull(
@@ -51,6 +53,7 @@ class PageSettingViewModel @Inject constructor(
                     PageType.LOCAL,
                     PageType.SOCIAL,
                     PageType.GLOBAL,
+                    if (isCalckey) PageType.CALCKEY_RECOMMENDED_TIMELINE else null,
                     if (version >= Version("12")) PageType.ANTENNA else null,
                     PageType.NOTIFICATION,
                     PageType.USER_LIST,

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/MakeDefaultPagesUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/MakeDefaultPagesUseCase.kt
@@ -4,12 +4,15 @@ import net.pantasystem.milktea.model.UseCase
 import net.pantasystem.milktea.model.account.page.Page
 import net.pantasystem.milktea.model.account.page.PageableTemplate
 import net.pantasystem.milktea.model.instance.Meta
+import net.pantasystem.milktea.model.nodeinfo.NodeInfo
+import net.pantasystem.milktea.model.nodeinfo.NodeInfoRepository
 
 interface PageDefaultStrings {
     val homeTimeline: String
     val hybridThrowable: String
     val globalTimeline: String
     val localTimeline: String
+    val recommendedTimeline: String
 }
 
 
@@ -23,13 +26,18 @@ class PageDefaultStringsJp : PageDefaultStrings {
 
     override val localTimeline: String
         get() = "ローカル"
+    override val recommendedTimeline: String
+        get() = "一押し"
 }
 
 class MakeDefaultPagesUseCase(
-    private val pageDefaultStrings: PageDefaultStrings
+    private val pageDefaultStrings: PageDefaultStrings,
+    private val nodeInfoRepository: NodeInfoRepository,
 ) : UseCase {
 
     operator fun invoke(account: Account, meta: Meta?) : List<Page> {
+        val nodeInfo = nodeInfoRepository.get(account.getHost())
+        val isCalckey = nodeInfo?.type is NodeInfo.SoftwareType.Misskey.Calckey
         return when(account.instanceType) {
             Account.InstanceType.MISSKEY -> {
                 val isGlobalEnabled = !(meta?.disableGlobalTimeline ?: false)
@@ -41,6 +49,9 @@ class MakeDefaultPagesUseCase(
                 }
                 if (isGlobalEnabled) {
                     defaultPages.add(PageableTemplate(account).globalTimeline(pageDefaultStrings.globalTimeline))
+                }
+                if (isCalckey) {
+                    defaultPages.add(PageableTemplate(account).calckeyRecommendedTimeline(pageDefaultStrings.recommendedTimeline))
                 }
                 defaultPages
             }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
@@ -180,6 +180,9 @@ data class PageParams(
                         excludeReplies = includeReplies?.not()
                     )
                 }
+                CALCKEY_RECOMMENDED_TIMELINE -> {
+                    Pageable.CalckeyRecommendedTimeline
+                }
             }
         } catch (e: NullPointerException) {
             throw IllegalStateException("パラメーターに問題があります: $this")

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageType.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageType.kt
@@ -28,17 +28,9 @@ enum class PageType(val defaultName: String){
     MASTODON_HOME_TIMELINE("MastodonHomeTimeline"),
     MASTODON_HASHTAG_TIMELINE("MastodonHashtagTimeline"),
     MASTODON_LIST_TIMELINE("MastodonListTimeline"),
-    MASTODON_USER_TIMELINE("MastodonUserTimeline")
+    MASTODON_USER_TIMELINE("MastodonUserTimeline"),
+
+    CALCKEY_RECOMMENDED_TIMELINE("CalckeyRecommendedTimeline"),
+
     //USER_PINは別
 }
-
-
-
-val galleryTypes = setOf(
-    PageType.GALLERY_FEATURED,
-    PageType.GALLERY_POSTS,
-    PageType.GALLERY_POPULAR,
-    PageType.USERS_GALLERY_POSTS,
-    PageType.I_LIKED_GALLERY_POSTS,
-    PageType.MY_GALLERY_POSTS
-)

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
@@ -339,6 +339,14 @@ sealed class Pageable : Serializable {
 
     }
 
+    object CalckeyRecommendedTimeline : Pageable(), UntilPaginate, SincePaginate {
+        override fun toParams(): PageParams {
+            return PageParams(
+                type = PageType.CALCKEY_RECOMMENDED_TIMELINE,
+            )
+        }
+    }
+
 
     abstract fun toParams(): PageParams
 

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageableTemplate.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageableTemplate.kt
@@ -80,6 +80,15 @@ class PageableTemplate(val account: Account?) {
             Pageable.Mastodon.HomeTimeline
         )
     }
+
+    fun calckeyRecommendedTimeline(title: String): Page {
+        return Page(
+            account?.accountId ?: -1,
+            title,
+            0,
+            Pageable.CalckeyRecommendedTimeline
+        )
+    }
 }
 
 fun Account.newPage(pageable: Pageable, name: String): Page {


### PR DESCRIPTION
## やったこと
Calckeyの独自機能である一押しタイムラインを表示できるようにしました。
またCalckey初回連携時は自動的に一押しタイムラインをタブに追加するようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考
ストリーミングAPIのサポートは行なっていません。

## Issue番号

Closed #1334 
#951

