### PR TITLE
DeviceTokenをSharedPreferencesに保存するようにしました

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/FCMService.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/FCMService.kt
@@ -22,6 +22,7 @@ import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notification.PushNotification
 import net.pantasystem.milktea.model.notification.toPushNotification
+import net.pantasystem.milktea.model.sw.register.DeviceTokenRepository
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.note.NoteDetailActivity
 import net.pantasystem.milktea.user.activity.UserDetailActivity
@@ -40,12 +41,14 @@ const val GROUP_KEY_MISSKEY_NOTIFICATION = "jp.panta.misskeyandroidclient.notifi
 class FCMService : FirebaseMessagingService() {
 
 
-    @Inject lateinit var accountStore: AccountStore
+    @Inject internal lateinit var accountStore: AccountStore
 
+    @Inject internal lateinit var deviceTokenRepository: DeviceTokenRepository
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
 
+        deviceTokenRepository.save(token)
         val subscriptionRegistrationWorker =
             OneTimeWorkRequestBuilder<SubscriptionRegistrationWorker>()
 

--- a/app/src/main/java/jp/panta/misskeyandroidclient/di/module/PushSubscriptionModule.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/di/module/PushSubscriptionModule.kt
@@ -8,10 +8,13 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import jp.panta.misskeyandroidclient.BuildConfig
 import net.pantasystem.milktea.common.Logger
+import net.pantasystem.milktea.common.getPreferences
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.data.infrastructure.sw.register.DeviceTokenRepositoryImpl
 import net.pantasystem.milktea.data.infrastructure.sw.register.SubscriptionRegistrationImpl
 import net.pantasystem.milktea.data.infrastructure.sw.register.SubscriptionUnRegistrationImpl
 import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.sw.register.DeviceTokenRepository
 import net.pantasystem.milktea.model.sw.register.SubscriptionRegistration
 import net.pantasystem.milktea.model.sw.register.SubscriptionUnRegistration
 import java.util.*
@@ -27,7 +30,8 @@ object PushSubscriptionModule {
         @ApplicationContext context: Context,
         accountRepository: AccountRepository,
         misskeyAPIProvider: MisskeyAPIProvider,
-        loggerFactory: Logger.Factory
+        loggerFactory: Logger.Factory,
+        deviceTokenRepository: DeviceTokenRepository,
     ): SubscriptionRegistration {
         return SubscriptionRegistrationImpl(
             accountRepository,
@@ -38,6 +42,7 @@ object PushSubscriptionModule {
             publicKey = BuildConfig.PUSH_TO_FCM_PUBLIC_KEY,
             endpointBase = BuildConfig.PUSH_TO_FCM_SERVER_BASE_URL,
             context = context,
+            deviceTokenRepository = deviceTokenRepository
         )
     }
 
@@ -56,6 +61,17 @@ object PushSubscriptionModule {
             auth = BuildConfig.PUSH_TO_FCM_AUTH,
             publicKey = BuildConfig.PUSH_TO_FCM_PUBLIC_KEY,
             context = context,
+        )
+    }
+
+    @Singleton
+    @Provides
+    fun provideDeviceTokenRepository(
+        @ApplicationContext context: Context,
+    ): DeviceTokenRepository {
+        return DeviceTokenRepositoryImpl(
+            context = context,
+            sharedPreferences = context.getPreferences()
         )
     }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/sw/register/DeviceTokenRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/sw/register/DeviceTokenRepositoryImpl.kt
@@ -6,6 +6,8 @@ import androidx.core.content.edit
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import net.pantasystem.milktea.common.runCancellableCatching
@@ -25,7 +27,9 @@ class DeviceTokenRepositoryImpl @Inject constructor(
             "net.pantasystem.milktea.data.infrastructure.sw.register.DeviceTokenRepositoryImpl.GET_START_AT"
     }
 
-    override suspend fun clear(): Result<Unit> = runCancellableCatching{
+    val lock = Mutex()
+
+    override fun clear(): Result<Unit> = runCancellableCatching{
         sharedPreferences.edit {
             putString(TOKEN, null)
             putString(GET_START_AT, null)
@@ -33,51 +37,53 @@ class DeviceTokenRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getOrCreate(): Result<String> = runCancellableCatching {
-        var token = sharedPreferences.getString(TOKEN, null)
+        lock.withLock {
+            var token = sharedPreferences.getString(TOKEN, null)
 
-        // NOTE: 既にTokenが入っている場合はそれを返す
-        if (!token.isNullOrBlank()) {
-            return@runCancellableCatching token
-        }
-
-        val now = Clock.System.now()
-
-        // NOTE: 前回Tokenの取得を実施した日時を取得する
-        // NOTE: 成功時に必ずToken取得日の記録を削除するようにしているので、取得日が残っているということは、前回取得に失敗していると言える
-        val beforeGetStartAt = sharedPreferences.getString(GET_START_AT, null)?.let {
-            try {
-                Instant.parse(it)
-            } catch (e: IllegalArgumentException) {
-                null
+            // NOTE: 既にTokenが入っている場合はそれを返す
+            if (!token.isNullOrBlank()) {
+                return@runCancellableCatching token
             }
+
+            val now = Clock.System.now()
+
+            // NOTE: 前回Tokenの取得を実施した日時を取得する
+            // NOTE: 成功時に必ずToken取得日の記録を削除するようにしているので、取得日が残っているということは、前回取得に失敗していると言える
+            val beforeGetStartAt = sharedPreferences.getString(GET_START_AT, null)?.let {
+                try {
+                    Instant.parse(it)
+                } catch (e: IllegalArgumentException) {
+                    null
+                }
+            }
+
+            // NOTE: 前回のTokenの取得に失敗していて、まだ24時間経過していない場合はエラー扱いにする
+            if (beforeGetStartAt != null) {
+                val diff = now - beforeGetStartAt
+                if (diff < 1.days) {
+                    throw IllegalArgumentException("Tokenの取得は24時間以内に失敗している可能性があります。前回失敗した場合は24時間以上時間を空けて取得する必要性があります。")
+                }
+            }
+            sharedPreferences.edit {
+                putString(GET_START_AT, now.toString())
+            }
+
+            when (val state =
+                GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)) {
+                ConnectionResult.SUCCESS -> {
+                    token = FirebaseMessaging.getInstance().token.asSuspend()
+                    save(token)
+                }
+                else -> {
+                    throw IllegalStateException("Google Play Serviceが有効ではないあるいは接続に失敗しためキャンセルしました。state:${state}")
+                }
+            }
+            token
         }
 
-
-        // NOTE: 前回のTokenの取得に失敗していて、まだ24時間経過していない場合はエラー扱いにする
-        if (beforeGetStartAt != null) {
-            val diff = now - beforeGetStartAt
-            if (diff < 1.days) {
-                throw IllegalArgumentException("Tokenの取得は24時間以内に失敗している可能性があります。前回失敗した場合は24時間以上時間を空けて取得する必要性があります。")
-            }
-        }
-        sharedPreferences.edit {
-            putString(GET_START_AT, now.toString())
-        }
-
-        when (val state =
-            GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)) {
-            ConnectionResult.SUCCESS -> {
-                token = FirebaseMessaging.getInstance().token.asSuspend()
-                save(token)
-            }
-            else -> {
-                throw IllegalStateException("Google Play Serviceが有効ではないあるいは接続に失敗しためキャンセルしました。state:${state}")
-            }
-        }
-        token
     }
 
-    override suspend fun save(deviceToken: String): Result<Unit> = runCancellableCatching {
+    override fun save(deviceToken: String): Result<Unit> = runCancellableCatching {
         sharedPreferences.edit {
             putString(TOKEN, deviceToken)
             putString(GET_START_AT, null)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/sw/register/DeviceTokenRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/sw/register/DeviceTokenRepositoryImpl.kt
@@ -1,0 +1,86 @@
+package net.pantasystem.milktea.data.infrastructure.sw.register
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.model.sw.register.DeviceTokenRepository
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.days
+
+class DeviceTokenRepositoryImpl @Inject constructor(
+    private val sharedPreferences: SharedPreferences,
+    private val context: Context,
+) : DeviceTokenRepository {
+
+    companion object {
+        const val TOKEN =
+            "net.pantasystem.milktea.data.infrastructure.sw.register.DeviceTokenRepositoryImpl.TOKEN"
+        const val GET_START_AT =
+            "net.pantasystem.milktea.data.infrastructure.sw.register.DeviceTokenRepositoryImpl.GET_START_AT"
+    }
+
+    override suspend fun clear(): Result<Unit> = runCancellableCatching{
+        sharedPreferences.edit {
+            putString(TOKEN, null)
+            putString(GET_START_AT, null)
+        }
+    }
+
+    override suspend fun getOrCreate(): Result<String> = runCancellableCatching {
+        var token = sharedPreferences.getString(TOKEN, null)
+
+        // NOTE: 既にTokenが入っている場合はそれを返す
+        if (!token.isNullOrBlank()) {
+            return@runCancellableCatching token
+        }
+
+        val now = Clock.System.now()
+
+        // NOTE: 前回Tokenの取得を実施した日時を取得する
+        // NOTE: 成功時に必ずToken取得日の記録を削除するようにしているので、取得日が残っているということは、前回取得に失敗していると言える
+        val beforeGetStartAt = sharedPreferences.getString(GET_START_AT, null)?.let {
+            try {
+                Instant.parse(it)
+            } catch (e: IllegalArgumentException) {
+                null
+            }
+        }
+
+
+        // NOTE: 前回のTokenの取得に失敗していて、まだ24時間経過していない場合はエラー扱いにする
+        if (beforeGetStartAt != null) {
+            val diff = now - beforeGetStartAt
+            if (diff < 1.days) {
+                throw IllegalArgumentException("Tokenの取得は24時間以内に失敗している可能性があります。前回失敗した場合は24時間以上時間を空けて取得する必要性があります。")
+            }
+        }
+        sharedPreferences.edit {
+            putString(GET_START_AT, now.toString())
+        }
+
+        when (val state =
+            GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)) {
+            ConnectionResult.SUCCESS -> {
+                token = FirebaseMessaging.getInstance().token.asSuspend()
+                save(token)
+            }
+            else -> {
+                throw IllegalStateException("Google Play Serviceが有効ではないあるいは接続に失敗しためキャンセルしました。state:${state}")
+            }
+        }
+        token
+    }
+
+    override suspend fun save(deviceToken: String): Result<Unit> = runCancellableCatching {
+        sharedPreferences.edit {
+            putString(TOKEN, deviceToken)
+            putString(GET_START_AT, null)
+        }
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/sw/register/SubscriptionRegistrationImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/sw/register/SubscriptionRegistrationImpl.kt
@@ -1,9 +1,6 @@
 package net.pantasystem.milktea.data.infrastructure.sw.register
 
 import android.content.Context
-import com.google.android.gms.common.ConnectionResult
-import com.google.android.gms.common.GoogleApiAvailability
-import com.google.firebase.messaging.FirebaseMessaging
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -13,6 +10,7 @@ import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
 import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.sw.register.DeviceTokenRepository
 import net.pantasystem.milktea.model.sw.register.SubscriptionRegistration
 import net.pantasystem.milktea.model.sw.register.SubscriptionState
 
@@ -25,6 +23,7 @@ class SubscriptionRegistrationImpl(
     val publicKey: String,
     val endpointBase: String,
     val context: Context,
+    val deviceTokenRepository: DeviceTokenRepository,
 ) : SubscriptionRegistration {
     val logger = loggerFactory.create("sw/register")
 
@@ -32,37 +31,32 @@ class SubscriptionRegistrationImpl(
      * 特定のアカウントをsw/registerに登録します。
      */
     override suspend fun register(accountId: Long) : Result<SubscriptionState?> = runCancellableCatching {
-        when(GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)) {
-            ConnectionResult.SUCCESS -> {
-                val token = FirebaseMessaging.getInstance().token.asSuspend()
-                logger.debug("call register(accountId:$accountId)")
-                logger.debug("auth:$auth, publicKey:$publicKey")
-                val account = accountRepository.get(accountId).getOrThrow()
-                val endpoint = EndpointBuilder(
-                    deviceToken = token,
-                    accountId = accountId,
-                    lang = lang,
-                    auth = auth,
-                    endpointBase = endpointBase,
-                    publicKey = publicKey
-                ).build()
-                logger.debug("endpoint:${endpoint}")
+        val token = deviceTokenRepository.getOrCreate().getOrThrow()
+        logger.debug("call register(accountId:$accountId)")
+        logger.debug("auth:$auth, publicKey:$publicKey")
+        val account = accountRepository.get(accountId).getOrThrow()
+        val endpoint = EndpointBuilder(
+            deviceToken = token,
+            accountId = accountId,
+            lang = lang,
+            auth = auth,
+            endpointBase = endpointBase,
+            publicKey = publicKey
+        ).build()
+        logger.debug("endpoint:${endpoint}")
 
-                val api = misskeyAPIProvider.get(account.normalizedInstanceDomain)
-                val res = api.swRegister(
-                    Subscription(
-                        i = account.token,
-                        endpoint = endpoint,
-                        auth = auth,
-                        publicKey = publicKey
-                    )
-                )
-                res.throwIfHasError()
-                logger.debug("res code:${res.code()}, body:${res.body()}")
-                res.body()
-            }
-        }
-        null
+        val api = misskeyAPIProvider.get(account.normalizedInstanceDomain)
+        val res = api.swRegister(
+            Subscription(
+                i = account.token,
+                endpoint = endpoint,
+                auth = auth,
+                publicKey = publicKey
+            )
+        )
+        res.throwIfHasError()
+        logger.debug("res code:${res.code()}, body:${res.body()}")
+        res.body()
 
     }
 

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/sw/register/DeviceTokenRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/sw/register/DeviceTokenRepository.kt
@@ -1,0 +1,11 @@
+package net.pantasystem.milktea.model.sw.register
+
+interface DeviceTokenRepository {
+
+    suspend fun getOrCreate(): Result<String>
+
+    suspend fun save(deviceToken: String): Result<Unit>
+
+    suspend fun clear(): Result<Unit>
+
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/sw/register/DeviceTokenRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/sw/register/DeviceTokenRepository.kt
@@ -4,8 +4,8 @@ interface DeviceTokenRepository {
 
     suspend fun getOrCreate(): Result<String>
 
-    suspend fun save(deviceToken: String): Result<Unit>
+    fun save(deviceToken: String): Result<Unit>
 
-    suspend fun clear(): Result<Unit>
+    fun clear(): Result<Unit>
 
 }


### PR DESCRIPTION
## やったこと
DeviceTokenを取得しようとするとクラッシュするという不具合がどうしても修正できないので、
DeviceTokenを保存し頻繁にGoogle Play Service経由で取得しなくても良いようにしました。
またDeivceTokenをGppgle Play Service経由で取得するときは取得開始日時を記録するようにし、
成功した時は取得開始日時を削除するようにし、失敗した時はそのまま記録しておくようにしました。
また取得開始時に前回の取得開始日時が保存されている時は前回の取得処理に失敗したという判定をするようにし、
なおかつ失敗回数 * 24時間経過していない場合は処理をキャンセルするようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1328



