### PR TITLE
リアクションが16種類より多くある時は16件より多く表示しないようにした

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/accounts/MastodonAccountDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/accounts/MastodonAccountDTO.kt
@@ -36,13 +36,13 @@ data class MastodonAccountDTO (
     val emojis: List<TootEmojiDTO>,
 
     @SerialName("followers_count")
-    val followersCount: Int,
+    val followersCount: Long,
 
     @SerialName("following_count")
-    val followingCount: Int,
+    val followingCount: Long,
 
     @SerialName("statuses_count")
-    val statusesCount: Int,
+    val statusesCount: Long,
 
 
     ) {
@@ -69,9 +69,9 @@ data class MastodonAccountDTO (
             instance = null,
             avatarBlurhash = null,
             info = User.Info(
-                followersCount = followersCount,
-                followingCount = followingCount,
-                notesCount = statusesCount,
+                followersCount = followersCount.toInt(),
+                followingCount = followingCount.toInt(),
+                notesCount = statusesCount.toInt(),
                 hostLower = null,
                 pinnedNoteIds = null,
                 bannerUrl = header,

--- a/modules/common/src/main/java/net/pantasystem/milktea/common/errors.kt
+++ b/modules/common/src/main/java/net/pantasystem/milktea/common/errors.kt
@@ -18,26 +18,39 @@ data class Error(
     )
 }
 
+sealed interface ErrorType {
+    data class Misskey(val error: Error) : ErrorType
+    data class Raw(val body: String) : ErrorType
+}
+
 
 
 sealed class APIError(msg: String) : Exception(msg){
-    abstract val error: Error?
-    data class ClientException(override val error: Error?) : APIError("error:$error")
-    data class AuthenticationException(override val error: Error?) : APIError("error:$error")
-    data class ForbiddenException(override val error: Error?) : APIError("error:$error")
-    data class IAmAIException(override val error: Error?) : APIError("API Error I am AI Error:$error")
-    data class InternalServerException(override val error: Error?) : APIError("API Error Internal Server Error:$error")
-    data class SomethingException(override val error: Error?, val statusCode: Int) : APIError("API Error:$error, statusCode:$statusCode")
-    data class NotFoundException(override val error: Error?) : APIError("API Error Not Found:$error")
-    data class ToManyRequestsException(override val error: Error?) : APIError("To many requests $error")
+    abstract val error: ErrorType?
+    data class ClientException(override val error: ErrorType?) : APIError("error:$error")
+    data class AuthenticationException(override val error: ErrorType?) : APIError("error:$error")
+    data class ForbiddenException(override val error: ErrorType?) : APIError("error:$error")
+    data class IAmAIException(override val error: ErrorType?) : APIError("API Error I am AI Error:$error")
+    data class InternalServerException(override val error: ErrorType?) : APIError("API Error Internal Server Error:$error")
+    data class SomethingException(override val error: ErrorType?, val statusCode: Int) : APIError("API Error:$error, statusCode:$statusCode")
+    data class NotFoundException(override val error: ErrorType?) : APIError("API Error Not Found:$error")
+    data class ToManyRequestsException(override val error: ErrorType?) : APIError("To many requests $error")
 }
 
-val formatter = Json
+val formatter = Json {
+    ignoreUnknownKeys = true
+}
 
 fun<T> Response<T>.throwIfHasError(): Response<T> {
     val error = runCancellableCatching {
-        this.errorBody()?.string()?.let {
-            formatter.decodeFromString<Error>(it)
+        if (code() in 400 .. 599) {
+            this.errorBody()?.string()?.let {
+                runCancellableCatching {
+                    ErrorType.Misskey(formatter.decodeFromString<Error>(it))
+                }.getOrNull() ?: ErrorType.Raw(it)
+            }
+        } else {
+            null
         }
     }.getOrNull()
     throwErrorFromStatusCode(code(), error)
@@ -46,7 +59,7 @@ fun<T> Response<T>.throwIfHasError(): Response<T> {
 }
 
 
-fun throwErrorFromStatusCode(code: Int, error: Error? = null) {
+fun throwErrorFromStatusCode(code: Int, error: ErrorType? = null) {
     when(code) {
         400 -> throw APIError.ClientException(error)
         401 -> throw APIError.AuthenticationException(error)

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -434,5 +434,6 @@
     <string name="unauthorized_error">未認証エラー</string>
     <string name="rate_limit_error">レートリミットエラー</string>
     <string name="not_found_error">404 見つからないエラー</string>
+    <string name="show_more_reactions">もっとリアクションを見る</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -431,5 +431,6 @@
     <string name="unauthorized_error">未认证错误（Unauthorized）</string>
     <string name="rate_limit_error">速率限制错误</string>
     <string name="not_found_error">404 未找到错误</string>
+    <string name="show_more_reactions">显示更多反应</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -425,4 +425,5 @@
     <string name="unauthorized_error">Unauthorized error</string>
     <string name="rate_limit_error">Rate limit error</string>
     <string name="not_found_error">404 Not found error</string>
+    <string name="show_more_reactions">Show more Reactions</string>
 </resources>

--- a/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/GalleryPostsFragment.kt
+++ b/modules/features/gallery/src/main/java/net/pantasystem/milktea/gallery/GalleryPostsFragment.kt
@@ -17,6 +17,7 @@ import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import net.pantasystem.milktea.common.APIError
+import net.pantasystem.milktea.common.ErrorType
 import net.pantasystem.milktea.common_navigation.*
 import net.pantasystem.milktea.common_viewmodel.CurrentPageableTimelineViewModel
 import net.pantasystem.milktea.gallery.viewmodel.GalleryPostsViewModel
@@ -132,7 +133,7 @@ class GalleryPostsFragment : Fragment() {
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 viewModel.error.collect {
-                    if (it is APIError.ClientException && it.error?.error?.code == "PERMISSION_DENIED") {
+                    if (it is APIError.ClientException && (it.error as? ErrorType.Misskey)?.error?.error?.code == "PERMISSION_DENIED") {
                         Toast.makeText(requireContext(), "再認証が必要です。", Toast.LENGTH_LONG).show()
                         // 再認証をする
                         startActivity(authorizationNavigation.newIntent(AuthorizationArgs.New))

--- a/modules/features/messaging/src/main/java/net/pantasystem/milktea/messaging/MessageHistoryScreen.kt
+++ b/modules/features/messaging/src/main/java/net/pantasystem/milktea/messaging/MessageHistoryScreen.kt
@@ -46,14 +46,14 @@ fun MessageHistoryScreen(
         ),
         onRefresh = { historyViewModel.loadGroupAndUser() }
     ) {
-        when(val content = uiState.histories.content) {
-            is StateContent.Exist -> {
-                val list = content.rawContent
 
-                LazyColumn(
-                    modifier = Modifier
-                        .fillMaxSize()
-                ) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+        ) {
+            when(val content = uiState.histories.content) {
+                is StateContent.Exist -> {
+                    val list = content.rawContent
                     items(content.rawContent.size, key = { list[it].messagingId }) { i ->
                         MessageHistoryCard(
                             history = list[i],
@@ -62,29 +62,32 @@ fun MessageHistoryScreen(
                         )
                     }
                 }
-
-            }
-            is StateContent.NotExist -> {
-                Column(
-                    Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    when (val state = uiState.histories) {
-                        is ResultState.Error -> {
-                            Text("Load Error")
-                            Text(state.throwable.toString())
-                        }
-                        is ResultState.Fixed -> {
-                            Text("No content")
-                        }
-                        is ResultState.Loading -> {
-                            CircularProgressIndicator()
+                is StateContent.NotExist -> {
+                    item {
+                        Column(
+                            Modifier.fillMaxSize(),
+                            verticalArrangement = Arrangement.Center,
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            when (val state = uiState.histories) {
+                                is ResultState.Error -> {
+                                    Text("Load Error")
+                                    Text(state.throwable.toString())
+                                }
+                                is ResultState.Fixed -> {
+                                    Text("No content")
+                                }
+                                is ResultState.Loading -> {
+                                    CircularProgressIndicator()
+                                }
+                            }
                         }
                     }
                 }
             }
+
         }
+
 
     }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewData.kt
@@ -30,4 +30,8 @@ class NoteDetailViewData(
     instanceEmojis,
     noteDataSource,
     coroutineScope
-)
+) {
+    init {
+        super.reactionCountsExpanded.postValue(true)
+    }
+}

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -137,12 +137,16 @@ class TimelineViewModel @AssistedInject constructor(
 
         viewModelScope.launch {
             (0..Int.MAX_VALUE).asFlow().map {
-                delay(5_000)
+                delay(1_000)
             }.filter {
                 this@TimelineViewModel.isActive && !timelineStore.isActiveStreaming
             }.map {
                 logger.debug { "active state isActive:${isActive}, isActiveStreaming:${timelineStore.isActiveStreaming}" }
-                timelineStore.loadFuture()
+                timelineStore.loadFuture().onFailure {
+                    if (it is APIError.ToManyRequestsException) {
+                        delay(10_000)
+                    }
+                }
             }.collect()
         }
     }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -23,6 +23,7 @@ import net.pantasystem.milktea.model.url.UrlPreview
 import net.pantasystem.milktea.model.url.UrlPreviewLoadTask
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.note.media.viewmodel.MediaViewData
+import kotlin.math.min
 
 open class PlaneNoteViewData(
     val note: NoteRelation,
@@ -139,8 +140,17 @@ open class PlaneNoteViewData(
         it.canRenote(User.Id(accountId = account.accountId, id = account.remoteId))
     }
 
-    val reactionCounts: LiveData<List<ReactionCount>> = Transformations.map(currentNote) {
-        it?.reactionCounts ?: emptyList()
+    val reactionCountsExpanded = MutableLiveData(toShowNote.note.reactionCounts.size <= 16)
+
+    val reactionCounts: LiveData<List<ReactionCount>> = currentNote.switchMap { note ->
+        reactionCountsExpanded.map {
+            if (it == true) {
+                note.reactionCounts
+            } else {
+                note.reactionCounts.subList(0, min(note.reactionCounts.size, 16))
+            }
+
+        }
     }
 
     val reactionCount = Transformations.map(reactionCounts) {
@@ -244,6 +254,10 @@ open class PlaneNoteViewData(
     fun expand() {
         Log.d("PlaneNoteViewData", "expand")
         expanded.value = true
+    }
+
+    fun expandReactions() {
+        reactionCountsExpanded.value = true
     }
 
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -236,7 +236,7 @@ open class PlaneNoteViewData(
         }.catch { e ->
             Log.d("PlaneNoteViewData", "error", e)
         }
-        job(flow)
+        this.job = job(flow)
     }
 
     var job: Job? = null

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -23,7 +23,6 @@ import net.pantasystem.milktea.model.url.UrlPreview
 import net.pantasystem.milktea.model.url.UrlPreviewLoadTask
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.note.media.viewmodel.MediaViewData
-import kotlin.math.min
 
 open class PlaneNoteViewData(
     val note: NoteRelation,
@@ -140,14 +139,14 @@ open class PlaneNoteViewData(
         it.canRenote(User.Id(accountId = account.accountId, id = account.remoteId))
     }
 
-    val reactionCountsExpanded = MutableLiveData(toShowNote.note.reactionCounts.size <= 16)
+    val reactionCountsExpanded = MutableLiveData(toShowNote.note.reactionCounts.size <= Note.SHORT_REACTION_COUNT_MAX_SIZE)
 
     val reactionCounts: LiveData<List<ReactionCount>> = currentNote.switchMap { note ->
         reactionCountsExpanded.map {
             if (it == true) {
                 note.reactionCounts
             } else {
-                note.reactionCounts.subList(0, min(note.reactionCounts.size, 16))
+                note.shortReactionCounts
             }
 
         }

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -401,11 +401,23 @@
                 android:layout_marginStart="4dp"
                 />
 
+        <com.google.android.material.button.MaterialButton
+                android:id="@+id/expandAllReactionCounts"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="@id/reaction_view"
+                app:layout_constraintTop_toBottomOf="@id/reaction_view"
+                android:visibility="@{ note.reactionCountsExpanded ? View.GONE : View.VISIBLE }"
+                android:text="@string/show_more_reactions"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:onClick="@{ ()-> note.expandReactions() }"
+                />
+
         <LinearLayout
                 android:id="@+id/noteActionButtonsBase"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                app:layout_constraintTop_toBottomOf="@id/reaction_view"
+                app:layout_constraintTop_toBottomOf="@id/expandAllReactionCounts"
                 app:layout_constraintStart_toEndOf="@id/avatarIcon"
                 app:layout_constraintEnd_toEndOf="parent"
                 android:gravity="center_vertical"

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
@@ -13,6 +13,7 @@ import net.pantasystem.milktea.model.notes.poll.Poll
 import net.pantasystem.milktea.model.notes.reaction.Reaction
 import net.pantasystem.milktea.model.notes.reaction.ReactionCount
 import net.pantasystem.milktea.model.user.User
+import kotlin.math.min
 import java.io.Serializable as JSerializable
 
 data class Note(
@@ -87,12 +88,20 @@ data class Note(
         }
     }
 
-    companion object
+    companion object {
+        const val SHORT_REACTION_COUNT_MAX_SIZE = 16
+    }
 
     val isMastodon: Boolean = type is Type.Mastodon
     val isMisskey: Boolean = type is Type.Misskey
 
     val isSupportEmojiReaction: Boolean = type is Type.Misskey || nodeInfo?.type is NodeInfo.SoftwareType.Mastodon.Fedibird
+
+    val shortReactionCounts = if (reactionCounts.size <= SHORT_REACTION_COUNT_MAX_SIZE) {
+        reactionCounts
+    } else {
+        reactionCounts.subList(0, min(reactionCounts.size, SHORT_REACTION_COUNT_MAX_SIZE))
+    }
 
     /**
      * 引用リノートであるか

--- a/modules/model/src/test/java/net/pantasystem/milktea/model/notes/NoteTest.kt
+++ b/modules/model/src/test/java/net/pantasystem/milktea/model/notes/NoteTest.kt
@@ -3,7 +3,9 @@ package net.pantasystem.milktea.model.notes
 import net.pantasystem.milktea.model.drive.FileProperty
 import net.pantasystem.milktea.model.notes.poll.Poll
 import net.pantasystem.milktea.model.notes.reaction.Reaction
+import net.pantasystem.milktea.model.notes.reaction.ReactionCount
 import net.pantasystem.milktea.model.user.User
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -207,6 +209,66 @@ class NoteTest {
             )
         )
         assertFalse(note.hasContent())
+    }
+
+    @Test
+    fun shortReactionCounts_GiveOverMaxCountCounts() {
+        val counts = (0..(Note.SHORT_REACTION_COUNT_MAX_SIZE)).map {
+            ReactionCount("r$it", 1)
+        }
+        val note = Note.make(
+            id = Note.Id(0L, ""),
+            text = null,
+            userId = User.Id(0L, ""),
+            reactionCounts = counts,
+        )
+        Assertions.assertEquals(Note.SHORT_REACTION_COUNT_MAX_SIZE + 1, counts.size)
+        Assertions.assertEquals(Note.SHORT_REACTION_COUNT_MAX_SIZE, note.shortReactionCounts.size)
+        Assertions.assertEquals(counts.subList(0, Note.SHORT_REACTION_COUNT_MAX_SIZE), note.shortReactionCounts)
+    }
+
+    @Test
+    fun shortReactionCounts_GiveUnderMaxCountCounts() {
+        val counts = (0 until (Note.SHORT_REACTION_COUNT_MAX_SIZE - 1)).map {
+            ReactionCount("r$it", 1)
+        }
+        val note = Note.make(
+            id = Note.Id(0L, ""),
+            text = null,
+            userId = User.Id(0L, ""),
+            reactionCounts = counts,
+        )
+        Assertions.assertEquals(Note.SHORT_REACTION_COUNT_MAX_SIZE - 1, counts.size)
+        Assertions.assertEquals(Note.SHORT_REACTION_COUNT_MAX_SIZE - 1, note.shortReactionCounts.size)
+        Assertions.assertEquals(counts, note.shortReactionCounts)
+    }
+
+    @Test
+    fun shortReactionCounts_GiveMaxCountCounts() {
+        val counts = (0 until Note.SHORT_REACTION_COUNT_MAX_SIZE).map {
+            ReactionCount("r$it", 1)
+        }
+        val note = Note.make(
+            id = Note.Id(0L, ""),
+            text = null,
+            userId = User.Id(0L, ""),
+            reactionCounts = counts,
+        )
+        Assertions.assertEquals(Note.SHORT_REACTION_COUNT_MAX_SIZE, counts.size)
+        Assertions.assertEquals(Note.SHORT_REACTION_COUNT_MAX_SIZE, note.shortReactionCounts.size, )
+        Assertions.assertEquals(counts, note.shortReactionCounts)
+    }
+
+    @Test
+    fun shortReactionCounts_GiveZeroElementsCounts() {
+
+        val note = Note.make(
+            id = Note.Id(0L, ""),
+            text = null,
+            userId = User.Id(0L, ""),
+            reactionCounts = emptyList(),
+        )
+        Assertions.assertEquals(emptyList<ReactionCount>(), note.shortReactionCounts)
     }
 
 }


### PR DESCRIPTION
## やったこと
リアクションの種別が16種より多くあるときは、表示種別が16件以下になるようにしました。
また省略表示にしているときは、リアクション一覧下部にさらに表示ボタンを配置し、クリックすると隠されているリアクションも全て表示されるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考
既に画面上に表示されているリアクションの種別がノートのキャプチャーやユーザのアクションによって16を超えた場合は展開されたままになります。

## Issue番号
Closed #1380 


