### PR TITLE
JSON対応クラスをEntityクラスに変換するロジックをクラスに切り出すようにしました

### DIFF
--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/notes/impl/InMemoryNoteDataSourceTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/notes/impl/InMemoryNoteDataSourceTest.kt
@@ -3,18 +3,16 @@ package jp.panta.misskeyandroidclient.model.notes.impl
 import jp.panta.misskeyandroidclient.logger.TestLogger
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
-import net.pantasystem.milktea.api.misskey.notes.NoteDTO
-import net.pantasystem.milktea.api.misskey.users.UserDTO
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.data.infrastructure.MemoryCacheCleaner
 import net.pantasystem.milktea.data.infrastructure.notes.impl.InMemoryNoteDataSource
-import net.pantasystem.milktea.data.infrastructure.toNote
 import net.pantasystem.milktea.model.AddResult
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.nodeinfo.NodeInfo
+import net.pantasystem.milktea.model.notes.Note
+import net.pantasystem.milktea.model.notes.make
+import net.pantasystem.milktea.model.user.User
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -39,16 +37,10 @@ class InMemoryNoteDataSourceTest {
     fun testAdd() {
         val noteDataSource = InMemoryNoteDataSource(MemoryCacheCleaner())
 
-        val dto = NoteDTO(
-            "",
-            Clock.System.now(),
-            renoteCount = 0,
-            replyCount = 0,
-            userId = "hoge",
-            user = UserDTO("hoge", "hogeName")
-        )
-        val note = dto.toNote(
-            account, NodeInfo(
+        val note = Note.make(
+            Note.Id(0L, ""),
+            userId = User.Id(0L, ""),
+            nodeInfo = NodeInfo(
                 host = "", version = "", software = NodeInfo.Software(
                     name = "misskey",
                     version = ""
@@ -74,42 +66,5 @@ class InMemoryNoteDataSourceTest {
     }
 
 
-    @Test
-    fun testUpdateNote(): Unit = runBlocking {
-        val noteDataSource = InMemoryNoteDataSource(MemoryCacheCleaner())
 
-        val dto = NoteDTO(
-            "note-1",
-            Clock.System.now(),
-            renoteCount = 0,
-            replyCount = 0,
-            userId = "hoge",
-            user = UserDTO("hoge", "hogeName")
-        )
-        val note = dto.toNote(
-            account, NodeInfo(
-                host = "", version = "", software = NodeInfo.Software(
-                    name = "misskey",
-                    version = ""
-                )
-
-            )
-        )
-        noteDataSource.add(
-            note
-        )
-
-        val dtoParsed = dto.toNote(
-            account, NodeInfo(
-                host = "", version = "", software = NodeInfo.Software(
-                    name = "misskey",
-                    version = ""
-                )
-
-            )
-        )
-        assertEquals(AddResult.Updated, noteDataSource.add(dtoParsed).getOrThrow())
-
-        assertTrue(dtoParsed === noteDataSource.get(dtoParsed.id).getOrThrow())
-    }
 }

--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/notes/impl/NoteCaptureAPIAdapterTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/notes/impl/NoteCaptureAPIAdapterTest.kt
@@ -6,22 +6,19 @@ import jp.panta.misskeyandroidclient.model.account.TestAccountRepository
 import jp.panta.misskeyandroidclient.streaming.TestSocketWithAccountProviderImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
-import net.pantasystem.milktea.api.misskey.notes.NoteDTO
-import net.pantasystem.milktea.api.misskey.users.UserDTO
 import net.pantasystem.milktea.api_streaming.NoteCaptureAPIImpl
 import net.pantasystem.milktea.api_streaming.NoteUpdated
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.data.infrastructure.MemoryCacheCleaner
 import net.pantasystem.milktea.data.infrastructure.notes.NoteCaptureAPIWithAccountProviderImpl
 import net.pantasystem.milktea.data.infrastructure.notes.impl.InMemoryNoteDataSource
-import net.pantasystem.milktea.data.infrastructure.toNote
 import net.pantasystem.milktea.model.account.AccountRepository
-import net.pantasystem.milktea.model.nodeinfo.NodeInfo
+import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.NoteDataSource
+import net.pantasystem.milktea.model.notes.make
+import net.pantasystem.milktea.model.user.User
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
-
 import org.junit.jupiter.api.Test
 
 class NoteCaptureAPIAdapterTest {
@@ -63,22 +60,9 @@ class NoteCaptureAPIAdapterTest {
             val account = accountRepository.getCurrentAccount().getOrThrow()
             val noteCapture = noteCaptureAPIWithAccountProvider.get(account) as NoteCaptureAPIImpl
 
-            val dto = NoteDTO(
-                "note-1",
-                Clock.System.now(),
-                renoteCount = 0,
-                replyCount = 0,
-                userId = "hoge",
-                user = UserDTO("hoge", "hogeName")
-            )
-            val note = dto.toNote(
-                account, NodeInfo(
-                    host = "", version = "", software = NodeInfo.Software(
-                        name = "misskey",
-                        version = ""
-                    )
-
-                )
+            val note = Note.make(
+                id = Note.Id(account.accountId, "note-1"),
+                userId = User.Id(account.accountId, "hoge")
             )
             noteDataSource.add(
                 note

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/FilePropertyDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/FilePropertyDTOEntityConverter.kt
@@ -1,0 +1,33 @@
+package net.pantasystem.milktea.data.converters
+
+import net.pantasystem.milktea.api.misskey.drive.FilePropertyDTO
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.drive.FileProperty
+import net.pantasystem.milktea.model.user.User
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FilePropertyDTOEntityConverter @Inject constructor() {
+
+    suspend fun convert(filePropertyDTO: FilePropertyDTO, account: Account): FileProperty {
+        return FileProperty(
+            id = FileProperty.Id(account.accountId, filePropertyDTO.id),
+            name = filePropertyDTO.name,
+            createdAt = filePropertyDTO.createdAt,
+            type = filePropertyDTO.type,
+            md5 = filePropertyDTO.md5,
+            size = filePropertyDTO.size ?: 0,
+            userId = filePropertyDTO.userId?.let { User.Id(account.accountId, filePropertyDTO.userId!!) },
+            folderId = filePropertyDTO.folderId,
+            comment = filePropertyDTO.comment,
+            isSensitive = filePropertyDTO.isSensitive ?: false,
+            url = filePropertyDTO.getUrl(account.normalizedInstanceDomain),
+            thumbnailUrl = filePropertyDTO.getThumbnailUrl(account.normalizedInstanceDomain),
+            blurhash = filePropertyDTO.blurhash,
+            properties = filePropertyDTO.properties?.let {
+                FileProperty.Properties(it.width, it.height)
+            }
+        )
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/GalleryPostDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/GalleryPostDTOEntityConverter.kt
@@ -1,6 +1,5 @@
 package net.pantasystem.milktea.data.converters
 
-import net.pantasystem.milktea.data.infrastructure.toFileProperty
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.drive.FileProperty
 import net.pantasystem.milktea.model.drive.FilePropertyDataSource
@@ -14,6 +13,7 @@ class GalleryPostDTOEntityConverter @Inject constructor(
     private val filePropertyDataSource: FilePropertyDataSource,
     private val userDataSource: net.pantasystem.milktea.model.user.UserDataSource,
     private val userDTOEntityConverter: UserDTOEntityConverter,
+    private val filePropertyDTOEntityConverter: FilePropertyDTOEntityConverter,
 ) {
 
     suspend fun convert(
@@ -21,7 +21,7 @@ class GalleryPostDTOEntityConverter @Inject constructor(
         account: Account
     ): GalleryPost {
         filePropertyDataSource.addAll(galleryPostDTO.files.map {
-            it.toFileProperty(account)
+            filePropertyDTOEntityConverter.convert(it, account)
         })
         // NOTE: API上ではdetailだったが実際に受信されたデータはSimpleだったのでfalse
         userDataSource.add(userDTOEntityConverter.convert(account, galleryPostDTO.user, false))

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/GalleryPostDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/GalleryPostDTOEntityConverter.kt
@@ -1,0 +1,60 @@
+package net.pantasystem.milktea.data.converters
+
+import net.pantasystem.milktea.data.infrastructure.toFileProperty
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.drive.FileProperty
+import net.pantasystem.milktea.model.drive.FilePropertyDataSource
+import net.pantasystem.milktea.model.gallery.GalleryPost
+import net.pantasystem.milktea.model.user.User
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class GalleryPostDTOEntityConverter @Inject constructor(
+    private val filePropertyDataSource: FilePropertyDataSource,
+    private val userDataSource: net.pantasystem.milktea.model.user.UserDataSource,
+    private val userDTOEntityConverter: UserDTOEntityConverter,
+) {
+
+    suspend fun convert(
+        galleryPostDTO: net.pantasystem.milktea.api.misskey.v12_75_0.GalleryPost,
+        account: Account
+    ): GalleryPost {
+        filePropertyDataSource.addAll(galleryPostDTO.files.map {
+            it.toFileProperty(account)
+        })
+        // NOTE: API上ではdetailだったが実際に受信されたデータはSimpleだったのでfalse
+        userDataSource.add(userDTOEntityConverter.convert(account, galleryPostDTO.user, false))
+        if (galleryPostDTO.likedCount == null || galleryPostDTO.isLiked == null) {
+            return GalleryPost.Normal(
+                GalleryPost.Id(account.accountId, galleryPostDTO.id),
+                galleryPostDTO.createdAt,
+                galleryPostDTO.updatedAt,
+                galleryPostDTO.title,
+                galleryPostDTO.description,
+                User.Id(account.accountId, galleryPostDTO.userId),
+                galleryPostDTO.files.map {
+                    FileProperty.Id(account.accountId, it.id)
+                },
+                galleryPostDTO.tags ?: emptyList(),
+                galleryPostDTO.isSensitive
+            )
+        } else {
+            return GalleryPost.Authenticated(
+                GalleryPost.Id(account.accountId, galleryPostDTO.id),
+                galleryPostDTO.createdAt,
+                galleryPostDTO.updatedAt,
+                galleryPostDTO.title,
+                galleryPostDTO.description,
+                User.Id(account.accountId, galleryPostDTO.userId),
+                galleryPostDTO.files.map {
+                    FileProperty.Id(account.accountId, it.id)
+                },
+                galleryPostDTO.tags ?: emptyList(),
+                galleryPostDTO.isSensitive,
+                galleryPostDTO.likedCount ?: 0,
+                galleryPostDTO.isLiked ?: false
+            )
+        }
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverter.kt
@@ -1,0 +1,69 @@
+package net.pantasystem.milktea.data.converters
+
+import net.pantasystem.milktea.api.misskey.notes.NoteDTO
+import net.pantasystem.milktea.api.misskey.notes.NoteVisibilityType
+import net.pantasystem.milktea.data.infrastructure.Visibility
+import net.pantasystem.milktea.data.infrastructure.toPoll
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.channel.Channel
+import net.pantasystem.milktea.model.drive.FileProperty
+import net.pantasystem.milktea.model.emoji.Emoji
+import net.pantasystem.milktea.model.nodeinfo.NodeInfo
+import net.pantasystem.milktea.model.notes.Note
+import net.pantasystem.milktea.model.notes.reaction.ReactionCount
+import net.pantasystem.milktea.model.user.User
+import javax.inject.Inject
+
+class NoteDTOEntityConverter @Inject constructor() {
+
+    suspend fun convert(noteDTO: NoteDTO, account: Account, nodeInfo: NodeInfo?): Note {
+        val visibility = Visibility(
+            noteDTO.visibility ?: NoteVisibilityType.Public,
+            isLocalOnly = noteDTO.localOnly ?: false,
+            visibleUserIds = noteDTO.visibleUserIds?.map { id ->
+                User.Id(account.accountId, id)
+            } ?: emptyList()
+        )
+        return Note(
+            id = Note.Id(account.accountId, noteDTO.id),
+            createdAt = noteDTO.createdAt,
+            text = noteDTO.text,
+            cw = noteDTO.cw,
+            userId = User.Id(account.accountId, noteDTO.userId),
+            replyId = noteDTO.replyId?.let { Note.Id(account.accountId, noteDTO.replyId!!) },
+            renoteId = noteDTO.renoteId?.let { Note.Id(account.accountId, noteDTO.renoteId!!) },
+            viaMobile = noteDTO.viaMobile,
+            visibility = visibility,
+            localOnly = noteDTO.localOnly,
+            emojis = (noteDTO.emojiList ?: emptyList()) + (noteDTO.reactionEmojis?.map {
+                Emoji(name = it.key, uri = it.value, url = it.value)
+            } ?: emptyList()),
+            app = noteDTO.app?.toModel(),
+            fileIds = noteDTO.fileIds?.map { FileProperty.Id(account.accountId, it) },
+            poll = noteDTO.poll?.toPoll(),
+            reactionCounts = noteDTO.reactionCounts?.map {
+                ReactionCount(reaction = it.key, it.value)
+            } ?: emptyList(),
+            renoteCount = noteDTO.renoteCount,
+            repliesCount = noteDTO.replyCount,
+            uri = noteDTO.uri,
+            url = noteDTO.url,
+            visibleUserIds = noteDTO.visibleUserIds?.map {
+                User.Id(account.accountId, it)
+            } ?: emptyList(),
+            myReaction = noteDTO.myReaction,
+            channelId = noteDTO.channelId?.let {
+                Channel.Id(account.accountId, it)
+            },
+            type = Note.Type.Misskey(
+                channel = noteDTO.channel?.let {
+                    Note.Type.Misskey.SimpleChannelInfo(
+                        id = Channel.Id(account.accountId, it.id),
+                        name = it.name
+                    )
+                }
+            ),
+            nodeInfo = nodeInfo,
+        )
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverter.kt
@@ -2,14 +2,15 @@ package net.pantasystem.milktea.data.converters
 
 import net.pantasystem.milktea.api.misskey.notes.NoteDTO
 import net.pantasystem.milktea.api.misskey.notes.NoteVisibilityType
-import net.pantasystem.milktea.data.infrastructure.Visibility
-import net.pantasystem.milktea.data.infrastructure.toPoll
+import net.pantasystem.milktea.api.misskey.notes.PollDTO
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.channel.Channel
 import net.pantasystem.milktea.model.drive.FileProperty
 import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.nodeinfo.NodeInfo
 import net.pantasystem.milktea.model.notes.Note
+import net.pantasystem.milktea.model.notes.Visibility
+import net.pantasystem.milktea.model.notes.poll.Poll
 import net.pantasystem.milktea.model.notes.reaction.ReactionCount
 import net.pantasystem.milktea.model.user.User
 import javax.inject.Inject
@@ -65,5 +66,34 @@ class NoteDTOEntityConverter @Inject constructor() {
             ),
             nodeInfo = nodeInfo,
         )
+    }
+}
+
+fun PollDTO?.toPoll(): Poll? {
+    return this?.let { dto ->
+        Poll(
+            multiple = dto.multiple,
+            expiresAt = dto.expiresAt,
+            choices = choices.mapIndexed { index, value ->
+                Poll.Choice(
+                    index = index,
+                    text = value.text,
+                    isVoted = value.isVoted,
+                    votes = value.votes
+                )
+            }
+        )
+    }
+}
+
+
+@Throws(IllegalArgumentException::class)
+fun Visibility(type: NoteVisibilityType, isLocalOnly: Boolean, visibleUserIds: List<User.Id>? = null): Visibility {
+    return when(type){
+        NoteVisibilityType.Public -> Visibility.Public(isLocalOnly)
+        NoteVisibilityType.Followers -> Visibility.Followers(isLocalOnly)
+        NoteVisibilityType.Home -> Visibility.Home(isLocalOnly)
+        NoteVisibilityType.Specified -> Visibility.Specified(visibleUserIds ?: emptyList())
+        else -> Visibility.Public(isLocalOnly)
     }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverter.kt
@@ -14,7 +14,9 @@ import net.pantasystem.milktea.model.notes.poll.Poll
 import net.pantasystem.milktea.model.notes.reaction.ReactionCount
 import net.pantasystem.milktea.model.user.User
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class NoteDTOEntityConverter @Inject constructor() {
 
     suspend fun convert(noteDTO: NoteDTO, account: Account, nodeInfo: NodeInfo?): Note {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NotificationDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NotificationDTOEntityConverter.kt
@@ -9,7 +9,9 @@ import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notification.*
 import net.pantasystem.milktea.model.user.User
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class NotificationDTOEntityConverter @Inject constructor(
     private val noteDTOEntityConverter: NoteDTOEntityConverter
 ) {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NotificationDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NotificationDTOEntityConverter.kt
@@ -1,0 +1,158 @@
+package net.pantasystem.milktea.data.converters
+
+import net.pantasystem.milktea.api.misskey.notification.NotificationDTO
+import net.pantasystem.milktea.data.infrastructure.toGroup
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.group.InvitationId
+import net.pantasystem.milktea.model.nodeinfo.NodeInfo
+import net.pantasystem.milktea.model.notes.Note
+import net.pantasystem.milktea.model.notification.*
+import net.pantasystem.milktea.model.user.User
+import javax.inject.Inject
+
+class NotificationDTOEntityConverter @Inject constructor(
+    private val noteDTOEntityConverter: NoteDTOEntityConverter
+) {
+    suspend fun convert(
+        notificationDTO: NotificationDTO,
+        account: Account,
+        nodeInfo: NodeInfo?
+    ): Notification {
+        val id = Notification.Id(account.accountId, notificationDTO.id)
+        return when (notificationDTO.type) {
+            "follow" -> {
+                FollowNotification(
+                    id,
+                    notificationDTO.createdAt,
+                    User.Id(account.accountId, notificationDTO.userId!!),
+                    notificationDTO.isRead ?: true
+                )
+            }
+            "followRequestAccepted" -> {
+                FollowRequestAcceptedNotification(
+                    id,
+                    notificationDTO.createdAt,
+                    User.Id(account.accountId, notificationDTO.userId!!),
+                    notificationDTO.isRead ?: true
+                )
+            }
+            "receiveFollowRequest" -> {
+                ReceiveFollowRequestNotification(
+                    id,
+                    notificationDTO.createdAt,
+                    User.Id(account.accountId, notificationDTO.userId!!),
+                    notificationDTO.isRead ?: true
+                )
+            }
+            "mention" -> {
+                MentionNotification(
+                    id,
+                    notificationDTO.createdAt,
+                    User.Id(account.accountId, notificationDTO.userId!!),
+                    Note.Id(
+                        account.accountId,
+                        notificationDTO.note?.id ?: throw IllegalStateException("noteId参照不能")
+                    ),
+                    notificationDTO.isRead ?: true
+                )
+            }
+            "reply" -> {
+                ReplyNotification(
+                    id,
+                    notificationDTO.createdAt,
+                    User.Id(account.accountId, notificationDTO.userId!!),
+                    Note.Id(
+                        account.accountId,
+                        notificationDTO.note?.id ?: throw IllegalStateException("noteId参照不能")
+                    ),
+                    notificationDTO.isRead ?: true
+                )
+            }
+            "renote" -> {
+                RenoteNotification(
+                    id,
+                    notificationDTO.createdAt,
+                    User.Id(account.accountId, notificationDTO.userId!!),
+                    Note.Id(
+                        account.accountId,
+                        notificationDTO.note?.id ?: throw IllegalStateException("noteId参照不能")
+                    ),
+                    notificationDTO.isRead ?: true
+                )
+            }
+            "quote" -> {
+                QuoteNotification(
+                    id,
+                    notificationDTO.createdAt,
+                    User.Id(account.accountId, notificationDTO.userId!!),
+                    Note.Id(
+                        account.accountId,
+                        notificationDTO.note?.id ?: throw IllegalStateException("noteId参照不能")
+                    ),
+                    notificationDTO.isRead ?: true
+                )
+            }
+            "reaction" -> {
+
+                require(notificationDTO.reaction != null) {
+                    "想定しないデータ=$notificationDTO"
+                }
+                require(notificationDTO.note != null)
+                val n = noteDTOEntityConverter.convert(notificationDTO.note!!, account, nodeInfo)
+                ReactionNotification(
+                    id,
+                    notificationDTO.createdAt,
+                    User.Id(account.accountId, notificationDTO.userId!!),
+                    n.id,
+                    notificationDTO.reaction!!,
+                    notificationDTO.isRead ?: true
+                )
+            }
+            "pollVote" -> {
+                require(notificationDTO.noteId != null || notificationDTO.note != null)
+                require(notificationDTO.choice != null)
+                PollVoteNotification(
+                    id,
+                    Note.Id(
+                        account.accountId,
+                        notificationDTO.noteId ?: notificationDTO.note?.id!!
+                    ),
+                    notificationDTO.createdAt,
+                    User.Id(account.accountId, notificationDTO.userId!!),
+                    notificationDTO.choice!!,
+                    notificationDTO.isRead ?: true
+                )
+            }
+            "pollEnded", "poll_finished" -> {
+                require(notificationDTO.note != null)
+                PollEndedNotification(
+                    id,
+                    notificationDTO.createdAt,
+                    isRead = notificationDTO.isRead ?: true,
+                    Note.Id(account.accountId, notificationDTO.note!!.id)
+                )
+            }
+            "groupInvited" -> {
+                require(notificationDTO.invitation != null)
+                require(notificationDTO.userId != null)
+                GroupInvitedNotification(
+                    id,
+                    isRead = notificationDTO.isRead ?: true,
+                    notificationDTO.createdAt,
+                    group = notificationDTO.invitation!!.group.toGroup(account.accountId),
+                    User.Id(account.accountId, notificationDTO.userId!!),
+                    InvitationId(account.accountId, notificationDTO.invitation!!.id),
+                )
+            }
+            else -> {
+                return UnknownNotification(
+                    id,
+                    notificationDTO.createdAt,
+                    notificationDTO.isRead ?: false,
+                    User.Id(account.accountId, notificationDTO.userId!!),
+                    notificationDTO.type
+                )
+            }
+        }
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/UserDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/UserDTOEntityConverter.kt
@@ -1,0 +1,84 @@
+package net.pantasystem.milktea.data.converters
+
+import net.pantasystem.milktea.api.misskey.users.UserDTO
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.notes.Note
+import net.pantasystem.milktea.model.user.User
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UserDTOEntityConverter @Inject constructor() {
+
+    suspend fun convert(account: Account, userDTO: UserDTO, isDetail: Boolean = false): User {
+        val instanceInfo = userDTO.instance?.let {
+            User.InstanceInfo(
+                name = it.name,
+                faviconUrl = it.faviconUrl,
+                iconUrl = it.iconUrl,
+                softwareName = it.softwareName,
+                softwareVersion = it.softwareVersion,
+                themeColor = it.themeColor
+            )
+        }
+        if (isDetail) {
+            return User.Detail(
+                id = User.Id(account.accountId, userDTO.id),
+                avatarUrl = userDTO.avatarUrl,
+                emojis = userDTO.emojiList ?: emptyList(),
+                isBot = userDTO.isBot,
+                isCat = userDTO.isCat,
+                name = userDTO.name,
+                userName = userDTO.userName,
+                host = userDTO.host ?: account.getHost(),
+                nickname = null,
+                isSameHost = userDTO.host == null,
+                instance = instanceInfo,
+                avatarBlurhash = userDTO.avatarBlurhash,
+                info = User.Info(
+                    bannerUrl = userDTO.bannerUrl,
+                    description = userDTO.description,
+                    followersCount = userDTO.followersCount,
+                    followingCount = userDTO.followingCount,
+                    url = userDTO.url,
+                    hostLower = userDTO.hostLower,
+                    notesCount = userDTO.notesCount,
+                    pinnedNoteIds = userDTO.pinnedNoteIds?.map {
+                        Note.Id(account.accountId, it)
+                    },
+                    isLocked = userDTO.isLocked ?: false,
+                    birthday = userDTO.birthday,
+                    createdAt = userDTO.createdAt,
+                    updatedAt = userDTO.updatedAt,
+                    fields = userDTO.fields?.map {
+                        User.Field(it.name, it.value)
+                    }?: emptyList(),
+                    isPublicReactions = userDTO.publicReactions ?: false,
+                ),
+                related = User.Related(
+                    isFollowing = userDTO.isFollowing ?: false,
+                    isFollower = userDTO.isFollowed ?: false,
+                    isBlocking = userDTO.isBlocking ?: false,
+                    isMuting = userDTO.isMuted ?: false,
+                    hasPendingFollowRequestFromYou = userDTO.hasPendingFollowRequestFromYou ?: false,
+                    hasPendingFollowRequestToYou = userDTO.hasPendingFollowRequestToYou ?: false,
+                )
+            )
+        } else {
+            return User.Simple(
+                id = User.Id(account.accountId, userDTO.id),
+                avatarUrl = userDTO.avatarUrl,
+                emojis = userDTO.emojiList ?: emptyList(),
+                isBot = userDTO.isBot,
+                isCat = userDTO.isCat,
+                name = userDTO.name,
+                userName = userDTO.userName,
+                host = userDTO.host ?: account.getHost(),
+                nickname = null,
+                isSameHost = userDTO.host == null,
+                instance = instanceInfo,
+                avatarBlurhash = userDTO.avatarBlurhash
+            )
+        }
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/DriveFileModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/DriveFileModule.kt
@@ -12,6 +12,7 @@ import net.pantasystem.milktea.api.misskey.OkHttpClientProvider
 import net.pantasystem.milktea.app_store.drive.FilePropertyPagingStore
 import net.pantasystem.milktea.data.api.mastodon.MastodonAPIFactory
 import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
+import net.pantasystem.milktea.data.converters.FilePropertyDTOEntityConverter
 import net.pantasystem.milktea.data.infrastructure.drive.*
 import net.pantasystem.milktea.model.drive.DriveFileRepository
 import net.pantasystem.milktea.model.drive.FilePropertyDataSource
@@ -44,6 +45,7 @@ object DriveFileModule {
         filePropertyDataSource: FilePropertyDataSource,
         mastodonAPIFactory: MastodonAPIFactory,
         mastodonAPIProvider: MastodonAPIProvider,
+        filePropertyDTOEntityConverter: FilePropertyDTOEntityConverter,
     ): FileUploaderProvider {
         return OkHttpFileUploaderProvider(
             okHttpClientProvider,
@@ -54,6 +56,7 @@ object DriveFileModule {
             filePropertyDataSource = filePropertyDataSource,
             mastodonAPIFactory = mastodonAPIFactory,
             mastodonAPIProvider = mastodonAPIProvider,
+            filePropertyDTOEntityConverter = filePropertyDTOEntityConverter
         )
     }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/MisskeyEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/MisskeyEntityConverters.kt
@@ -6,7 +6,6 @@ import net.pantasystem.milktea.api.misskey.list.UserListDTO
 import net.pantasystem.milktea.api.misskey.notes.NoteDTO
 import net.pantasystem.milktea.api.misskey.notes.NoteVisibilityType
 import net.pantasystem.milktea.api.misskey.notes.PollDTO
-import net.pantasystem.milktea.api.misskey.notification.NotificationDTO
 import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.channel.Channel
@@ -15,14 +14,12 @@ import net.pantasystem.milktea.model.drive.FilePropertyDataSource
 import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.gallery.GalleryPost
 import net.pantasystem.milktea.model.group.Group
-import net.pantasystem.milktea.model.group.InvitationId
 import net.pantasystem.milktea.model.list.UserList
 import net.pantasystem.milktea.model.nodeinfo.NodeInfo
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.Visibility
 import net.pantasystem.milktea.model.notes.poll.Poll
 import net.pantasystem.milktea.model.notes.reaction.ReactionCount
-import net.pantasystem.milktea.model.notification.*
 import net.pantasystem.milktea.model.user.User
 
 fun FilePropertyDTO.toFileProperty(account: Account): FileProperty {
@@ -133,135 +130,6 @@ fun Visibility(type: NoteVisibilityType, isLocalOnly: Boolean, visibleUserIds: L
         NoteVisibilityType.Home -> Visibility.Home(isLocalOnly)
         NoteVisibilityType.Specified -> Visibility.Specified(visibleUserIds ?: emptyList())
         else -> Visibility.Public(isLocalOnly)
-    }
-}
-
-
-
-fun NotificationDTO.toNotification(account: Account, nodeInfo: NodeInfo?): Notification {
-    val id = Notification.Id(account.accountId, this.id)
-    return when (this.type) {
-        "follow" -> {
-            FollowNotification(
-                id, createdAt, User.Id(account.accountId, this.userId!!), isRead ?: true
-            )
-        }
-        "followRequestAccepted" -> {
-            FollowRequestAcceptedNotification(
-                id, createdAt, User.Id(account.accountId, this.userId!!), isRead ?: true
-            )
-        }
-        "receiveFollowRequest" -> {
-            ReceiveFollowRequestNotification(
-                id, createdAt, User.Id(account.accountId, this.userId!!), isRead ?: true
-            )
-        }
-        "mention" -> {
-            MentionNotification(
-                id,
-                createdAt,
-                User.Id(account.accountId, this.userId!!),
-                Note.Id(
-                    account.accountId,
-                    note?.id ?: throw IllegalStateException("noteId参照不能")
-                ),
-                isRead ?: true
-            )
-        }
-        "reply" -> {
-            ReplyNotification(
-                id,
-                createdAt,
-                User.Id(account.accountId, this.userId!!),
-                Note.Id(
-                    account.accountId,
-                    note?.id ?: throw IllegalStateException("noteId参照不能")
-                ),
-                isRead ?: true
-            )
-        }
-        "renote" -> {
-            RenoteNotification(
-                id,
-                createdAt,
-                User.Id(account.accountId, this.userId!!),
-                Note.Id(
-                    account.accountId,
-                    note?.id ?: throw IllegalStateException("noteId参照不能")
-                ),
-                isRead ?: true
-            )
-        }
-        "quote" -> {
-            QuoteNotification(
-                id,
-                createdAt,
-                User.Id(account.accountId, this.userId!!),
-                Note.Id(
-                    account.accountId,
-                    note?.id ?: throw IllegalStateException("noteId参照不能")
-                ),
-                isRead ?: true
-            )
-        }
-        "reaction" -> {
-
-            require(reaction != null) {
-                "想定しないデータ=$this"
-            }
-            require(note != null)
-            val n = note!!.toNote(account, nodeInfo)
-            ReactionNotification(
-                id,
-                createdAt,
-                User.Id(account.accountId, this.userId!!),
-                n.id,
-                reaction!!,
-                isRead ?: true
-            )
-        }
-        "pollVote" -> {
-            require(noteId != null || note != null)
-            require(choice != null)
-            PollVoteNotification(
-                id,
-                Note.Id(account.accountId, noteId ?: note?.id!!),
-                createdAt,
-                User.Id(account.accountId, this.userId!!),
-                choice!!,
-                isRead ?: true
-            )
-        }
-        "pollEnded", "poll_finished" -> {
-            require(note != null)
-            PollEndedNotification(
-                id,
-                createdAt,
-                isRead = isRead ?: true,
-                Note.Id(account.accountId, note!!.id)
-            )
-        }
-        "groupInvited" -> {
-            require(invitation != null)
-            require(userId != null)
-            GroupInvitedNotification(
-                id,
-                isRead = isRead?: true,
-                createdAt,
-                group = invitation!!.group.toGroup(account.accountId),
-                User.Id(account.accountId, userId!!),
-                InvitationId(account.accountId, invitation!!.id),
-            )
-        }
-        else -> {
-            return UnknownNotification(
-                id,
-                createdAt,
-                isRead ?: false,
-                User.Id(account.accountId, this.userId!!),
-                this.type
-            )
-        }
     }
 }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/MisskeyEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/MisskeyEntityConverters.kt
@@ -3,11 +3,8 @@ package net.pantasystem.milktea.data.infrastructure
 import net.pantasystem.milktea.api.misskey.drive.FilePropertyDTO
 import net.pantasystem.milktea.api.misskey.groups.GroupDTO
 import net.pantasystem.milktea.api.misskey.list.UserListDTO
-import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.drive.FileProperty
-import net.pantasystem.milktea.model.drive.FilePropertyDataSource
-import net.pantasystem.milktea.model.gallery.GalleryPost
 import net.pantasystem.milktea.model.group.Group
 import net.pantasystem.milktea.model.list.UserList
 import net.pantasystem.milktea.model.notes.Note
@@ -60,51 +57,6 @@ fun GroupDTO.toGroup(accountId: Long): Group {
     )
 }
 
-
-suspend fun net.pantasystem.milktea.api.misskey.v12_75_0.GalleryPost.toEntity(
-    account: Account,
-    filePropertyDataSource: FilePropertyDataSource,
-    userDataSource: net.pantasystem.milktea.model.user.UserDataSource,
-    userDTOEntityConverter: UserDTOEntityConverter,
-): GalleryPost {
-    filePropertyDataSource.addAll(files.map {
-        it.toFileProperty(account)
-    })
-    // NOTE: API上ではdetailだったが実際に受信されたデータはSimpleだったのでfalse
-    userDataSource.add(userDTOEntityConverter.convert(account, user, false))
-    if (this.likedCount == null || this.isLiked == null) {
-
-        return GalleryPost.Normal(
-            GalleryPost.Id(account.accountId, this.id),
-            createdAt,
-            updatedAt,
-            title,
-            description,
-            User.Id(account.accountId, userId),
-            files.map {
-                FileProperty.Id(account.accountId, it.id)
-            },
-            tags ?: emptyList(),
-            isSensitive
-        )
-    } else {
-        return GalleryPost.Authenticated(
-            GalleryPost.Id(account.accountId, this.id),
-            createdAt,
-            updatedAt,
-            title,
-            description,
-            User.Id(account.accountId, userId),
-            files.map {
-                FileProperty.Id(account.accountId, it.id)
-            },
-            tags ?: emptyList(),
-            isSensitive,
-            likedCount ?: 0,
-            isLiked ?: false
-        )
-    }
-}
 
 data class NoteRelationEntities(
     val note: Note,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/MisskeyEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/MisskeyEntityConverters.kt
@@ -1,6 +1,5 @@
 package net.pantasystem.milktea.data.infrastructure
 
-import net.pantasystem.milktea.api.misskey.drive.FilePropertyDTO
 import net.pantasystem.milktea.api.misskey.groups.GroupDTO
 import net.pantasystem.milktea.api.misskey.list.UserListDTO
 import net.pantasystem.milktea.model.account.Account
@@ -9,27 +8,6 @@ import net.pantasystem.milktea.model.group.Group
 import net.pantasystem.milktea.model.list.UserList
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.user.User
-
-fun FilePropertyDTO.toFileProperty(account: Account): FileProperty {
-    return FileProperty(
-        id = FileProperty.Id(account.accountId, id),
-        name = name,
-        createdAt = createdAt,
-        type = type,
-        md5 = md5,
-        size = size ?: 0,
-        userId = userId?.let { User.Id(account.accountId, userId!!) },
-        folderId = folderId,
-        comment = comment,
-        isSensitive = isSensitive ?: false,
-        url = getUrl(account.normalizedInstanceDomain),
-        thumbnailUrl = getThumbnailUrl(account.normalizedInstanceDomain),
-        blurhash = blurhash,
-        properties = properties?.let {
-            FileProperty.Properties(it.width, it.height)
-        }
-    )
-}
 
 
 fun UserListDTO.toEntity(account: Account): UserList {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/MisskeyEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/MisskeyEntityConverters.kt
@@ -3,23 +3,14 @@ package net.pantasystem.milktea.data.infrastructure
 import net.pantasystem.milktea.api.misskey.drive.FilePropertyDTO
 import net.pantasystem.milktea.api.misskey.groups.GroupDTO
 import net.pantasystem.milktea.api.misskey.list.UserListDTO
-import net.pantasystem.milktea.api.misskey.notes.NoteDTO
-import net.pantasystem.milktea.api.misskey.notes.NoteVisibilityType
-import net.pantasystem.milktea.api.misskey.notes.PollDTO
 import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.model.account.Account
-import net.pantasystem.milktea.model.channel.Channel
 import net.pantasystem.milktea.model.drive.FileProperty
 import net.pantasystem.milktea.model.drive.FilePropertyDataSource
-import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.gallery.GalleryPost
 import net.pantasystem.milktea.model.group.Group
 import net.pantasystem.milktea.model.list.UserList
-import net.pantasystem.milktea.model.nodeinfo.NodeInfo
 import net.pantasystem.milktea.model.notes.Note
-import net.pantasystem.milktea.model.notes.Visibility
-import net.pantasystem.milktea.model.notes.poll.Poll
-import net.pantasystem.milktea.model.notes.reaction.ReactionCount
 import net.pantasystem.milktea.model.user.User
 
 fun FilePropertyDTO.toFileProperty(account: Account): FileProperty {
@@ -55,83 +46,6 @@ fun UserListDTO.toEntity(account: Account): UserList {
     )
 }
 
-
-
-fun PollDTO?.toPoll(): Poll? {
-    return this?.let { dto ->
-        Poll(
-            multiple = dto.multiple,
-            expiresAt = dto.expiresAt,
-            choices = choices.mapIndexed { index, value ->
-                Poll.Choice(
-                    index = index,
-                    text = value.text,
-                    isVoted = value.isVoted,
-                    votes = value.votes
-                )
-            }
-        )
-    }
-}
-
-
-fun NoteDTO.toNote(account: Account, nodeInfo: NodeInfo?): Note {
-    val visibility = Visibility(this.visibility?: NoteVisibilityType.Public, isLocalOnly = localOnly?: false, visibleUserIds = visibleUserIds?.map { id ->
-        User.Id(account.accountId, id)
-    }?: emptyList())
-    return Note(
-        id = Note.Id(account.accountId, this.id),
-        createdAt = this.createdAt,
-        text = this.text,
-        cw = this.cw,
-        userId = User.Id(account.accountId, this.userId, ),
-        replyId = this.replyId?.let{ Note.Id(account.accountId, this.replyId!!) },
-        renoteId = this.renoteId?.let{ Note.Id(account.accountId, this.renoteId!!) },
-        viaMobile = this.viaMobile,
-        visibility = visibility,
-        localOnly = this.localOnly,
-        emojis = (this.emojiList ?: emptyList()) + (this.reactionEmojis?.map {
-            Emoji(name = it.key, uri = it.value, url = it.value)
-        } ?: emptyList()),
-        app = this.app?.toModel(),
-        fileIds = this.fileIds?.map { FileProperty.Id(account.accountId, it) },
-        poll = this.poll?.toPoll(),
-        reactionCounts = this.reactionCounts?.map{
-            ReactionCount(reaction = it.key, it.value)
-        }?: emptyList(),
-        renoteCount = this.renoteCount,
-        repliesCount = this.replyCount,
-        uri = this.uri,
-        url = this.url,
-        visibleUserIds = this.visibleUserIds?.map{
-            User.Id(account.accountId, it)
-        }?: emptyList(),
-        myReaction = this.myReaction,
-        channelId = this.channelId?.let {
-            Channel.Id(account.accountId, it)
-        },
-        type = Note.Type.Misskey(
-            channel = channel?.let {
-                Note.Type.Misskey.SimpleChannelInfo(
-                    id = Channel.Id(account.accountId, it.id),
-                    name = it.name
-                )
-            }
-        ),
-        nodeInfo = nodeInfo,
-    )
-}
-
-@Throws(IllegalArgumentException::class)
-fun Visibility(type: NoteVisibilityType, isLocalOnly: Boolean, visibleUserIds: List<User.Id>? = null): Visibility {
-    return when(type){
-        NoteVisibilityType.Public -> Visibility.Public(isLocalOnly)
-        NoteVisibilityType.Followers -> Visibility.Followers(isLocalOnly)
-        NoteVisibilityType.Home -> Visibility.Home(isLocalOnly)
-        NoteVisibilityType.Specified -> Visibility.Specified(visibleUserIds ?: emptyList())
-        else -> Visibility.Public(isLocalOnly)
-    }
-}
 
 
 fun GroupDTO.toGroup(accountId: Long): Group {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/ap/ApResolverRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/ap/ApResolverRepositoryImpl.kt
@@ -8,8 +8,8 @@ import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.data.infrastructure.notes.NoteDataSourceAdder
-import net.pantasystem.milktea.data.infrastructure.toUser
 import net.pantasystem.milktea.model.account.GetAccount
 import net.pantasystem.milktea.model.ap.ApResolver
 import net.pantasystem.milktea.model.ap.ApResolverRepository
@@ -21,6 +21,7 @@ class ApResolverRepositoryImpl @Inject constructor(
     private val getAccount: GetAccount,
     private val noteDataSourceAdder: NoteDataSourceAdder,
     private val userDataSource: UserDataSource,
+    private val userDTOEntityConverter: UserDTOEntityConverter,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ): ApResolverRepository {
 
@@ -39,7 +40,7 @@ class ApResolverRepositoryImpl @Inject constructor(
                 }
 
                 is ApResolveResult.TypeUser -> {
-                    val user = result.user.toUser(account, isDetail = true)
+                    val user = userDTOEntityConverter.convert(account, result.user, true)
                     userDataSource.add(user)
                     ApResolver.TypeUser(
                         user

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/DriveFileRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/DriveFileRepositoryImpl.kt
@@ -10,7 +10,7 @@ import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
-import net.pantasystem.milktea.data.infrastructure.toFileProperty
+import net.pantasystem.milktea.data.converters.FilePropertyDTOEntityConverter
 import net.pantasystem.milktea.model.account.GetAccount
 import net.pantasystem.milktea.model.drive.DriveFileRepository
 import net.pantasystem.milktea.model.drive.FileProperty
@@ -25,6 +25,7 @@ class DriveFileRepositoryImpl @Inject constructor(
     private val misskeyAPIProvider: MisskeyAPIProvider,
     private val driveFileDataSource: FilePropertyDataSource,
     private val driveFileUploaderProvider: FileUploaderProvider,
+    private val filePropertyDTOEntityConverter: FilePropertyDTOEntityConverter,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ) : DriveFileRepository {
     override suspend fun find(id: FileProperty.Id): FileProperty {
@@ -37,8 +38,8 @@ class DriveFileRepositoryImpl @Inject constructor(
             val api = misskeyAPIProvider.get(account.normalizedInstanceDomain)
             val response = api.showFile(ShowFile(fileId = id.fileId, i = account.token))
                 .throwIfHasError()
-            val fp = response.body()!!.toFileProperty(account)
-            driveFileDataSource.add(fp)    
+            val fp = filePropertyDTOEntityConverter.convert(response.body()!!, account)
+            driveFileDataSource.add(fp)
             return@withContext fp
         }
     }
@@ -59,7 +60,12 @@ class DriveFileRepositoryImpl @Inject constructor(
                 )
             ).throwIfHasError()
 
-            driveFileDataSource.add(result.body()!!.toFileProperty(account))
+            driveFileDataSource.add(
+                filePropertyDTOEntityConverter.convert(
+                    result.body()!!,
+                    account
+                )
+            )
         }
     }
 
@@ -91,15 +97,19 @@ class DriveFileRepositoryImpl @Inject constructor(
     override suspend fun update(updateFileProperty: UpdateFileProperty): Result<FileProperty> {
         return runCancellableCatching {
             withContext(ioDispatcher) {
-                val res = misskeyAPIProvider.get(getAccount.get(updateFileProperty.fileId.accountId))
-                    .updateFile(
-                        UpdateFileDTO.from(
-                            getAccount.get(updateFileProperty.fileId.accountId).token,
-                            updateFileProperty,
-                        )
-                    ).throwIfHasError()
-                    .body()!!
-                res.toFileProperty(getAccount.get(updateFileProperty.fileId.accountId)).also {
+                val res =
+                    misskeyAPIProvider.get(getAccount.get(updateFileProperty.fileId.accountId))
+                        .updateFile(
+                            UpdateFileDTO.from(
+                                getAccount.get(updateFileProperty.fileId.accountId).token,
+                                updateFileProperty,
+                            )
+                        ).throwIfHasError()
+                        .body()!!
+                filePropertyDTOEntityConverter.convert(
+                    res,
+                    getAccount.get(updateFileProperty.fileId.accountId)
+                ).also {
                     driveFileDataSource.add(it)
                 }
             }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/MisskeyOkHttpDriveFileUploader.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/MisskeyOkHttpDriveFileUploader.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import net.pantasystem.milktea.api.misskey.OkHttpClientProvider
 import net.pantasystem.milktea.api.misskey.drive.FilePropertyDTO
-import net.pantasystem.milktea.data.infrastructure.toFileProperty
+import net.pantasystem.milktea.data.converters.FilePropertyDTOEntityConverter
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.drive.FileProperty
 import net.pantasystem.milktea.model.drive.FilePropertyDataSource
@@ -36,13 +36,14 @@ class MisskeyOkHttpDriveFileUploader(
     val json: Json,
     private val okHttpClientProvider: OkHttpClientProvider,
     private val filePropertyDataSource: FilePropertyDataSource,
+    private val filePropertyDTOEntityConverter: FilePropertyDTOEntityConverter,
 ) : FileUploader {
     override suspend fun upload(file: UploadSource, isForce: Boolean): FileProperty {
         return when (file) {
             is UploadSource.LocalFile -> upload(file.file, isForce)
             is UploadSource.OtherAccountFile -> transferUpload(file.fileProperty, isForce)
         }.let {
-            val property = it.toFileProperty(account)
+            val property = filePropertyDTOEntityConverter.convert(it, account)
             filePropertyDataSource.add(property).getOrThrow()
             property
         }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/uploaders.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/uploaders.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.Json
 import net.pantasystem.milktea.api.misskey.OkHttpClientProvider
 import net.pantasystem.milktea.data.api.mastodon.MastodonAPIFactory
 import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
+import net.pantasystem.milktea.data.converters.FilePropertyDTOEntityConverter
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.drive.FileProperty
 import net.pantasystem.milktea.model.drive.FilePropertyDataSource
@@ -48,6 +49,7 @@ class OkHttpFileUploaderProvider(
     val filePropertyDataSource: FilePropertyDataSource,
     private val mastodonAPIFactory: MastodonAPIFactory,
     private val mastodonAPIProvider: MastodonAPIProvider,
+    private val filePropertyDTOEntityConverter: FilePropertyDTOEntityConverter,
 ) : FileUploaderProvider {
     private val lock = Mutex()
     private var instances = mapOf<Long, FileUploader>()
@@ -63,7 +65,8 @@ class OkHttpFileUploaderProvider(
                             account,
                             json,
                             okHttpClientProvider,
-                            filePropertyDataSource
+                            filePropertyDataSource,
+                            filePropertyDTOEntityConverter,
                         )
                         instances = map
                         instances[account.accountId]

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/GalleryRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/GalleryRepositoryImpl.kt
@@ -5,19 +5,16 @@ import net.pantasystem.milktea.api.misskey.v12_75_0.*
 import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
-import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
+import net.pantasystem.milktea.data.converters.GalleryPostDTOEntityConverter
 import net.pantasystem.milktea.data.infrastructure.drive.FileUploaderProvider
 import net.pantasystem.milktea.data.infrastructure.drive.UploadSource
-import net.pantasystem.milktea.data.infrastructure.toEntity
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.account.UnauthorizedException
-import net.pantasystem.milktea.model.drive.FilePropertyDataSource
 import net.pantasystem.milktea.model.file.AppFile
 import net.pantasystem.milktea.model.gallery.*
 import net.pantasystem.milktea.model.gallery.GalleryPost
 import net.pantasystem.milktea.model.instance.IllegalVersionException
-import net.pantasystem.milktea.model.user.UserDataSource
 import javax.inject.Inject
 import net.pantasystem.milktea.api.misskey.v12_75_0.CreateGallery as CreateGalleryDTO
 
@@ -26,10 +23,8 @@ class GalleryRepositoryImpl @Inject constructor(
     private val misskeyAPIProvider: MisskeyAPIProvider,
     private val galleryDataSource: GalleryDataSource,
     private val fileUploaderProvider: FileUploaderProvider,
-    private val userDataSource: UserDataSource,
-    private val filePropertyDataSource: FilePropertyDataSource,
     private val accountRepository: AccountRepository,
-    private val userDTOEntityConverter: UserDTOEntityConverter,
+    private val galleryPostDTOEntityConverter: GalleryPostDTOEntityConverter,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ) : GalleryRepository {
 
@@ -63,13 +58,7 @@ class GalleryRepositoryImpl @Inject constructor(
             ).throwIfHasError().body()
             requireNotNull(created)
 
-            val gallery =
-                created.toEntity(
-                    createGalleryPost.author,
-                    filePropertyDataSource,
-                    userDataSource,
-                    userDTOEntityConverter
-                )
+            val gallery = galleryPostDTOEntityConverter.convert(created, createGalleryPost.author)
             galleryDataSource.add(gallery)
             gallery
         }
@@ -104,12 +93,7 @@ class GalleryRepositoryImpl @Inject constructor(
             ).throwIfHasError()
             val body = res.body()
             requireNotNull(body)
-            val gallery = body.toEntity(
-                account,
-                filePropertyDataSource,
-                userDataSource,
-                userDTOEntityConverter
-            )
+            val gallery = galleryPostDTOEntityConverter.convert(body, account)
             galleryDataSource.add(gallery)
             gallery
         }
@@ -172,12 +156,7 @@ class GalleryRepositoryImpl @Inject constructor(
                 )
             ).throwIfHasError().body()
             requireNotNull(body)
-            val gallery = body.toEntity(
-                account,
-                filePropertyDataSource,
-                userDataSource,
-                userDTOEntityConverter
-            )
+            val gallery = galleryPostDTOEntityConverter.convert(body, account)
             galleryDataSource.add(gallery)
             gallery
         }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/GalleryRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/GalleryRepositoryImpl.kt
@@ -5,6 +5,7 @@ import net.pantasystem.milktea.api.misskey.v12_75_0.*
 import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.data.infrastructure.drive.FileUploaderProvider
 import net.pantasystem.milktea.data.infrastructure.drive.UploadSource
 import net.pantasystem.milktea.data.infrastructure.toEntity
@@ -28,6 +29,7 @@ class GalleryRepositoryImpl @Inject constructor(
     private val userDataSource: UserDataSource,
     private val filePropertyDataSource: FilePropertyDataSource,
     private val accountRepository: AccountRepository,
+    private val userDTOEntityConverter: UserDTOEntityConverter,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ) : GalleryRepository {
 
@@ -62,7 +64,12 @@ class GalleryRepositoryImpl @Inject constructor(
             requireNotNull(created)
 
             val gallery =
-                created.toEntity(createGalleryPost.author, filePropertyDataSource, userDataSource)
+                created.toEntity(
+                    createGalleryPost.author,
+                    filePropertyDataSource,
+                    userDataSource,
+                    userDTOEntityConverter
+                )
             galleryDataSource.add(gallery)
             gallery
         }
@@ -97,7 +104,12 @@ class GalleryRepositoryImpl @Inject constructor(
             ).throwIfHasError()
             val body = res.body()
             requireNotNull(body)
-            val gallery = body.toEntity(account, filePropertyDataSource, userDataSource)
+            val gallery = body.toEntity(
+                account,
+                filePropertyDataSource,
+                userDataSource,
+                userDTOEntityConverter
+            )
             galleryDataSource.add(gallery)
             gallery
         }
@@ -160,7 +172,12 @@ class GalleryRepositoryImpl @Inject constructor(
                 )
             ).throwIfHasError().body()
             requireNotNull(body)
-            val gallery = body.toEntity(account, filePropertyDataSource, userDataSource)
+            val gallery = body.toEntity(
+                account,
+                filePropertyDataSource,
+                userDataSource,
+                userDTOEntityConverter
+            )
             galleryDataSource.add(gallery)
             gallery
         }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/MediatorGalleryPostPaginator.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/MediatorGalleryPostPaginator.kt
@@ -9,6 +9,7 @@ import net.pantasystem.milktea.common.StateContent
 import net.pantasystem.milktea.common.paginator.FuturePagingController
 import net.pantasystem.milktea.common.paginator.PreviousPagingController
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.data.converters.GalleryPostDTOEntityConverter
 import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.page.Pageable
@@ -23,10 +24,7 @@ class GalleryPostsStoreImpl(
     pageable: Pageable.Gallery,
     getAccount: suspend () -> Account,
     misskeyAPIProvider: MisskeyAPIProvider,
-    filePropertyDataSource: FilePropertyDataSource,
-    userDataSource: UserDataSource,
-    galleryDataSource: GalleryDataSource,
-    userDTOEntityConverter: UserDTOEntityConverter
+    galleryPostDTOEntityConverter: GalleryPostDTOEntityConverter,
 ) : GalleryPostsStore {
 
     class Factory @Inject constructor(
@@ -34,7 +32,8 @@ class GalleryPostsStoreImpl(
         val filePropertyDataSource: FilePropertyDataSource,
         val userDataSource: UserDataSource,
         val galleryDataSource: GalleryDataSource,
-        val userDTOEntityConverter: UserDTOEntityConverter
+        val userDTOEntityConverter: UserDTOEntityConverter,
+        val galleryPostDTOEntityConverter: GalleryPostDTOEntityConverter,
     ) : GalleryPostsStore.Factory {
         override fun create(
             pageable: Pageable.Gallery,
@@ -44,20 +43,15 @@ class GalleryPostsStoreImpl(
                 LikedGalleryPostStoreImpl(
                     getAccount,
                     misskeyAPIProvider,
-                    filePropertyDataSource,
-                    userDataSource,
                     galleryDataSource,
-                    userDTOEntityConverter,
+                    galleryPostDTOEntityConverter
                 )
             } else {
                 GalleryPostsStoreImpl(
                     pageable,
                     getAccount,
                     misskeyAPIProvider,
-                    filePropertyDataSource,
-                    userDataSource,
-                    galleryDataSource,
-                    userDTOEntityConverter
+                    galleryPostDTOEntityConverter,
                 )
             }
         }
@@ -70,10 +64,7 @@ class GalleryPostsStoreImpl(
     private val entityAdder =
         GalleryPostsConverter(
             getAccount,
-            filePropertyDataSource,
-            userDataSource,
-            galleryDataSource,
-            userDTOEntityConverter
+            galleryPostDTOEntityConverter,
         )
     private val loader = GalleryPostsLoader(pageable, galleryPostState, misskeyAPIProvider, getAccount)
     private val previousPagingController =
@@ -101,10 +92,8 @@ class GalleryPostsStoreImpl(
 class LikedGalleryPostStoreImpl(
     getAccount: suspend () -> Account,
     misskeyAPIProvider: MisskeyAPIProvider,
-    filePropertyDataSource: FilePropertyDataSource,
-    userDataSource: UserDataSource,
     galleryDataSource: GalleryDataSource,
-    userDTOEntityConverter: UserDTOEntityConverter,
+    galleryPostDTOEntityConverter: GalleryPostDTOEntityConverter,
 ) : GalleryPostsStore {
 
     override val mutex: Mutex = Mutex()
@@ -112,10 +101,8 @@ class LikedGalleryPostStoreImpl(
     private val galleryPostState = LikedGalleryPostsState()
     private val entityAdder = LikedGalleryPostsConverter(
         getAccount,
-        filePropertyDataSource,
-        userDataSource,
         galleryDataSource,
-        userDTOEntityConverter,
+        galleryPostDTOEntityConverter = galleryPostDTOEntityConverter,
     )
     private val loader =
         LikedGalleryPostsLoader(galleryPostState, misskeyAPIProvider, getAccount)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/gallery_posts_paginators.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/gallery_posts_paginators.kt
@@ -12,6 +12,7 @@ import net.pantasystem.milktea.common.paginator.*
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.data.infrastructure.toEntity
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.page.Pageable
@@ -27,13 +28,18 @@ import net.pantasystem.milktea.api.misskey.v12_75_0.GalleryPost as GalleryPostDT
 interface GetGalleryPostsStateFlow {
     fun getFlow(): Flow<PageableState<List<GalleryPost.Id>>>
 }
+
 /**
  * EntityはDataSourceが保持しているので、ここではタイムラインの順番を保持する
  */
-class GalleryPostsState : PaginationState<GalleryPost.Id>, IdGetter<String>, GetGalleryPostsStateFlow {
+class GalleryPostsState : PaginationState<GalleryPost.Id>, IdGetter<String>,
+    GetGalleryPostsStateFlow {
 
-    private val _state = MutableStateFlow<PageableState<List<GalleryPost.Id>>>(PageableState.Fixed(
-        StateContent.NotExist()))
+    private val _state = MutableStateFlow<PageableState<List<GalleryPost.Id>>>(
+        PageableState.Fixed(
+            StateContent.NotExist()
+        )
+    )
     override val state: Flow<PageableState<List<GalleryPost.Id>>> = _state
 
     override fun getFlow(): Flow<PageableState<List<GalleryPost.Id>>> {
@@ -41,8 +47,9 @@ class GalleryPostsState : PaginationState<GalleryPost.Id>, IdGetter<String>, Get
     }
 
     private fun getList(): List<GalleryPost.Id> {
-        return (_state.value.content as? StateContent.Exist)?.rawContent?: emptyList()
+        return (_state.value.content as? StateContent.Exist)?.rawContent ?: emptyList()
     }
+
     override suspend fun getSinceId(): String? {
         return getList().firstOrNull()?.galleryId
     }
@@ -63,29 +70,35 @@ class GalleryPostsState : PaginationState<GalleryPost.Id>, IdGetter<String>, Get
 }
 
 class GalleryPostsConverter(
-    private val getAccount: suspend ()-> Account,
+    private val getAccount: suspend () -> Account,
     private val filePropertyDataSource: FilePropertyDataSource,
     private val userDataSource: UserDataSource,
-    private val galleryDataSource: GalleryDataSource
+    private val galleryDataSource: GalleryDataSource,
+    private val userDTOEntityConverter: UserDTOEntityConverter,
 ) : EntityConverter<GalleryPostDTO, GalleryPost.Id> {
 
     override suspend fun convertAll(list: List<GalleryPostDTO>): List<GalleryPost.Id> {
         return list.map {
-            it.toEntity(getAccount.invoke(), filePropertyDataSource, userDataSource).also { post ->
+            it.toEntity(
+                getAccount.invoke(),
+                filePropertyDataSource,
+                userDataSource,
+                userDTOEntityConverter
+            ).also { post ->
                 galleryDataSource.add(post)
             }.id
         }
     }
 }
 
-class GalleryPostsLoader (
+class GalleryPostsLoader(
     private val pageable: Pageable.Gallery,
     private val idGetter: IdGetter<String>,
     private val apiProvider: MisskeyAPIProvider,
     private val getAccount: suspend () -> Account,
 ) : FutureLoader<GalleryPostDTO>, PreviousLoader<GalleryPostDTO> {
-    init{
-        if(pageable is Pageable.Gallery.ILikedPosts){
+    init {
+        if (pageable is Pageable.Gallery.ILikedPosts) {
             throw IllegalArgumentException("${pageable::class.simpleName}は対応していません。")
         }
     }
@@ -103,20 +116,23 @@ class GalleryPostsLoader (
     }
 
 
-    suspend fun api(sinceId: String? = null, untilId: String? = null) : suspend ()-> Response<List<GalleryPostDTO>>{
+    suspend fun api(
+        sinceId: String? = null,
+        untilId: String? = null
+    ): suspend () -> Response<List<GalleryPostDTO>> {
         val i = getAccount.invoke().token
         val api = apiProvider.get(getAccount.invoke().normalizedInstanceDomain) as? MisskeyAPIV1275
             ?: throw IllegalVersionException()
-        when(pageable) {
+        when (pageable) {
             is Pageable.Gallery.MyPosts -> {
                 return {
                     api.myGalleryPosts(
                         GetPosts(
-                        i,
-                        sinceId = sinceId,
-                        untilId = untilId,
-                        limit = 20,
-                    )
+                            i,
+                            sinceId = sinceId,
+                            untilId = untilId,
+                            limit = 20,
+                        )
                     )
                 }
             }
@@ -125,7 +141,15 @@ class GalleryPostsLoader (
             }
             is Pageable.Gallery.User -> {
                 return {
-                    api.userPosts(GetPosts(i, sinceId = sinceId, untilId = untilId, limit = 20, userId = pageable.userId))
+                    api.userPosts(
+                        GetPosts(
+                            i,
+                            sinceId = sinceId,
+                            untilId = untilId,
+                            limit = 20,
+                            userId = pageable.userId
+                        )
+                    )
                 }
             }
             is Pageable.Gallery.Posts -> {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/gallery_posts_paginators.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/gallery_posts_paginators.kt
@@ -12,15 +12,11 @@ import net.pantasystem.milktea.common.paginator.*
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
-import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
-import net.pantasystem.milktea.data.infrastructure.toEntity
+import net.pantasystem.milktea.data.converters.GalleryPostDTOEntityConverter
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.page.Pageable
-import net.pantasystem.milktea.model.drive.FilePropertyDataSource
-import net.pantasystem.milktea.model.gallery.GalleryDataSource
 import net.pantasystem.milktea.model.gallery.GalleryPost
 import net.pantasystem.milktea.model.instance.IllegalVersionException
-import net.pantasystem.milktea.model.user.UserDataSource
 import retrofit2.Response
 import net.pantasystem.milktea.api.misskey.v12_75_0.GalleryPost as GalleryPostDTO
 
@@ -71,22 +67,12 @@ class GalleryPostsState : PaginationState<GalleryPost.Id>, IdGetter<String>,
 
 class GalleryPostsConverter(
     private val getAccount: suspend () -> Account,
-    private val filePropertyDataSource: FilePropertyDataSource,
-    private val userDataSource: UserDataSource,
-    private val galleryDataSource: GalleryDataSource,
-    private val userDTOEntityConverter: UserDTOEntityConverter,
+    private val galleryPostDTOEntityConverter: GalleryPostDTOEntityConverter
 ) : EntityConverter<GalleryPostDTO, GalleryPost.Id> {
 
     override suspend fun convertAll(list: List<GalleryPostDTO>): List<GalleryPost.Id> {
         return list.map {
-            it.toEntity(
-                getAccount.invoke(),
-                filePropertyDataSource,
-                userDataSource,
-                userDTOEntityConverter
-            ).also { post ->
-                galleryDataSource.add(post)
-            }.id
+            galleryPostDTOEntityConverter.convert(it, getAccount.invoke()).id
         }
     }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/liked_gallery_posts_paginator.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/liked_gallery_posts_paginator.kt
@@ -12,14 +12,11 @@ import net.pantasystem.milktea.common.paginator.*
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
-import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
-import net.pantasystem.milktea.data.infrastructure.toEntity
+import net.pantasystem.milktea.data.converters.GalleryPostDTOEntityConverter
 import net.pantasystem.milktea.model.account.Account
-import net.pantasystem.milktea.model.drive.FilePropertyDataSource
 import net.pantasystem.milktea.model.gallery.GalleryDataSource
 import net.pantasystem.milktea.model.gallery.GalleryPost
 import net.pantasystem.milktea.model.instance.IllegalVersionException
-import net.pantasystem.milktea.model.user.UserDataSource
 
 data class LikedGalleryPostId(
     val id: String,
@@ -73,10 +70,8 @@ class LikedGalleryPostsState : PaginationState<LikedGalleryPostId>, IdGetter<Str
 
 class LikedGalleryPostsConverter(
     private val getAccount: suspend () -> Account,
-    private val filePropertyDataSource: FilePropertyDataSource,
-    private val userDataSource: UserDataSource,
     private val galleryDataSource: GalleryDataSource,
-    private val userDTOEntityConverter: UserDTOEntityConverter,
+    private val galleryPostDTOEntityConverter: GalleryPostDTOEntityConverter
 ) : EntityConverter<LikedGalleryPost, LikedGalleryPostId> {
 
     override suspend fun convertAll(list: List<LikedGalleryPost>): List<LikedGalleryPostId> {
@@ -84,12 +79,7 @@ class LikedGalleryPostsConverter(
         return list.map {
             LikedGalleryPostId(
                 it.id,
-                it.post.toEntity(
-                    account,
-                    filePropertyDataSource,
-                    userDataSource,
-                    userDTOEntityConverter
-                ).also { post ->
+                galleryPostDTOEntityConverter.convert(it.post, account).also { post ->
                     galleryDataSource.add(post)
                 }.id
             )

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/messaging/MessagingRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/messaging/MessagingRepositoryImpl.kt
@@ -6,8 +6,8 @@ import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.data.infrastructure.toGroup
-import net.pantasystem.milktea.data.infrastructure.toUser
 import net.pantasystem.milktea.model.account.GetAccount
 import net.pantasystem.milktea.model.group.GroupDataSource
 import net.pantasystem.milktea.model.messaging.MessageRelation
@@ -22,6 +22,7 @@ class MessagingRepositoryImpl @Inject constructor(
     private val groupDataSource: GroupDataSource,
     private val userDataSource: UserDataSource,
     private val messageAdder: MessageAdder,
+    private val userDTOEntityConverter: UserDTOEntityConverter,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ) : MessagingRepository {
 
@@ -42,7 +43,7 @@ class MessagingRepositoryImpl @Inject constructor(
                     groupDataSource.add(groupDTO.toGroup(account.accountId))
                 }
                 it.recipient?.let { userDTO ->
-                    userDataSource.add(userDTO.toUser(account))
+                    userDataSource.add(userDTOEntityConverter.convert(account, userDTO))
                 }
                 messageAdder.add(account, it)
             }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteDataSourceAdder.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteDataSourceAdder.kt
@@ -2,12 +2,19 @@ package net.pantasystem.milktea.data.infrastructure.notes
 
 import net.pantasystem.milktea.api.mastodon.status.TootStatusDTO
 import net.pantasystem.milktea.api.misskey.notes.NoteDTO
+import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
+import net.pantasystem.milktea.data.infrastructure.NoteRelationEntities
 import net.pantasystem.milktea.data.infrastructure.toEntities
+import net.pantasystem.milktea.data.infrastructure.toFileProperty
+import net.pantasystem.milktea.data.infrastructure.toNote
 import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.drive.FileProperty
 import net.pantasystem.milktea.model.drive.FilePropertyDataSource
+import net.pantasystem.milktea.model.nodeinfo.NodeInfo
 import net.pantasystem.milktea.model.nodeinfo.NodeInfoRepository
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.NoteDataSource
+import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserDataSource
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -19,12 +26,13 @@ class NoteDataSourceAdder @Inject constructor(
     private val noteDataSource: NoteDataSource,
     private val filePropertyDataSource: FilePropertyDataSource,
     private val nodeInfoRepository: NodeInfoRepository,
+    private val userDTOEntityConverter: UserDTOEntityConverter,
 ) {
 
 
     suspend fun addNoteDtoToDataSource(account: Account, noteDTO: NoteDTO): Note {
         val nodeInfo = nodeInfoRepository.find(account.getHost()).getOrNull()
-        val entities = noteDTO.toEntities(account, nodeInfo)
+        val entities = noteDTO.toEntities(account, nodeInfo, userDTOEntityConverter)
         userDataSource.addAll(entities.users)
         noteDataSource.addAll(entities.notes)
         filePropertyDataSource.addAll(entities.files)
@@ -42,3 +50,68 @@ class NoteDataSourceAdder @Inject constructor(
     }
 }
 
+suspend fun NoteDTO.toEntities(
+    account: Account,
+    nodeInfo: NodeInfo?,
+    userDTOEntityConverter: UserDTOEntityConverter
+): NoteRelationEntities {
+    val dtoList = mutableListOf<NoteDTO>()
+    dtoList.add(this)
+
+
+    if (this.reply != null) {
+
+        dtoList.add(this.reply!!)
+    }
+    if (this.reNote != null) {
+        dtoList.add(reNote!!)
+    }
+
+    val note = this.toNote(account, nodeInfo)
+    val users = mutableListOf<User>()
+    val notes = mutableListOf<Note>()
+    val files = mutableListOf<FileProperty>()
+
+    pickEntities(account, notes, users, files, nodeInfo, userDTOEntityConverter)
+    return NoteRelationEntities(
+        note = note,
+        notes = notes,
+        users = users,
+        files = files
+    )
+}
+
+private suspend fun NoteDTO.pickEntities(
+    account: Account,
+    notes: MutableList<Note>,
+    users: MutableList<User>,
+    files: MutableList<FileProperty>,
+    nodeInfo: NodeInfo?,
+    userDTOEntityConverter: UserDTOEntityConverter,
+) {
+    val (note, user) = this.toNoteAndUser(account, nodeInfo, userDTOEntityConverter)
+    notes.add(note)
+    users.add(user)
+    files.addAll(
+        this.files?.map {
+            it.toFileProperty(account)
+        } ?: emptyList()
+    )
+    if (this.reply != null) {
+        this.reply!!.pickEntities(account, notes, users, files, nodeInfo, userDTOEntityConverter)
+    }
+
+    if (this.reNote != null) {
+        this.reNote!!.pickEntities(account, notes, users, files, nodeInfo, userDTOEntityConverter)
+    }
+}
+
+suspend fun NoteDTO.toNoteAndUser(
+    account: Account,
+    nodeInfo: NodeInfo?,
+    userDTOEntityConverter: UserDTOEntityConverter
+): Pair<Note, User> {
+    val note = this.toNote(account, nodeInfo)
+    val user = userDTOEntityConverter.convert(account, user, false)
+    return note to user
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/ReactionHistoryPaginatorImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/ReactionHistoryPaginatorImpl.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.withContext
 import net.pantasystem.milktea.api.misskey.notes.reaction.RequestReactionHistoryDTO
 import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
-import net.pantasystem.milktea.data.infrastructure.toUser
+import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.notes.reaction.ReactionHistory
 import net.pantasystem.milktea.model.notes.reaction.ReactionHistoryDataSource
@@ -22,14 +22,16 @@ class ReactionHistoryPaginatorImpl(
     private val reactionHistoryDataSource: ReactionHistoryDataSource,
     private val misskeyAPIProvider: MisskeyAPIProvider,
     private val accountRepository: AccountRepository,
-    private val userDataSource: UserDataSource
+    private val userDataSource: UserDataSource,
+    private val userDTOEntityConverter: UserDTOEntityConverter,
 ) : ReactionHistoryPaginator {
 
     class Factory @Inject constructor(
         private val reactionHistoryDataSource: ReactionHistoryDataSource,
         private val misskeyAPIProvider: MisskeyAPIProvider,
         private val accountRepository: AccountRepository,
-        private val userDataSource: UserDataSource
+        private val userDataSource: UserDataSource,
+        private val userDTOEntityConverter: UserDTOEntityConverter,
     ) : ReactionHistoryPaginator.Factory {
         override fun create(reactionHistoryRequest: ReactionHistoryRequest) : ReactionHistoryPaginator {
             return ReactionHistoryPaginatorImpl(
@@ -37,7 +39,8 @@ class ReactionHistoryPaginatorImpl(
                 reactionHistoryDataSource,
                 misskeyAPIProvider,
                 accountRepository,
-                userDataSource
+                userDataSource,
+                userDTOEntityConverter,
             )
         }
     }
@@ -68,7 +71,7 @@ class ReactionHistoryPaginatorImpl(
                     offset += res.size
                 }
                 val reactionHistories = res.map {
-                    val user = it.user.toUser(account)
+                    val user = userDTOEntityConverter.convert(account, it.user)
                     userDataSource.add(user)
                     ReactionHistory(
                         ReactionHistory.Id(it.id, account.accountId),

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notification/impl/NotificationCacheAdder.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notification/impl/NotificationCacheAdder.kt
@@ -2,8 +2,12 @@ package net.pantasystem.milktea.data.infrastructure.notification.impl
 
 import net.pantasystem.milktea.api.mastodon.notification.MstNotificationDTO
 import net.pantasystem.milktea.api.misskey.notification.NotificationDTO
-import net.pantasystem.milktea.data.infrastructure.*
+import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.data.infrastructure.notes.NoteDataSourceAdder
+import net.pantasystem.milktea.data.infrastructure.toGroup
+import net.pantasystem.milktea.data.infrastructure.toModel
+import net.pantasystem.milktea.data.infrastructure.toNote
+import net.pantasystem.milktea.data.infrastructure.toNotification
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.group.GroupDataSource
 import net.pantasystem.milktea.model.nodeinfo.NodeInfoRepository
@@ -22,9 +26,12 @@ class NotificationCacheAdder @Inject constructor(
     private val noteDataSourceAdder: NoteDataSourceAdder,
     private val groupDataSource: GroupDataSource,
     private val nodeInfoRepository: NodeInfoRepository,
+    private val userDTOEntityConverter: UserDTOEntityConverter,
 ) {
     suspend fun addAndConvert(account: Account, notificationDTO: NotificationDTO): NotificationRelation {
-        val user = notificationDTO.user?.toUser(account, false)
+        val user = notificationDTO.user?.let {
+            userDTOEntityConverter.convert(account, it)
+        }
         val nodeInfo = nodeInfoRepository.find(account.getHost()).getOrNull()
         if (user != null) {
             userDataSource.add(user)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notification/impl/NotificationCacheAdder.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notification/impl/NotificationCacheAdder.kt
@@ -2,12 +2,12 @@ package net.pantasystem.milktea.data.infrastructure.notification.impl
 
 import net.pantasystem.milktea.api.mastodon.notification.MstNotificationDTO
 import net.pantasystem.milktea.api.misskey.notification.NotificationDTO
+import net.pantasystem.milktea.data.converters.NotificationDTOEntityConverter
 import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.data.infrastructure.notes.NoteDataSourceAdder
 import net.pantasystem.milktea.data.infrastructure.toGroup
 import net.pantasystem.milktea.data.infrastructure.toModel
 import net.pantasystem.milktea.data.infrastructure.toNote
-import net.pantasystem.milktea.data.infrastructure.toNotification
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.group.GroupDataSource
 import net.pantasystem.milktea.model.nodeinfo.NodeInfoRepository
@@ -27,6 +27,7 @@ class NotificationCacheAdder @Inject constructor(
     private val groupDataSource: GroupDataSource,
     private val nodeInfoRepository: NodeInfoRepository,
     private val userDTOEntityConverter: UserDTOEntityConverter,
+    private val notificationDTOEntityConverter: NotificationDTOEntityConverter,
 ) {
     suspend fun addAndConvert(account: Account, notificationDTO: NotificationDTO): NotificationRelation {
         val user = notificationDTO.user?.let {
@@ -39,7 +40,7 @@ class NotificationCacheAdder @Inject constructor(
         val noteRelation = notificationDTO.note?.let{
             noteRelationGetter.get(noteDataSourceAdder.addNoteDtoToDataSource(account, it))
         }
-        val notification = notificationDTO.toNotification(account, nodeInfo)
+        val notification = notificationDTOEntityConverter.convert(notificationDTO, account, nodeInfo)
         notificationDataSource.add(notification)
         notificationDTO.invitation?.group?.toGroup(account.accountId)?.let { group ->
             groupDataSource.add(group)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/streaming/MediatorMainEventDispatcher.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/streaming/MediatorMainEventDispatcher.kt
@@ -10,6 +10,7 @@ import net.pantasystem.milktea.api_streaming.channel.ChannelAPI
 import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.data.infrastructure.messaging.MessageDataSource
 import net.pantasystem.milktea.data.infrastructure.notification.db.UnreadNotificationDAO
 import net.pantasystem.milktea.data.infrastructure.notification.impl.NotificationCacheAdder
@@ -29,6 +30,7 @@ class MediatorMainEventDispatcher(val logger: Logger) {
         val userDataSource: UserDataSource,
         val streamingMainMessageEventDispatcher: StreamingMainMessageEventDispatcher,
         val notificationCacheAdder: NotificationCacheAdder,
+        val userDTOEntityConverter: UserDTOEntityConverter,
     ) {
 
         fun create(): MediatorMainEventDispatcher {
@@ -42,7 +44,7 @@ class MediatorMainEventDispatcher(val logger: Logger) {
                         notificationCacheAdder,
                     )
                 )
-                .attach(StreamingMainUserEventDispatcher(userDataSource))
+                .attach(StreamingMainUserEventDispatcher(userDataSource, userDTOEntityConverter))
         }
     }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/streaming/StreamingMainUserEventDispatcher.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/streaming/StreamingMainUserEventDispatcher.kt
@@ -1,7 +1,7 @@
 package net.pantasystem.milktea.data.infrastructure.streaming
 
 import net.pantasystem.milktea.api_streaming.ChannelBody
-import net.pantasystem.milktea.data.infrastructure.toUser
+import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.user.UserDataSource
 
@@ -10,11 +10,12 @@ import net.pantasystem.milktea.model.user.UserDataSource
  */
 class StreamingMainUserEventDispatcher(
     private val userDataSource: UserDataSource,
+    private val userDTOEntityConverter: UserDTOEntityConverter,
 ) : StreamingMainEventDispatcher{
 
     override suspend fun dispatch(account: Account, mainEvent: ChannelBody.Main): Boolean {
         return (mainEvent as? ChannelBody.Main.HavingUserBody)?.let {
-            userDataSource.add(mainEvent.body.toUser(account, true))
+            userDataSource.add(userDTOEntityConverter.convert(account, mainEvent.body, true))
         } != null
     }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
@@ -8,7 +8,7 @@ import net.pantasystem.milktea.api.misskey.users.RequestUser
 import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
-import net.pantasystem.milktea.data.infrastructure.toUser
+import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.data.infrastructure.toUserRelated
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.AccountRepository
@@ -19,14 +19,15 @@ import javax.inject.Singleton
 
 @Singleton
 class UserApiAdapter @Inject constructor(
-    val accountRepository: AccountRepository,
-    val misskeyAPIProvider: MisskeyAPIProvider,
-    val mastodonAPIProvider: MastodonAPIProvider,
-){
+    private val accountRepository: AccountRepository,
+    private val misskeyAPIProvider: MisskeyAPIProvider,
+    private val mastodonAPIProvider: MastodonAPIProvider,
+    private val userDTOEntityConverter: UserDTOEntityConverter,
+) {
 
     suspend fun show(userId: User.Id, detail: Boolean): User {
         val account = accountRepository.get(userId.accountId).getOrThrow()
-        return when(account.instanceType) {
+        return when (account.instanceType) {
             Account.InstanceType.MISSKEY -> {
                 val res = misskeyAPIProvider.get(account).showUser(
                     RequestUser(
@@ -35,7 +36,11 @@ class UserApiAdapter @Inject constructor(
                         detail = detail,
                     )
                 )
-                requireNotNull(res.throwIfHasError().body()).toUser(account, detail)
+                userDTOEntityConverter.convert(
+                    account,
+                    requireNotNull(res.throwIfHasError().body()),
+                    detail
+                )
             }
             Account.InstanceType.MASTODON -> {
                 val res = mastodonAPIProvider.get(account).getAccount(userId.id)
@@ -57,7 +62,7 @@ class UserApiAdapter @Inject constructor(
 
     suspend fun follow(userId: User.Id): Boolean {
         val account = accountRepository.get(userId.accountId).getOrThrow()
-        return when(account.instanceType) {
+        return when (account.instanceType) {
             Account.InstanceType.MISSKEY -> {
                 misskeyAPIProvider.get(account).followUser(
                     RequestUser(userId = userId.id, i = account.token)
@@ -71,7 +76,7 @@ class UserApiAdapter @Inject constructor(
 
     suspend fun unfollow(userId: User.Id): Boolean {
         val account = accountRepository.get(userId.accountId).getOrThrow()
-        return when(account.instanceType) {
+        return when (account.instanceType) {
             Account.InstanceType.MISSKEY -> misskeyAPIProvider.get(account)
                 .unFollowUser(RequestUser(userId = userId.id, i = account.token))
                 .throwIfHasError()
@@ -84,7 +89,7 @@ class UserApiAdapter @Inject constructor(
 
     suspend fun muteUser(createMute: CreateMute): UserActionResult {
         val account = accountRepository.get(createMute.userId.accountId).getOrThrow()
-        return when(account.instanceType) {
+        return when (account.instanceType) {
             Account.InstanceType.MISSKEY -> {
                 require(createMute.notifications == null) {
                     "Misskey does not support notifications mute account parameter"
@@ -115,12 +120,14 @@ class UserApiAdapter @Inject constructor(
 
     suspend fun unmuteUser(userId: User.Id): UnMuteResult {
         val account = accountRepository.get(userId.accountId).getOrThrow()
-        return when(account.instanceType) {
+        return when (account.instanceType) {
             Account.InstanceType.MISSKEY -> {
-                misskeyAPIProvider.get(account).unmuteUser(RequestUser(
-                    i = account.token,
-                    userId = userId.id,
-                )).throwIfHasError()
+                misskeyAPIProvider.get(account).unmuteUser(
+                    RequestUser(
+                        i = account.token,
+                        userId = userId.id,
+                    )
+                ).throwIfHasError()
                 UserActionResult.Misskey
             }
             Account.InstanceType.MASTODON -> {
@@ -134,12 +141,14 @@ class UserApiAdapter @Inject constructor(
 
     suspend fun blockUser(userId: User.Id): BlockUserResult {
         val account = accountRepository.get(userId.accountId).getOrThrow()
-        return when(account.instanceType) {
+        return when (account.instanceType) {
             Account.InstanceType.MISSKEY -> {
-                misskeyAPIProvider.get(account).blockUser(RequestUser(
-                    i = account.token,
-                    userId = userId.id,
-                ))
+                misskeyAPIProvider.get(account).blockUser(
+                    RequestUser(
+                        i = account.token,
+                        userId = userId.id,
+                    )
+                )
                     .throwIfHasError()
                 UserActionResult.Misskey
             }
@@ -154,12 +163,14 @@ class UserApiAdapter @Inject constructor(
 
     suspend fun unblockUser(userId: User.Id): UnBlockUserResult {
         val account = accountRepository.get(userId.accountId).getOrThrow()
-        return when(account.instanceType) {
+        return when (account.instanceType) {
             Account.InstanceType.MISSKEY -> {
-                misskeyAPIProvider.get(account).unblockUser(RequestUser(
-                    i = account.token,
-                    userId = userId.id,
-                ))
+                misskeyAPIProvider.get(account).unblockUser(
+                    RequestUser(
+                        i = account.token,
+                        userId = userId.id,
+                    )
+                )
                     .throwIfHasError()
                 UserActionResult.Misskey
             }


### PR DESCRIPTION
## やったこと
現状JSONに対応するDTOクラスを拡張関数として定義していたが、
クラスとして切り出すようにした。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



