### PR TITLE
ノートをクリップに追加できるようにした　

### DIFF
--- a/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/CircleCheckbox.kt
+++ b/modules/common_compose/src/main/java/net/pantasystem/milktea/common_compose/CircleCheckbox.kt
@@ -1,0 +1,29 @@
+package net.pantasystem.milktea.common_compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.outlined.Circle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+@Stable
+fun CircleCheckbox(modifier: Modifier = Modifier, selected: Boolean) {
+
+    val color = MaterialTheme.colors
+    val imageVector = if (selected) Icons.Filled.CheckCircle else Icons.Outlined.Circle
+    val tint = color.primary
+    val background = if (selected) Color.White else Color.Transparent
+
+    Icon(
+        imageVector = imageVector, tint = tint,
+        modifier = modifier.background(background, shape = CircleShape),
+        contentDescription = "checkbox"
+    )
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/clip/ClipRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/clip/ClipRepositoryImpl.kt
@@ -1,9 +1,12 @@
 package net.pantasystem.milktea.data.infrastructure.clip
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 import net.pantasystem.milktea.api.misskey.I
 import net.pantasystem.milktea.api.misskey.clip.*
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common.throwIfHasError
+import net.pantasystem.milktea.common_android.hilt.IODispatcher
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
 import net.pantasystem.milktea.data.converters.ClipDTOEntityConverter
 import net.pantasystem.milktea.model.account.AccountRepository
@@ -16,24 +19,29 @@ class ClipRepositoryImpl @Inject constructor(
     private val accountRepository: AccountRepository,
     private val misskeyAPIProvider: MisskeyAPIProvider,
     private val clipDTOEntityConverter: ClipDTOEntityConverter,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ) : ClipRepository {
 
     override suspend fun getMyClips(accountId: Long): Result<List<Clip>> = runCancellableCatching {
-        val account = accountRepository.get(accountId).getOrThrow()
-        val api = misskeyAPIProvider.get(account)
-        val body = api.findMyClips(I(account.token)).throwIfHasError().body()
-        requireNotNull(body).map {
-            clipDTOEntityConverter.convert(account, it)
+        withContext(ioDispatcher) {
+            val account = accountRepository.get(accountId).getOrThrow()
+            val api = misskeyAPIProvider.get(account)
+            val body = api.findMyClips(I(account.token)).throwIfHasError().body()
+            requireNotNull(body).map {
+                clipDTOEntityConverter.convert(account, it)
+            }
         }
     }
 
     override suspend fun findOne(clipId: ClipId): Result<Clip> = runCancellableCatching  {
-        val account = accountRepository.get(clipId.accountId).getOrThrow()
-        val api = misskeyAPIProvider.get(account)
-        val body = api.showClip(ShowClipRequest(i = account.token, clipId = clipId.clipId))
-            .throwIfHasError()
-            .body()
-        clipDTOEntityConverter.convert(account, requireNotNull(body))
+        withContext(ioDispatcher) {
+            val account = accountRepository.get(clipId.accountId).getOrThrow()
+            val api = misskeyAPIProvider.get(account)
+            val body = api.showClip(ShowClipRequest(i = account.token, clipId = clipId.clipId))
+                .throwIfHasError()
+                .body()
+            clipDTOEntityConverter.convert(account, requireNotNull(body))
+        }
     }
 
     override suspend fun findBy(
@@ -42,99 +50,113 @@ class ClipRepositoryImpl @Inject constructor(
         untilId: String?,
         limit: Int
     ): Result<List<Clip>> = runCancellableCatching {
-        val account = accountRepository.get(userId.accountId).getOrThrow()
-        val api = misskeyAPIProvider.get(account)
-        val body = api.findByUsersClip(
-            FindUsersClipRequest(
-                i = account.token,
-                userId = userId.id,
-                limit = limit,
-                sinceId = sinceId,
-                untilId = untilId
-            )
-        ).throwIfHasError().body()
-        requireNotNull(body).map {
-            clipDTOEntityConverter.convert(account, it)
+        withContext(ioDispatcher) {
+            val account = accountRepository.get(userId.accountId).getOrThrow()
+            val api = misskeyAPIProvider.get(account)
+            val body = api.findByUsersClip(
+                FindUsersClipRequest(
+                    i = account.token,
+                    userId = userId.id,
+                    limit = limit,
+                    sinceId = sinceId,
+                    untilId = untilId
+                )
+            ).throwIfHasError().body()
+            requireNotNull(body).map {
+                clipDTOEntityConverter.convert(account, it)
+            }
         }
     }
 
     override suspend fun findBy(
         noteId: Note.Id
     ): Result<List<Clip>> = runCancellableCatching {
-        val account = accountRepository.get(noteId.accountId).getOrThrow()
-        val api = misskeyAPIProvider.get(account)
-        val body = api.findByNotesClip(FindNotesClip(
-            i = account.token,
-            noteId = noteId.noteId,
-        )).throwIfHasError().body()
-        requireNotNull(body).map {
-            clipDTOEntityConverter.convert(account, it)
+        withContext(ioDispatcher) {
+            val account = accountRepository.get(noteId.accountId).getOrThrow()
+            val api = misskeyAPIProvider.get(account)
+            val body = api.findByNotesClip(FindNotesClip(
+                i = account.token,
+                noteId = noteId.noteId,
+            )).throwIfHasError().body()
+            requireNotNull(body).map {
+                clipDTOEntityConverter.convert(account, it)
+            }
         }
     }
 
     override suspend fun create(
         createClip: CreateClip
     ): Result<Clip> = runCancellableCatching {
-        val account = accountRepository.get(createClip.accountId).getOrThrow()
-        val api = misskeyAPIProvider.get(account)
-        val body = api.createClip(CreateClipRequest(
-            i = account.token,
-            name = createClip.name,
-            description = createClip.description,
-            isPublic = createClip.isPublic
-        )).throwIfHasError().body()
-        clipDTOEntityConverter.convert(account, requireNotNull(body))
+        withContext(ioDispatcher) {
+            val account = accountRepository.get(createClip.accountId).getOrThrow()
+            val api = misskeyAPIProvider.get(account)
+            val body = api.createClip(CreateClipRequest(
+                i = account.token,
+                name = createClip.name,
+                description = createClip.description,
+                isPublic = createClip.isPublic
+            )).throwIfHasError().body()
+            clipDTOEntityConverter.convert(account, requireNotNull(body))
+        }
     }
 
     override suspend fun update(
         clipId: ClipId,
         updateClip: UpdateClip
     ): Result<Clip> = runCancellableCatching {
-        val account = accountRepository.get(clipId.accountId).getOrThrow()
-        val api = misskeyAPIProvider.get(account)
-        val body = api.updateClip(UpdateClipRequest(
-            i = account.token,
-            name = updateClip.name,
-            description = updateClip.description,
-            isPublic = updateClip.isPublic,
-            clipId = clipId.clipId
-        )).throwIfHasError().body()
-        clipDTOEntityConverter.convert(account, requireNotNull(body))
+        withContext(ioDispatcher) {
+            val account = accountRepository.get(clipId.accountId).getOrThrow()
+            val api = misskeyAPIProvider.get(account)
+            val body = api.updateClip(UpdateClipRequest(
+                i = account.token,
+                name = updateClip.name,
+                description = updateClip.description,
+                isPublic = updateClip.isPublic,
+                clipId = clipId.clipId
+            )).throwIfHasError().body()
+            clipDTOEntityConverter.convert(account, requireNotNull(body))
+        }
     }
 
     override suspend fun delete(
         clipId: ClipId
     ): Result<Unit> = runCancellableCatching {
-        val account = accountRepository.get(clipId.accountId).getOrThrow()
-        val api = misskeyAPIProvider.get(account)
-        api.deleteClip(DeleteClipRequest(i = account.token, clipId = clipId.clipId))
-            .throwIfHasError()
+        withContext(ioDispatcher) {
+            val account = accountRepository.get(clipId.accountId).getOrThrow()
+            val api = misskeyAPIProvider.get(account)
+            api.deleteClip(DeleteClipRequest(i = account.token, clipId = clipId.clipId))
+                .throwIfHasError()
+        }
     }
 
     override suspend fun appendNote(
         clipId: ClipId,
         noteId: Note.Id
     ): Result<Unit> = runCancellableCatching {
-        val account = accountRepository.get(clipId.accountId).getOrThrow()
-        val api = misskeyAPIProvider.get(account)
-        api.addNoteToClip(AddNoteToClipRequest(
-            i = account.token,
-            noteId = noteId.noteId,
-            clipId = clipId.clipId
-        )).throwIfHasError()
+        withContext(ioDispatcher) {
+            val account = accountRepository.get(clipId.accountId).getOrThrow()
+            val api = misskeyAPIProvider.get(account)
+            api.addNoteToClip(AddNoteToClipRequest(
+                i = account.token,
+                noteId = noteId.noteId,
+                clipId = clipId.clipId
+            )).throwIfHasError()
+        }
     }
 
     override suspend fun removeNote(
         clipId: ClipId,
         noteId: Note.Id
     ): Result<Unit> = runCancellableCatching {
-        val account = accountRepository.get(clipId.accountId).getOrThrow()
-        val api = misskeyAPIProvider.get(account)
-        api.removeNoteToClip(RemoveNoteToClipRequest(
-            i = account.token,
-            noteId = noteId.noteId,
-            clipId = clipId.clipId
-        )).throwIfHasError()
+        withContext(ioDispatcher) {
+            val account = accountRepository.get(clipId.accountId).getOrThrow()
+            val api = misskeyAPIProvider.get(account)
+            api.removeNoteToClip(RemoveNoteToClipRequest(
+                i = account.token,
+                noteId = noteId.noteId,
+                clipId = clipId.clipId
+            )).throwIfHasError()
+        }
     }
 
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipDialog.kt
@@ -1,0 +1,51 @@
+package net.pantasystem.milktea.note.clip
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.viewModels
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.composethemeadapter.MdcTheme
+import dagger.hilt.android.AndroidEntryPoint
+import net.pantasystem.milktea.model.notes.Note
+
+@AndroidEntryPoint
+class ToggleAddNoteToClipDialog : BottomSheetDialogFragment() {
+
+    companion object {
+        fun newInstance(noteId: Note.Id): ToggleAddNoteToClipDialog {
+            return ToggleAddNoteToClipDialog().apply {
+                arguments = Bundle().apply {
+                    putSerializable(ToggleAddNoteToClipDialogViewModel.EXTRA_NOTE_ID, noteId)
+                }
+            }
+        }
+    }
+
+    private val viewModel: ToggleAddNoteToClipDialogViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(
+            requireContext()
+        ).apply {
+            setContent {
+                MdcTheme {
+                    val uiState by viewModel.uiState.collectAsState()
+                    ToggleAddNoteToClipDialogLayout(
+                        uiState = uiState,
+                        onAddNoteToClip = viewModel::onAddToClip,
+                        onRemoveNoteToClip = viewModel::onRemoveToClip
+                    )
+                }
+            }
+        }
+    }
+}

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipDialogLayout.kt
@@ -1,9 +1,6 @@
 package net.pantasystem.milktea.note.clip
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.CircularProgressIndicator
@@ -36,7 +33,7 @@ fun ToggleAddNoteToClipDialogLayout(
         modifier = Modifier.fillMaxWidth()
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Box(

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipDialogLayout.kt
@@ -43,7 +43,7 @@ fun ToggleAddNoteToClipDialogLayout(
                 modifier = Modifier.fillMaxWidth(),
                 contentAlignment = Alignment.Center
             ) {
-                Text(stringResource(id = R.string.clip), fontWeight = FontWeight.Bold, fontSize = 18.sp)
+                Text(stringResource(id = R.string.clip), fontWeight = FontWeight.Bold, fontSize = 24.sp)
             }
             LazyColumn(
                 Modifier

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipDialogLayout.kt
@@ -1,0 +1,99 @@
+package net.pantasystem.milktea.note.clip
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import net.pantasystem.milktea.common.ResultState
+import net.pantasystem.milktea.common.StateContent
+import net.pantasystem.milktea.model.clip.ClipId
+import net.pantasystem.milktea.model.notes.Note
+import net.pantasystem.milktea.note.R
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun ToggleAddNoteToClipDialogLayout(
+    uiState: ToggleAddNoteToClipDialogUiState,
+    onAddNoteToClip: (Note.Id, ClipId) -> Unit,
+    onRemoveNoteToClip: (Note.Id, ClipId) -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(stringResource(id = R.string.clip), fontWeight = FontWeight.Bold, fontSize = 18.sp)
+            }
+            LazyColumn(
+                Modifier
+                    .fillMaxWidth()
+                    .height(300.dp)
+                    .nestedScroll(rememberNestedScrollInteropConnection())
+            ) {
+                when(val state = uiState.clips) {
+                    is ResultState.Error -> {
+                        item {
+                            Text("load error")
+                        }
+                    }
+                    is ResultState.Fixed -> {
+                        when (val content = state.content) {
+                            is StateContent.Exist -> {
+                                items(content.rawContent) { clip ->
+                                    ToggleAddNoteToClipTile(
+                                        clip = clip.clip,
+                                        isAdded = clip.isAdded,
+                                        onClick = {
+                                            if (clip.isAdded) {
+                                                uiState.noteId?.let {
+                                                    onRemoveNoteToClip(it, clip.clip.id)
+                                                }
+                                            } else {
+                                                uiState.noteId?.let {
+                                                    onAddNoteToClip(it, clip.clip.id)
+                                                }
+                                            }
+                                        }
+                                    )
+                                }
+                            }
+                            is StateContent.NotExist -> {
+                                item {
+                                    Text("clip is not exists")
+                                }
+                            }
+                        }
+                    }
+                    is ResultState.Loading -> {
+                        item {
+                            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                                CircularProgressIndicator()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipDialogLayout.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import net.pantasystem.milktea.common.ResultState
 import net.pantasystem.milktea.common.StateContent
-import net.pantasystem.milktea.model.clip.ClipId
+import net.pantasystem.milktea.model.clip.Clip
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.note.R
 
@@ -29,8 +29,8 @@ import net.pantasystem.milktea.note.R
 @Composable
 fun ToggleAddNoteToClipDialogLayout(
     uiState: ToggleAddNoteToClipDialogUiState,
-    onAddNoteToClip: (Note.Id, ClipId) -> Unit,
-    onRemoveNoteToClip: (Note.Id, ClipId) -> Unit,
+    onAddNoteToClip: (Note.Id, Clip) -> Unit,
+    onRemoveNoteToClip: (Note.Id, Clip) -> Unit,
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth()
@@ -63,16 +63,20 @@ fun ToggleAddNoteToClipDialogLayout(
                                 items(content.rawContent) { clip ->
                                     ToggleAddNoteToClipTile(
                                         clip = clip.clip,
-                                        isAdded = clip.isAdded,
+                                        state = clip.addState,
                                         onClick = {
-                                            if (clip.isAdded) {
-                                                uiState.noteId?.let {
-                                                    onRemoveNoteToClip(it, clip.clip.id)
+                                            when(clip.addState) {
+                                                ClipAddState.Added -> {
+                                                    uiState.noteId?.let {
+                                                        onRemoveNoteToClip(it, clip.clip)
+                                                    }
                                                 }
-                                            } else {
-                                                uiState.noteId?.let {
-                                                    onAddNoteToClip(it, clip.clip.id)
+                                                ClipAddState.Unknown, ClipAddState.NotAdded -> {
+                                                    uiState.noteId?.let {
+                                                        onAddNoteToClip(it, clip.clip)
+                                                    }
                                                 }
+                                                ClipAddState.Progress -> {}
                                             }
                                         }
                                     )

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipDialogViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipDialogViewModel.kt
@@ -1,0 +1,123 @@
+package net.pantasystem.milktea.note.clip
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import net.pantasystem.milktea.common.Logger
+import net.pantasystem.milktea.common.ResultState
+import net.pantasystem.milktea.common.StateContent
+import net.pantasystem.milktea.common.asLoadingStateFlow
+import net.pantasystem.milktea.model.clip.Clip
+import net.pantasystem.milktea.model.clip.ClipId
+import net.pantasystem.milktea.model.clip.ClipRepository
+import net.pantasystem.milktea.model.notes.Note
+import javax.inject.Inject
+
+@HiltViewModel
+class ToggleAddNoteToClipDialogViewModel @Inject constructor(
+    private val clipRepository: ClipRepository,
+    private val savedStateHandle: SavedStateHandle,
+    private val loggerFactory: Logger.Factory,
+) : ViewModel() {
+
+    companion object {
+        const val EXTRA_NOTE_ID = "ToggleAddNoteToClipDialogViewModel.EXTRA_NOTE_ID"
+    }
+
+    private val logger by lazy {
+        loggerFactory.create("TANTDViewModel")
+    }
+
+    val noteId = savedStateHandle.getStateFlow<Note.Id?>(EXTRA_NOTE_ID, null)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val myClipsState = noteId.filterNotNull().distinctUntilChanged().flatMapLatest {
+        suspend {
+            clipRepository.getMyClips(it.accountId).getOrThrow()
+        }.asLoadingStateFlow()
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        ResultState.Loading(StateContent.NotExist())
+    )
+
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val relatedClips = noteId.filterNotNull().flatMapLatest {
+        suspend {
+            clipRepository.findBy(it).getOrThrow()
+        }.asLoadingStateFlow()
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        ResultState.Loading(StateContent.NotExist())
+    )
+
+    private val clipStatuses: StateFlow<ResultState<List<ClipWithAddedState>>> =
+        combine(myClipsState, relatedClips) { own, related ->
+            val clips = (related.content as? StateContent.Exist)?.rawContent ?: emptyList()
+            own.convert { list ->
+                list.map { clip ->
+                    ClipWithAddedState(
+                        clip,
+                        isAdded = clips.any {
+                            it.id == clip.id
+                        }
+                    )
+                }
+            }
+        }.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            ResultState.Loading(StateContent.NotExist())
+        )
+
+    val uiState = combine(noteId, clipStatuses) { noteId, clipStatuses ->
+        ToggleAddNoteToClipDialogUiState(
+            noteId,
+            clipStatuses
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        ToggleAddNoteToClipDialogUiState()
+    )
+
+    fun onAddToClip(noteId: Note.Id, clipId: ClipId) {
+        viewModelScope.launch {
+            clipRepository.appendNote(clipId, noteId).onSuccess {
+
+            }.onFailure {
+                logger.error("クリップへの追加に失敗", it)
+            }
+            savedStateHandle[EXTRA_NOTE_ID] = noteId
+
+        }
+    }
+
+    fun onRemoveToClip(noteId: Note.Id, clipId: ClipId) {
+        viewModelScope.launch {
+            clipRepository.removeNote(clipId, noteId).onSuccess {
+
+            }.onFailure {
+                logger.error("クリップからの削除に失敗", it)
+            }
+            savedStateHandle[EXTRA_NOTE_ID] = noteId
+        }
+    }
+
+}
+
+data class ToggleAddNoteToClipDialogUiState(
+    val noteId: Note.Id? = null,
+    val clips: ResultState<List<ClipWithAddedState>> = ResultState.Loading(StateContent.NotExist()),
+)
+
+data class ClipWithAddedState(
+    val clip: Clip,
+    val isAdded: Boolean,
+)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipTile.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipTile.kt
@@ -16,22 +16,20 @@ import kotlinx.datetime.Clock
 import net.pantasystem.milktea.common_compose.CircleCheckbox
 import net.pantasystem.milktea.model.clip.Clip
 import net.pantasystem.milktea.model.clip.ClipId
-import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.user.User
 
 @Composable
 fun ToggleAddNoteToClipTile(
     modifier: Modifier = Modifier,
-    noteId: Note.Id,
     clip: Clip,
     isAdded: Boolean,
-    onClick: (Note.Id, Clip) -> Unit
+    onClick: () -> Unit
 ) {
     Surface(
         modifier
             .fillMaxWidth()
 
-            .clickable { onClick(noteId, clip) },
+            .clickable { onClick() },
         color = MaterialTheme.colors.surface,
     ) {
         Row(
@@ -50,7 +48,6 @@ fun ToggleAddNoteToClipTile(
 @Composable
 fun Preview_ToggleAddNoteToClipTile() {
     ToggleAddNoteToClipTile(
-        noteId = Note.Id(0L, ""),
         clip = Clip(
             id = ClipId(accountId = 0, clipId = ""),
             createdAt = Clock.System.now(),
@@ -60,8 +57,6 @@ fun Preview_ToggleAddNoteToClipTile() {
             isPublic = false
         ),
         isAdded = true,
-        onClick = { _, _ ->
-
-        }
+        onClick = {}
     )
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipTile.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipTile.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.QuestionMark
@@ -29,7 +30,6 @@ fun ToggleAddNoteToClipTile(
     Surface(
         modifier
             .fillMaxWidth()
-
             .clickable { onClick() },
         color = MaterialTheme.colors.surface,
     ) {
@@ -48,7 +48,10 @@ fun ToggleAddNoteToClipTile(
             when (state) {
                 ClipAddState.Added -> CircleCheckbox(selected = true)
                 ClipAddState.NotAdded -> CircleCheckbox(selected = false)
-                ClipAddState.Progress -> CircularProgressIndicator()
+                ClipAddState.Progress -> CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp
+                )
                 ClipAddState.Unknown -> Icon(
                     Icons.Default.QuestionMark,
                     contentDescription = "unknown added status"

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipTile.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipTile.kt
@@ -1,0 +1,67 @@
+package net.pantasystem.milktea.note.clip
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlinx.datetime.Clock
+import net.pantasystem.milktea.common_compose.CircleCheckbox
+import net.pantasystem.milktea.model.clip.Clip
+import net.pantasystem.milktea.model.clip.ClipId
+import net.pantasystem.milktea.model.notes.Note
+import net.pantasystem.milktea.model.user.User
+
+@Composable
+fun ToggleAddNoteToClipTile(
+    modifier: Modifier = Modifier,
+    noteId: Note.Id,
+    clip: Clip,
+    isAdded: Boolean,
+    onClick: (Note.Id, Clip) -> Unit
+) {
+    Surface(
+        modifier
+            .fillMaxWidth()
+
+            .clickable { onClick(noteId, clip) },
+        color = MaterialTheme.colors.surface,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(clip.name, modifier = Modifier.weight(1f))
+            CircleCheckbox(selected = isAdded)
+        }
+    }
+
+
+}
+
+@Preview
+@Composable
+fun Preview_ToggleAddNoteToClipTile() {
+    ToggleAddNoteToClipTile(
+        noteId = Note.Id(0L, ""),
+        clip = Clip(
+            id = ClipId(accountId = 0, clipId = ""),
+            createdAt = Clock.System.now(),
+            userId = User.Id(accountId = 0, id = ""),
+            name = "なんかいろいろ追加した",
+            description = null,
+            isPublic = false
+        ),
+        isAdded = true,
+        onClick = { _, _ ->
+
+        }
+    )
+}

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipTile.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipTile.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import kotlinx.datetime.Clock
 import net.pantasystem.milktea.common_compose.CircleCheckbox
 import net.pantasystem.milktea.model.clip.Clip
@@ -36,13 +37,22 @@ fun ToggleAddNoteToClipTile(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(clip.name, modifier = Modifier.weight(1f))
+            Text(
+                clip.name,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(vertical = 8.dp),
+                fontSize = 18.sp
+            )
 
-            when(state) {
+            when (state) {
                 ClipAddState.Added -> CircleCheckbox(selected = true)
                 ClipAddState.NotAdded -> CircleCheckbox(selected = false)
                 ClipAddState.Progress -> CircularProgressIndicator()
-                ClipAddState.Unknown -> Icon(Icons.Default.QuestionMark, contentDescription = "unknown added status")
+                ClipAddState.Unknown -> Icon(
+                    Icons.Default.QuestionMark,
+                    contentDescription = "unknown added status"
+                )
             }
 
         }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipTile.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/clip/ToggleAddNoteToClipTile.kt
@@ -4,9 +4,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,7 +22,7 @@ import net.pantasystem.milktea.model.user.User
 fun ToggleAddNoteToClipTile(
     modifier: Modifier = Modifier,
     clip: Clip,
-    isAdded: Boolean,
+    state: ClipAddState,
     onClick: () -> Unit
 ) {
     Surface(
@@ -37,7 +37,14 @@ fun ToggleAddNoteToClipTile(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(clip.name, modifier = Modifier.weight(1f))
-            CircleCheckbox(selected = isAdded)
+
+            when(state) {
+                ClipAddState.Added -> CircleCheckbox(selected = true)
+                ClipAddState.NotAdded -> CircleCheckbox(selected = false)
+                ClipAddState.Progress -> CircularProgressIndicator()
+                ClipAddState.Unknown -> Icon(Icons.Default.QuestionMark, contentDescription = "unknown added status")
+            }
+
         }
     }
 
@@ -56,7 +63,7 @@ fun Preview_ToggleAddNoteToClipTile() {
             description = null,
             isPublic = false
         ),
-        isAdded = true,
+        state = ClipAddState.Added,
         onClick = {}
     )
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialog.kt
@@ -20,6 +20,7 @@ import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.user.report.toReport
 import net.pantasystem.milktea.note.NoteDetailActivity
 import net.pantasystem.milktea.note.R
+import net.pantasystem.milktea.note.clip.ToggleAddNoteToClipDialog
 import net.pantasystem.milktea.note.reaction.history.ReactionHistoryPagerDialog
 import net.pantasystem.milktea.note.viewmodel.NotesViewModel
 
@@ -132,6 +133,10 @@ class NoteOptionDialog : BottomSheetDialogFragment() {
                         onShowReactionHistoryButtonClicked = {
                             dismiss()
                             ReactionHistoryPagerDialog.newInstance(it).show(parentFragmentManager, "ReactionHistoryPagerDialog")
+                        },
+                        onToggleAddNoteToClipButtonClicked = {
+                            dismiss()
+                            ToggleAddNoteToClipDialog.newInstance(it).show(parentFragmentManager, "ToggleAddNoteToClipDialog")
                         }
                     )
                 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialogLayout.kt
@@ -34,6 +34,7 @@ fun NoteOptionDialogLayout(
     onDeleteButtonClicked: (NoteRelation?) -> Unit,
     onReportButtonClicked: (NoteRelation?) -> Unit,
     onShowReactionHistoryButtonClicked: (noteId: Note.Id) -> Unit,
+    onToggleAddNoteToClipButtonClicked: (noteId: Note.Id) -> Unit,
 ) {
     Surface(Modifier.fillMaxWidth()) {
         Column(Modifier.fillMaxWidth()) {
@@ -133,6 +134,17 @@ fun NoteOptionDialogLayout(
                     }
                     else -> {}
                 }
+            }
+
+            if (uiState.note?.isMisskey == true) {
+                NormalBottomSheetDialogSelectionLayout(
+                    icon = Icons.Default.Attachment, text = stringResource(id = R.string.clip),
+                    onClick = {
+                        onToggleAddNoteToClipButtonClicked(
+                            uiState.note.id
+                        )
+                    },
+                )
             }
 
             if (uiState.noteState == null || uiState.noteState.isMutedThread != null) {

--- a/modules/features/note/src/main/res/values-ja/strings.xml
+++ b/modules/features/note/src/main/res/values-ja/strings.xml
@@ -22,4 +22,5 @@
     <string name="removed_from_favorites">お気に入りから削除しました</string>
     <string name="failed_to_delete_favorites">お気に入りの削除に失敗しました</string>
     <string name="successfully_deleted">正常に削除されました</string>
+    <string name="clip">クリップ</string>
 </resources>

--- a/modules/features/note/src/main/res/values-zh/strings.xml
+++ b/modules/features/note/src/main/res/values-zh/strings.xml
@@ -22,4 +22,5 @@
     <string name="removed_from_favorites">从收藏夹中删除</string>
     <string name="failed_to_delete_favorites">删除收藏失败</string>
     <string name="successfully_deleted">成功删除</string>
+    <string name="clip">夹子</string>
 </resources>

--- a/modules/features/note/src/main/res/values/strings.xml
+++ b/modules/features/note/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="removed_from_favorites">Removed from Favorites</string>
     <string name="failed_to_delete_favorites">Failed to delete favorites</string>
     <string name="successfully_deleted">Successfully deleted</string>
+    <string name="clip">Clip</string>
 </resources>


### PR DESCRIPTION
## やったこと
NoteOptionDialogにクリップの項目を追加しました。
クリップの項目を選択すると、所有するクリップが一覧表示され、
選択すると追加・削除を行うようにしました。
またAPIの仕様上非公開状態のClipの追加状態を取得することができないので、
非公開状態のClipの項目はチェックボックスを表示せずに？のアイコンを表示するようにし、
クリック時には追加処理を実行するようにしましました。
また追加・削除処理実施時に400エラーが返ってくる時は、既に追加済み、削除済み判定を行い、
その状態を画面に反映するようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1372


