### PR TITLE
ギャラリーの投稿を表示することができない不具合を修正

### DIFF
--- a/modules/app_store/src/main/java/net/pantasystem/milktea/app_store/gallery/GalleryPostsStore.kt
+++ b/modules/app_store/src/main/java/net/pantasystem/milktea/app_store/gallery/GalleryPostsStore.kt
@@ -14,7 +14,7 @@ interface GalleryPostsStore : StateLocker {
     }
     val state: Flow<PageableState<List<GalleryPost.Id>>>
 
-    suspend fun loadPrevious()
-    suspend fun loadFuture()
+    suspend fun loadPrevious(): Result<Int>
+    suspend fun loadFuture(): Result<Int>
     suspend fun clear()
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/MediatorGalleryPostPaginator.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/MediatorGalleryPostPaginator.kt
@@ -24,6 +24,7 @@ class GalleryPostsStoreImpl(
     pageable: Pageable.Gallery,
     getAccount: suspend () -> Account,
     misskeyAPIProvider: MisskeyAPIProvider,
+    galleryDataSource: GalleryDataSource,
     galleryPostDTOEntityConverter: GalleryPostDTOEntityConverter,
 ) : GalleryPostsStore {
 
@@ -51,6 +52,7 @@ class GalleryPostsStoreImpl(
                     pageable,
                     getAccount,
                     misskeyAPIProvider,
+                    galleryDataSource,
                     galleryPostDTOEntityConverter,
                 )
             }
@@ -65,6 +67,7 @@ class GalleryPostsStoreImpl(
         GalleryPostsConverter(
             getAccount,
             galleryPostDTOEntityConverter,
+            galleryDataSource = galleryDataSource,
         )
     private val loader = GalleryPostsLoader(pageable, galleryPostState, misskeyAPIProvider, getAccount)
     private val previousPagingController =

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/MediatorGalleryPostPaginator.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/MediatorGalleryPostPaginator.kt
@@ -72,12 +72,12 @@ class GalleryPostsStoreImpl(
     private val futurePaginatorController =
         FuturePagingController(entityAdder, this, galleryPostState, loader)
 
-    override suspend fun loadPrevious() {
-        previousPagingController.loadPrevious()
+    override suspend fun loadPrevious(): Result<Int> {
+        return previousPagingController.loadPrevious()
     }
 
-    override suspend fun loadFuture() {
-        futurePaginatorController.loadFuture()
+    override suspend fun loadFuture(): Result<Int> {
+        return futurePaginatorController.loadFuture()
     }
 
     override suspend fun clear() {
@@ -111,12 +111,12 @@ class LikedGalleryPostStoreImpl(
     private val futurePaginatorController =
         FuturePagingController(entityAdder, this, galleryPostState, loader)
 
-    override suspend fun loadPrevious() {
-        previousPagingController.loadPrevious()
+    override suspend fun loadPrevious(): Result<Int> {
+        return previousPagingController.loadPrevious()
     }
 
-    override suspend fun loadFuture() {
-        futurePaginatorController.loadFuture()
+    override suspend fun loadFuture(): Result<Int> {
+        return futurePaginatorController.loadFuture()
     }
 
     override suspend fun clear() {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/gallery_posts_paginators.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/gallery_posts_paginators.kt
@@ -15,6 +15,7 @@ import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
 import net.pantasystem.milktea.data.converters.GalleryPostDTOEntityConverter
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.page.Pageable
+import net.pantasystem.milktea.model.gallery.GalleryDataSource
 import net.pantasystem.milktea.model.gallery.GalleryPost
 import net.pantasystem.milktea.model.instance.IllegalVersionException
 import retrofit2.Response
@@ -67,12 +68,17 @@ class GalleryPostsState : PaginationState<GalleryPost.Id>, IdGetter<String>,
 
 class GalleryPostsConverter(
     private val getAccount: suspend () -> Account,
-    private val galleryPostDTOEntityConverter: GalleryPostDTOEntityConverter
+    private val galleryPostDTOEntityConverter: GalleryPostDTOEntityConverter,
+    private val galleryDataSource: GalleryDataSource,
 ) : EntityConverter<GalleryPostDTO, GalleryPost.Id> {
 
     override suspend fun convertAll(list: List<GalleryPostDTO>): List<GalleryPost.Id> {
-        return list.map {
-            galleryPostDTOEntityConverter.convert(it, getAccount.invoke()).id
+        val posts = list.map {
+            galleryPostDTOEntityConverter.convert(it, getAccount.invoke())
+        }
+        galleryDataSource.addAll(posts)
+        return posts.map {
+            it.id
         }
     }
 }

--- a/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/GalleryPostCardList.kt
+++ b/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/GalleryPostCardList.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -47,53 +49,61 @@ fun GalleryPostCardList(
     val state by viewModel.galleryPosts.collectAsState()
 
     val content = state.content
-    if (content is StateContent.Exist) {
-
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .nestedScroll(rememberNestedScrollInteropConnection())
-        ) {
-            items(content.rawContent) { post ->
-                GalleryPostCard(
-                    galleryState = post,
-                    onAction = {
-                        if (
-                            it is GalleryPostCardAction.OnThumbnailClicked
-                            && (!visibleFileIds.contains(it.fileProperty.id) && it.fileProperty.isSensitive)
-                        ) {
-                            viewModel.toggleFileVisibleState(it.fileProperty.id)
-                        } else {
-                            onAction.invoke(it)
-                        }
-                    },
-                    visibleFileIds = visibleFileIds
-                )
-            }
-            if (state is PageableState.Loading.Previous) {
-                item {
-                    CircularProgressIndicator()
-                }
-            }
+    SwipeRefresh(
+        state = rememberSwipeRefreshState(isRefreshing = state is PageableState.Loading.Init),
+        onRefresh = {
+            viewModel.loadInit()
         }
-    } else {
-        Box(Modifier.fillMaxSize()) {
-            when (state) {
+    ) {
+        if (content is StateContent.Exist) {
 
-                is PageableState.Loading -> {
-                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .nestedScroll(rememberNestedScrollInteropConnection())
+            ) {
+                items(content.rawContent) { post ->
+                    GalleryPostCard(
+                        galleryState = post,
+                        onAction = {
+                            if (
+                                it is GalleryPostCardAction.OnThumbnailClicked
+                                && (!visibleFileIds.contains(it.fileProperty.id) && it.fileProperty.isSensitive)
+                            ) {
+                                viewModel.toggleFileVisibleState(it.fileProperty.id)
+                            } else {
+                                onAction.invoke(it)
+                            }
+                        },
+                        visibleFileIds = visibleFileIds
+                    )
+                }
+                if (state is PageableState.Loading.Previous) {
+                    item {
                         CircularProgressIndicator()
                     }
                 }
-                is PageableState.Error -> {
-                    Text("Load error")
-                }
-                is PageableState.Fixed -> {
-                    Text("No contents")
+            }
+        } else {
+            Box(Modifier.fillMaxSize()) {
+                when (state) {
+
+                    is PageableState.Loading -> {
+                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator()
+                        }
+                    }
+                    is PageableState.Error -> {
+                        Text("Load error")
+                    }
+                    is PageableState.Fixed -> {
+                        Text("No contents")
+                    }
                 }
             }
         }
     }
+
 
 
 }

--- a/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/GalleryPostCardList.kt
+++ b/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/GalleryPostCardList.kt
@@ -2,6 +2,7 @@ package net.pantasystem.milktea.gallery
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -50,6 +51,9 @@ fun GalleryPostCardList(
 
     val content = state.content
     SwipeRefresh(
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(rememberNestedScrollInteropConnection()),
         state = rememberSwipeRefreshState(isRefreshing = state is PageableState.Loading.Init),
         onRefresh = {
             viewModel.loadInit()
@@ -59,8 +63,8 @@ fun GalleryPostCardList(
 
             LazyColumn(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .nestedScroll(rememberNestedScrollInteropConnection())
+                    .fillMaxSize(),
+                state = listViewState,
             ) {
                 items(content.rawContent) { post ->
                     GalleryPostCard(
@@ -80,7 +84,12 @@ fun GalleryPostCardList(
                 }
                 if (state is PageableState.Loading.Previous) {
                     item {
-                        CircularProgressIndicator()
+                        Box(
+                            Modifier.fillMaxWidth(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator()
+                        }
                     }
                 }
             }
@@ -103,7 +112,6 @@ fun GalleryPostCardList(
             }
         }
     }
-
 
 
 }

--- a/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/viewmodel/GalleryPostsViewModel.kt
+++ b/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/viewmodel/GalleryPostsViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import net.pantasystem.milktea.app_store.gallery.GalleryPostSendFavoriteStore
 import net.pantasystem.milktea.app_store.gallery.GalleryPostsStore
+import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common.PageableState
 import net.pantasystem.milktea.common.StateContent
 import net.pantasystem.milktea.common.runCancellableCatching
@@ -37,6 +38,7 @@ class GalleryPostsViewModel @AssistedInject constructor(
     private val userRepository: UserRepository,
     private val accountRepository: AccountRepository,
     private val galleryPostsStoreFactory: GalleryPostsStore.Factory,
+    private val loggerFactory: Logger.Factory,
     @Assisted val pageable: Pageable.Gallery,
     @Assisted private var accountId: Long?,
 ) : ViewModel(), GalleryToggleLikeOrUnlike {
@@ -48,6 +50,10 @@ class GalleryPostsViewModel @AssistedInject constructor(
         fun create(pageable: Pageable.Gallery, accountId: Long?): GalleryPostsViewModel
     }
     companion object;
+
+    private val logger by lazy {
+        loggerFactory.create("GalleryPostsViewModel")
+    }
 
     private val galleryPostsStore: GalleryPostsStore by lazy {
         galleryPostsStoreFactory.create(pageable, this::getAccount)
@@ -155,7 +161,9 @@ class GalleryPostsViewModel @AssistedInject constructor(
         }
         viewModelScope.launch {
             galleryPostsStore.clear()
-            galleryPostsStore.loadPrevious()
+            galleryPostsStore.loadPrevious().onFailure {
+                logger.error("failed loadInit", it)
+            }
         }
     }
 
@@ -173,7 +181,9 @@ class GalleryPostsViewModel @AssistedInject constructor(
             return
         }
         viewModelScope.launch {
-            galleryPostsStore.loadPrevious()
+            galleryPostsStore.loadPrevious().onFailure {
+                logger.error("failed loadPrevious", it)
+            }
         }
     }
 


### PR DESCRIPTION
## やったこと
ギャラリーの投稿を表示することができない不具合を修正しました。
原因としてはデータ変換時に変換したデータをキャッシュレイヤーに追加していないのが原因でした。
また画面の状態を自動で更新する仕組みがなかったのでSwipeRefreshでリロードできるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1364 



