### PR TITLE
絵文字ピッカーが一定件数以上表示することができなかった不具合を修正

### DIFF
--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/account/MakeDefaultPagesUseCaseTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/account/MakeDefaultPagesUseCaseTest.kt
@@ -1,10 +1,14 @@
 package jp.panta.misskeyandroidclient.model.account
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.MakeDefaultPagesUseCase
 import net.pantasystem.milktea.model.account.PageDefaultStringsJp
 import net.pantasystem.milktea.model.account.page.PageType
 import net.pantasystem.milktea.model.instance.Meta
+import net.pantasystem.milktea.model.nodeinfo.NodeInfo
+import net.pantasystem.milktea.model.nodeinfo.NodeInfoRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,7 +22,23 @@ class MakeDefaultPagesUseCaseTest {
     @BeforeEach
     fun setup() {
         makeDefaultPagesUseCase = MakeDefaultPagesUseCase(
-            PageDefaultStringsJp()
+            PageDefaultStringsJp(),
+            nodeInfoRepository = object : NodeInfoRepository {
+                override suspend fun find(host: String): Result<NodeInfo> = Result.success(get(host))
+
+                override fun get(host: String): NodeInfo {
+                    return NodeInfo(
+                        host = "", version = "", software = NodeInfo.Software(
+                            name = "misskey",
+                            version = ""
+                        )
+                    )
+                }
+
+                override fun observe(host: String): Flow<NodeInfo?> = flowOf()
+                override suspend fun sync(host: String): Result<Unit> = Result.success(Unit)
+                override suspend fun syncAll(): Result<Unit> = Result.success(Unit)
+            }
         )
         account = Account(
             "remoteId",

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/resource/DpHelper.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/resource/DpHelper.kt
@@ -1,0 +1,9 @@
+package net.pantasystem.milktea.common_android.resource
+
+import android.content.Context
+import android.util.DisplayMetrics
+
+fun Context.convertDp2Px(dp: Float): Float {
+    val metrics: DisplayMetrics = resources.displayMetrics
+    return dp * metrics.density
+}

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiChoicesListAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiChoicesListAdapter.kt
@@ -2,14 +2,16 @@ package net.pantasystem.milktea.note.reaction.choices
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.flexbox.AlignItems
-import com.google.android.flexbox.FlexboxLayoutManager
+import net.pantasystem.milktea.common_android.resource.convertDp2Px
 import net.pantasystem.milktea.note.EmojiType
 import net.pantasystem.milktea.note.SegmentType
 import net.pantasystem.milktea.note.databinding.ItemCategoryWithListBinding
+
 
 class EmojiChoicesListAdapter(
     val onEmojiSelected: (EmojiType) -> Unit,
@@ -41,17 +43,38 @@ class SegmentViewHolder(
     val binding: ItemCategoryWithListBinding,
     onEmojiSelected: (EmojiType) -> Unit,
 ) : RecyclerView.ViewHolder(binding.root) {
+
+    var isSatLayoutManager = false
+
     val adapter = EmojiChoicesAdapter(onEmojiSelected)
     fun onBind(segmentType: SegmentType) {
         val label = segmentType.label.getString(binding.root.context)
         binding.categoryName.text = label
 
-        val flexBoxLayoutManager = FlexboxLayoutManager(binding.root.context)
-        flexBoxLayoutManager.alignItems = AlignItems.STRETCH
-        binding.emojisView.layoutManager = flexBoxLayoutManager
+        if (!isSatLayoutManager) {
+            val listener = object : ViewTreeObserver.OnGlobalLayoutListener {
+                override fun onGlobalLayout() {
+                    val layoutManager = GridLayoutManager(binding.root.context, calculateSpanCount())
+
+                    binding.emojisView.layoutManager = layoutManager
+                    binding.emojisView.viewTreeObserver.removeOnGlobalLayoutListener(this)
+                    isSatLayoutManager = true
+                }
+            }
+            binding.emojisView.viewTreeObserver.addOnGlobalLayoutListener(listener)
+        }
+
+
         adapter.submitList(segmentType.emojis)
         binding.emojisView.isNestedScrollingEnabled = false
 
         binding.emojisView.adapter = adapter
     }
+
+    private fun calculateSpanCount(): Int {
+        val viewWidth = binding.emojisView.measuredWidth
+        val itemWidth =  binding.root.context.convertDp2Px(54f).toInt()
+        return viewWidth / itemWidth
+    }
+
 }

--- a/modules/features/note/src/main/res/layout/fragment_emoji_picker.xml
+++ b/modules/features/note/src/main/res/layout/fragment_emoji_picker.xml
@@ -7,9 +7,10 @@
                 type="net.pantasystem.milktea.note.emojis.viewmodel.EmojiPickerViewModel" />
         <import type="android.view.View" />
     </data>
-    <RelativeLayout
+    <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:orientation="vertical"
             >
 
         <com.google.android.material.textfield.TextInputLayout
@@ -39,43 +40,35 @@
                 app:tabMode="scrollable"
                 app:tabTextColor="?attr/normalIconTint"
                 android:elevation="0dp"
-                android:layout_below="@id/searchReactionInputLayout"
                 style="@style/Widget.MaterialComponents.Toolbar.Surface"
                 android:visibility="@{ emojiPickerViewModel.uiState.isSearchMode ? View.GONE : View.VISIBLE }"
                 >
 
 
         </com.google.android.material.tabs.TabLayout>
-
-        <LinearLayout
+        <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/reaction_choices_view_pager"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="vertical"
-                android:layout_below="@id/reaction_choices_tab">
-            <androidx.core.widget.NestedScrollView
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent">
-                <androidx.appcompat.widget.LinearLayoutCompat
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content">
-                    <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/reaction_choices_view_pager"
-                            android:layout_width="match_parent"
-                            android:layout_height="match_parent"
-                            android:layout_below="@id/reaction_choices_tab"
-                            android:visibility="@{ emojiPickerViewModel.uiState.isSearchMode ? View.GONE : View.VISIBLE }"
-                            />
+                android:visibility="@{ emojiPickerViewModel.uiState.isSearchMode ? View.GONE : View.VISIBLE }"
+                />
 
-                    <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/searchSuggestionsView"
-                            android:layout_width="match_parent"
-                            android:layout_height="match_parent"
-                            android:layout_below="@id/reaction_choices_tab"
-                            android:visibility="@{ emojiPickerViewModel.uiState.isSearchMode ? View.VISIBLE : View.GONE }"
-                            />
-                </androidx.appcompat.widget.LinearLayoutCompat>
-            </androidx.core.widget.NestedScrollView>
-        </LinearLayout>
+        <androidx.core.widget.NestedScrollView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:visibility="@{ emojiPickerViewModel.uiState.isSearchMode ? View.VISIBLE : View.GONE }">
+            <androidx.appcompat.widget.LinearLayoutCompat
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content">
 
-    </RelativeLayout>
+                <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/searchSuggestionsView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+
+                        />
+            </androidx.appcompat.widget.LinearLayoutCompat>
+        </androidx.core.widget.NestedScrollView>
+
+    </LinearLayout>
 </layout>


### PR DESCRIPTION
## やったこと
FlexboxLayoutManager+RecyclerView使用時にRecyclerViewのheightにwrap_contentを使用すると
なぜか一定件数以上表示することができないという謎バグが発生してしまうことを確認した（LinearLayoautManagerの時は全て表示される）
そこでGridLayoutManagerを使用することによって解決するようにした。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号




