### PR TITLE
リアクションピッカーの位置が勝手にずれてしまう問題を修正しました

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiChoicesListAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiChoicesListAdapter.kt
@@ -30,13 +30,7 @@ class EmojiChoicesListAdapter(
         }
 
         override fun areItemsTheSame(oldItem: SegmentType, newItem: SegmentType): Boolean {
-            return when (oldItem) {
-                is SegmentType.Category -> oldItem.name == (newItem as? SegmentType.Category)?.name
-                is SegmentType.OftenUse -> oldItem == newItem
-                is SegmentType.OtherCategory -> oldItem == newItem
-                is SegmentType.RecentlyUsed -> oldItem == newItem
-                is SegmentType.UserCustom -> oldItem == newItem
-            }
+            return oldItem.javaClass == newItem.javaClass && oldItem.label == newItem.label
         }
     }
 ) {


### PR DESCRIPTION
## やったこと
DiffUtil.ItemCallbackの実装を修正しました。
原因としてareItemsTheSameで要素が同一Entityであるのかという判定をする必要性があったが
内容まで比較してしまっていたため、本来同一要素として判定されるべきものは別要素として判定されてしまったため
スクロールの位置を保持することができなくなってしまった。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1366 


