### PR TITLE
NoteOptionDialogからリアクションの履歴を表示できるようにした

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialog.kt
@@ -20,6 +20,7 @@ import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.user.report.toReport
 import net.pantasystem.milktea.note.NoteDetailActivity
 import net.pantasystem.milktea.note.R
+import net.pantasystem.milktea.note.reaction.history.ReactionHistoryPagerDialog
 import net.pantasystem.milktea.note.viewmodel.NotesViewModel
 
 @AndroidEntryPoint
@@ -127,6 +128,10 @@ class NoteOptionDialog : BottomSheetDialogFragment() {
                         onDeleteBookmarkButtonClicked = {
                             notesViewModel.removeBookmark(it)
                             dismiss()
+                        },
+                        onShowReactionHistoryButtonClicked = {
+                            dismiss()
+                            ReactionHistoryPagerDialog.newInstance(it).show(parentFragmentManager, "ReactionHistoryPagerDialog")
                         }
                     )
                 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.outlined.Star
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.NoteRelation
 import net.pantasystem.milktea.note.R
@@ -32,6 +33,7 @@ fun NoteOptionDialogLayout(
     onDeleteAndEditButtonClicked: (NoteRelation?) -> Unit,
     onDeleteButtonClicked: (NoteRelation?) -> Unit,
     onReportButtonClicked: (NoteRelation?) -> Unit,
+    onShowReactionHistoryButtonClicked: (noteId: Note.Id) -> Unit,
 ) {
     Surface(Modifier.fillMaxWidth()) {
         Column(Modifier.fillMaxWidth()) {
@@ -42,6 +44,19 @@ fun NoteOptionDialogLayout(
                     },
                     icon = Icons.Default.Info,
                     text = stringResource(id = R.string.show_detail)
+                )
+            }
+
+            if (uiState.currentAccount?.instanceType == Account.InstanceType.MISSKEY
+                && uiState.note?.id != null
+            ) {
+                NormalBottomSheetDialogSelectionLayout(
+                    onClick = {
+                        onShowReactionHistoryButtonClicked(uiState.note.id)
+                    },
+                    icon = Icons.Default.Mood, text = stringResource(
+                        id = R.string.reaction
+                    )
                 )
             }
 


### PR DESCRIPTION
## やったこと
NoteOptionDialogにリアクション履歴を表示する項目を追加し、
タップするとリアクション履歴ダイアログを表示するようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1355 

