### PR TITLE
Mastodonのお気に入りと投稿の通知を表示できるようにした

### DIFF
--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -423,5 +423,7 @@
     <string name="visibility_limited">サークル</string>
     <string name="visibility_mutual">相互フォロー</string>
     <string name="calckey_recomended_timeline">一押し</string>
+    <string name="notification_favorited_by">%sさんにお気に入りにされました</string>
+    <string name="notification_posted_by">%sさんが投稿しました</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -420,5 +420,7 @@
     <string name="visibility_limited">圆圈</string>
     <string name="visibility_mutual">相互关注</string>
     <string name="calckey_recomended_timeline">推荐的</string>
+    <string name="notification_favorited_by">被 %s 收藏</string>
+    <string name="notification_posted_by">发布者 %s</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -413,5 +413,7 @@
     <string name="visibility_limited">Circle</string>
     <string name="visibility_mutual">Mutual Follow</string>
     <string name="calckey_recomended_timeline">Recommended</string>
+    <string name="notification_favorited_by">Favorited by %s</string>
+    <string name="notification_posted_by">Posted by %s</string>
 
 </resources>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
@@ -172,7 +172,13 @@ fun MstNotificationDTO.toModel(a: Account, isRead: Boolean): Notification {
             )
         }
         MstNotificationDTO.NotificationType.Status -> {
-            TODO("通知種別${type}はまだ実装されていません")
+            StatusNotification(
+                createdAt = createdAt,
+                id = id,
+                userId = userId,
+                isRead = isRead,
+                noteId = Note.Id(a.accountId, requireNotNull(status).id)
+            )
         }
         MstNotificationDTO.NotificationType.Reblog -> {
             RenoteNotification(
@@ -200,7 +206,13 @@ fun MstNotificationDTO.toModel(a: Account, isRead: Boolean): Notification {
             )
         }
         MstNotificationDTO.NotificationType.Favourite -> {
-            TODO("通知種別${type}はまだ実装されていません")
+            FavoriteNotification(
+                createdAt = createdAt,
+                id = id,
+                userId = userId,
+                isRead = isRead,
+                noteId = Note.Id(a.accountId, requireNotNull(status).id)
+            )
         }
         MstNotificationDTO.NotificationType.Poll -> {
             PollEndedNotification(

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationStatusIconHelper.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationStatusIconHelper.kt
@@ -11,13 +11,33 @@ import net.pantasystem.milktea.notification.viewmodel.NotificationViewData
 object NotificationStatusIconHelper {
 
     @JvmStatic
-    @BindingAdapter("notificationStatusView", "notificationReactionImageView", "notificationReactionStringView", "notificationType", "notificationReaction", "notification")
-    fun LinearLayout.setStatusIcon(notificationStatusView: ImageView, notificationReactionImageView: ImageView, notificationReactionStringView: TextView, notificationType: String, notificationReaction: String?, notification: NotificationViewData){
-        when(notificationType){
+    @BindingAdapter(
+        "notificationStatusView",
+        "notificationReactionImageView",
+        "notificationReactionStringView",
+        "notificationType",
+        "notificationReaction",
+        "notification"
+    )
+    fun LinearLayout.setStatusIcon(
+        notificationStatusView: ImageView,
+        notificationReactionImageView: ImageView,
+        notificationReactionStringView: TextView,
+        notificationType: String,
+        notificationReaction: String?,
+        notification: NotificationViewData
+    ) {
+        when (notificationType) {
             "reaction" -> {
                 //context: Context, reactionTextTypeView: TextView, reactionImageTypeView: ImageView,reaction: String, note: PlaneNoteViewData)
-                if(notificationReaction != null && notification.noteViewData != null) {
-                    NoteReactionViewHelper.setReactionCount(this.context, notificationReactionStringView, notificationReactionImageView,  notificationReaction, notification.noteViewData)
+                if (notificationReaction != null && notification.noteViewData != null) {
+                    NoteReactionViewHelper.setReactionCount(
+                        this.context,
+                        notificationReactionStringView,
+                        notificationReactionImageView,
+                        notificationReaction,
+                        notification.noteViewData
+                    )
                 }
                 notificationStatusView.visibility = View.GONE
 
@@ -30,9 +50,9 @@ object NotificationStatusIconHelper {
         }
     }
 
-    private fun setStatusView(statusView: ImageView, type: String){
+    private fun setStatusView(statusView: ImageView, type: String) {
         statusView.visibility = View.VISIBLE
-        when(type){
+        when (type) {
             "follow" -> statusView.setImageResource(R.drawable.ic_follow)
             "mention" -> statusView.setImageResource(R.drawable.ic_mention)
             "reply" -> statusView.setImageResource(R.drawable.ic_reply_black_24dp)
@@ -43,6 +63,8 @@ object NotificationStatusIconHelper {
             "receiveFollowRequest", "groupInvited" -> statusView.setImageResource(R.drawable.ic_supervisor_account_black_24dp)
             "followRequestAccepted" -> statusView.setImageResource(R.drawable.ic_done_black_24dp)
             "unknown" -> statusView.setImageResource(R.drawable.ic_baseline_report_problem_24)
+            "favorite" -> statusView.setImageResource(R.drawable.ic_star_black_24dp)
+            "status" -> statusView.setImageResource(R.drawable.ic_menu_send)
         }
     }
 }

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/notification_message_helper.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/notification_message_helper.kt
@@ -55,8 +55,19 @@ class NotificationMessageScope(val context: Context) {
                 this.user?.displayUserName ?: ""
             )
             is PollEndedNotification -> context.getString(R.string.poll_ended)
-            is GroupInvitedNotification -> context.getString(R.string.notification_group_invited_message, notification.group.name)
+            is GroupInvitedNotification -> context.getString(
+                R.string.notification_group_invited_message,
+                notification.group.name
+            )
             is UnknownNotification -> context.getString(R.string.unknown_notification)
+            is FavoriteNotification -> context.getString(
+                R.string.notification_favorited_by,
+                user?.displayUserName ?: ""
+            )
+            is StatusNotification -> context.getString(
+                R.string.notification_posted_by,
+                user?.displayUserName ?: ""
+            )
         }
     }
 }

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/viewmodel/NotificationViewData.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/viewmodel/NotificationViewData.kt
@@ -22,8 +22,9 @@ class NotificationViewData(
         FOLLOW_REQUEST_ACCEPTED("followRequestAccepted"),
         POLL_ENDED("pollEnded"),
         UNKNOWN("unknown"),
-        GROUP_INVITED("groupInvited")
-
+        GROUP_INVITED("groupInvited"),
+        STATUS("status"),
+        FAVORITE("favorite"),
     }
 
     val id = notification.notification.id
@@ -41,6 +42,8 @@ class NotificationViewData(
         is PollEndedNotification -> Type.POLL_ENDED
         is GroupInvitedNotification -> Type.GROUP_INVITED
         is UnknownNotification -> Type.UNKNOWN
+        is FavoriteNotification -> Type.FAVORITE
+        is StatusNotification -> Type.STATUS
     }
     val statusType: String = type.default
 

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notification/Notification.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notification/Notification.kt
@@ -82,6 +82,31 @@ data class MentionNotification(
     }
 }
 
+data class StatusNotification(
+    override val id: Id,
+
+    override val createdAt: Instant,
+    override val userId: User.Id,
+    override val noteId: Note.Id,
+    override val isRead: Boolean
+
+) : Notification(), HasNote, HasUser {
+    override fun read(): Notification {
+        return copy(isRead = true)
+    }
+}
+
+data class FavoriteNotification(
+    override val id: Id,
+    override val createdAt: Instant,
+    override val userId: User.Id,
+    override val noteId: Note.Id,
+    override val isRead: Boolean
+) : Notification(), HasNote, HasUser {
+    override fun read(): Notification {
+        return copy(isRead = true)
+    }
+}
 
 data class ReplyNotification(
     override val id: Id,


### PR DESCRIPTION
## やったこと
Mastodonのお気に入りと投稿の通知を表示できるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1357 



