### PR TITLE
絵文字ピッカーを以前のレイアウト方式に戻した

### DIFF
--- a/modules/features/note/src/main/res/layout/fragment_emoji_picker.xml
+++ b/modules/features/note/src/main/res/layout/fragment_emoji_picker.xml
@@ -7,7 +7,7 @@
                 type="net.pantasystem.milktea.note.emojis.viewmodel.EmojiPickerViewModel" />
         <import type="android.view.View" />
     </data>
-    <LinearLayout
+    <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="vertical"
@@ -42,6 +42,7 @@
                 android:elevation="0dp"
                 style="@style/Widget.MaterialComponents.Toolbar.Surface"
                 android:visibility="@{ emojiPickerViewModel.uiState.isSearchMode ? View.GONE : View.VISIBLE }"
+                android:layout_below="@id/searchReactionInputLayout"
                 >
 
 
@@ -51,12 +52,15 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:visibility="@{ emojiPickerViewModel.uiState.isSearchMode ? View.GONE : View.VISIBLE }"
+                android:layout_below="@id/reaction_choices_tab"
                 />
 
         <androidx.core.widget.NestedScrollView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:visibility="@{ emojiPickerViewModel.uiState.isSearchMode ? View.VISIBLE : View.GONE }">
+                android:visibility="@{ emojiPickerViewModel.uiState.isSearchMode ? View.VISIBLE : View.GONE }"
+                android:layout_below="@id/reaction_choices_tab"
+                >
             <androidx.appcompat.widget.LinearLayoutCompat
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent">
@@ -70,5 +74,5 @@
             </androidx.appcompat.widget.LinearLayoutCompat>
         </androidx.core.widget.NestedScrollView>
 
-    </LinearLayout>
+    </RelativeLayout>
 </layout>


### PR DESCRIPTION
## やったこと
件数が少ないと高さが変わってしまう不具合が発生するようになってしまったので
LinearLayoutからRelativeLayoutに戻しました

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



