### PR TITLE
タイムラインのUI周りのパフォーマンスチューニングを行いました

### DIFF
--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/APIErrorStringConverter.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/APIErrorStringConverter.kt
@@ -14,7 +14,13 @@ class APIErrorStringConverter @Inject constructor() {
             is APIError.IAmAIException -> StringSource(R.string.bot_error)
             is APIError.InternalServerException -> StringSource(R.string.server_error)
             is APIError.NotFoundException -> StringSource(R.string.not_found_error)
-            is APIError.SomethingException -> StringSource("error :${error.statusCode}")
+            is APIError.SomethingException -> {
+                if (error.statusCode >= 500) {
+                    StringSource(R.string.server_error)
+                } else {
+                    StringSource("error :${error.statusCode}")
+                }
+            }
             is APIError.ToManyRequestsException -> StringSource(R.string.rate_limit_error)
         }
     }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
@@ -12,6 +12,7 @@ import android.view.MotionEvent
 import android.widget.TextView
 import androidx.core.text.getSpans
 import androidx.databinding.BindingAdapter
+import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.gif.GifDrawable
 import com.github.penfeizhou.animation.apng.APNGDrawable
 import dagger.hilt.android.EntryPointAccessors
@@ -57,6 +58,9 @@ object DecorateTextHelper {
                         }
                     }
                 }
+                // NOTE: 不要になった画像リソースを解放している
+                // NOTE: MFMDecoratorの仕様上現状はEmojiSpanを使いまわさないのでここでリソース破棄をしてしまっても問題ない。
+                Glide.with(textView).clear(it.target)
             }
         }
     }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteDataSourceAdder.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteDataSourceAdder.kt
@@ -33,7 +33,6 @@ class NoteDataSourceAdder @Inject constructor(
 
 
     suspend fun addNoteDtoToDataSource(account: Account, noteDTO: NoteDTO, skipExists: Boolean = false): Note {
-        val isMisskeyIo = account.getHost().lowercase() == "misskey.io"
         val nodeInfo = nodeInfoRepository.find(account.getHost()).getOrNull()
         val entities =
             noteDTO.toEntities(
@@ -43,9 +42,7 @@ class NoteDataSourceAdder @Inject constructor(
                 noteDTOEntityConverter,
                 filePropertyDTOEntityConverter
             )
-        // TODO: misskeyの不整合問題が解決したらmisskey.ioの比較を削除する
-        // TODO: misskey.ioのデータが信用できないので、キャッシュ上に存在する場合はスキップする
-        if (skipExists || isMisskeyIo) {
+        if (skipExists) {
             userDataSource.addAll(
                 entities.users.filterNot {
                     userDataSource.get(it.id).isSuccess

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteDataSourceAdder.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteDataSourceAdder.kt
@@ -33,6 +33,7 @@ class NoteDataSourceAdder @Inject constructor(
 
 
     suspend fun addNoteDtoToDataSource(account: Account, noteDTO: NoteDTO, skipExists: Boolean = false): Note {
+        val isMisskeyIo = account.getHost().lowercase() == "misskey.io"
         val nodeInfo = nodeInfoRepository.find(account.getHost()).getOrNull()
         val entities =
             noteDTO.toEntities(
@@ -42,7 +43,9 @@ class NoteDataSourceAdder @Inject constructor(
                 noteDTOEntityConverter,
                 filePropertyDTOEntityConverter
             )
-        if (skipExists) {
+        // TODO: misskeyの不整合問題が解決したらmisskey.ioの比較を削除する
+        // TODO: misskey.ioのデータが信用できないので、キャッシュ上に存在する場合はスキップする
+        if (skipExists || isMisskeyIo) {
             userDataSource.addAll(
                 entities.users.filterNot {
                     userDataSource.get(it.id).isSuccess

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/PreviewAbleFileListAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/PreviewAbleFileListAdapter.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
 import net.pantasystem.milktea.note.databinding.ItemMediaPreviewBinding
 import net.pantasystem.milktea.note.media.viewmodel.MediaViewData
 import net.pantasystem.milktea.note.media.viewmodel.PreviewAbleFile
@@ -47,9 +46,5 @@ class PreviewAbleFileListAdapter(
         )
     }
 
-    override fun onViewRecycled(holder: ViewHolder) {
-        super.onViewRecycled(holder)
 
-        Glide.with(holder.binding.thumbnail).clear(holder.binding.thumbnail)
-    }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/PreviewAbleFileListAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/PreviewAbleFileListAdapter.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import net.pantasystem.milktea.note.databinding.ItemMediaPreviewBinding
 import net.pantasystem.milktea.note.media.viewmodel.MediaViewData
 import net.pantasystem.milktea.note.media.viewmodel.PreviewAbleFile
@@ -44,5 +45,11 @@ class PreviewAbleFileListAdapter(
         return ViewHolder(
             binding,
         )
+    }
+
+    override fun onViewRecycled(holder: ViewHolder) {
+        super.onViewRecycled(holder)
+
+        Glide.with(holder.binding.thumbnail).clear(holder.binding.thumbnail)
     }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/ReactionCountAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/ReactionCountAdapter.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
 import net.pantasystem.milktea.model.notes.reaction.ReactionCount
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.ItemReactionBinding
@@ -86,11 +85,7 @@ class ReactionCountAdapter(
         return ReactionHolder(binding)
     }
 
-    override fun onViewRecycled(holder: ReactionHolder) {
-        super.onViewRecycled(holder)
-        Glide.with(holder.binding.reactionImage)
-            .clear(holder.binding.reactionImage)
-    }
+
 }
 
 sealed interface ReactionCountAction {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/ReactionCountAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/ReactionCountAdapter.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import net.pantasystem.milktea.model.notes.reaction.ReactionCount
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.ItemReactionBinding
@@ -83,6 +84,12 @@ class ReactionCountAdapter(
             false
         )
         return ReactionHolder(binding)
+    }
+
+    override fun onViewRecycled(holder: ReactionHolder) {
+        super.onViewRecycled(holder)
+        Glide.with(holder.binding.reactionImage)
+            .clear(holder.binding.reactionImage)
     }
 }
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiChoicesListAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiChoicesListAdapter.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.RecycledViewPool
 import net.pantasystem.milktea.common_android.resource.convertDp2Px
 import net.pantasystem.milktea.note.EmojiType
 import net.pantasystem.milktea.note.SegmentType
@@ -35,12 +36,15 @@ class EmojiChoicesListAdapter(
     }
 ) {
 
+    val viewPool = RecyclerView.RecycledViewPool()
+
     override fun onBindViewHolder(holder: SegmentViewHolder, position: Int) {
         holder.onBind(getItem(position))
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SegmentViewHolder {
         return SegmentViewHolder(
+            viewPool,
             ItemCategoryWithListBinding.inflate(LayoutInflater.from(parent.context), parent, false),
             onEmojiSelected
         )
@@ -49,11 +53,16 @@ class EmojiChoicesListAdapter(
 
 
 class SegmentViewHolder(
+    recyclerViewPool: RecycledViewPool,
     val binding: ItemCategoryWithListBinding,
     private val onEmojiSelected: (EmojiType) -> Unit,
 ) : RecyclerView.ViewHolder(binding.root) {
 
     var isSatLayoutManager = false
+
+    init {
+        binding.emojisView.setRecycledViewPool(recyclerViewPool)
+    }
 
     fun onBind(segmentType: SegmentType) {
         val adapter = EmojiChoicesAdapter(onEmojiSelected)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineErrorHandler.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineErrorHandler.kt
@@ -8,7 +8,6 @@ import net.pantasystem.milktea.common_android_ui.APIErrorStringConverter
 import net.pantasystem.milktea.model.account.UnauthorizedException
 import net.pantasystem.milktea.note.R
 import java.io.IOException
-import java.net.SocketTimeoutException
 
 class TimelineErrorHandler(
     val context: Context,
@@ -17,10 +16,6 @@ class TimelineErrorHandler(
     operator fun invoke(error: Throwable) {
         Log.e("TimelineErrorHandler", "error", error)
         when (error) {
-            is SocketTimeoutException -> {
-                Toast.makeText(context, R.string.timeout_error, Toast.LENGTH_LONG)
-                    .show()
-            }
             is IOException -> {
                 Toast.makeText(context, R.string.network_error, Toast.LENGTH_LONG)
                     .show()

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
@@ -57,6 +57,10 @@ class TimelineListAdapter(
 
     val cardActionListener = NoteCardActionListenerAdapter(onAction)
 
+    private val reactionCounterRecyclerViewPool = RecyclerView.RecycledViewPool()
+    private val urlPreviewListRecyclerViewPool = RecyclerView.RecycledViewPool()
+    private val manyFilePreviewListViewRecyclerViewPool = RecyclerView.RecycledViewPool()
+
     sealed class TimelineListItemViewHolderBase(view: View) : RecyclerView.ViewHolder(view)
 
     sealed class NoteViewHolderBase<out T: ViewDataBinding>(view: View) : TimelineListItemViewHolderBase(view){
@@ -71,6 +75,7 @@ class TimelineListAdapter(
             val flexBoxLayoutManager = FlexboxLayoutManager(reactionCountsView.context)
             flexBoxLayoutManager.alignItems = AlignItems.STRETCH
             reactionCountsView.layoutManager = flexBoxLayoutManager
+            flexBoxLayoutManager.recycleChildrenOnDetach = true
             flexBoxLayoutManager
         }
 
@@ -261,10 +266,16 @@ class TimelineListAdapter(
         return when(ViewHolderType.values()[p1]) {
             ViewHolderType.NormalNote -> {
                 val binding = DataBindingUtil.inflate<ItemNoteBinding>(LayoutInflater.from(p0.context), R.layout.item_note, p0, false)
+                binding.simpleNote.reactionView.setRecycledViewPool(reactionCounterRecyclerViewPool)
+                binding.simpleNote.urlPreviewList.setRecycledViewPool(urlPreviewListRecyclerViewPool)
+                binding.simpleNote.manyFilePreviewListView.setRecycledViewPool(manyFilePreviewListViewRecyclerViewPool)
                 NoteViewHolder(binding)
             }
             ViewHolderType.HasReplyToNote -> {
                 val binding = DataBindingUtil.inflate<ItemHasReplyToNoteBinding>(LayoutInflater.from(p0.context), R.layout.item_has_reply_to_note, p0, false)
+                binding.simpleNote.reactionView.setRecycledViewPool(reactionCounterRecyclerViewPool)
+                binding.simpleNote.urlPreviewList.setRecycledViewPool(urlPreviewListRecyclerViewPool)
+                binding.simpleNote.manyFilePreviewListView.setRecycledViewPool(manyFilePreviewListViewRecyclerViewPool)
                 HasReplyToNoteViewHolder(binding)
             }
             ViewHolderType.Loading -> {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineListAdapter.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.google.android.flexbox.AlignItems
 import com.google.android.flexbox.FlexboxLayoutManager
 import net.pantasystem.milktea.model.notes.reaction.ReactionCount
@@ -293,7 +294,37 @@ class TimelineListAdapter(
     }
 
 
+    override fun onViewRecycled(holder: TimelineListItemViewHolderBase) {
+        super.onViewRecycled(holder)
+        val simpleNote = when(holder) {
+            is EmptyViewHolder -> return
+            is ErrorViewHolder -> return
+            is LoadingViewHolder -> return
+            is HasReplyToNoteViewHolder -> {
+                holder.binding.simpleNote
+            }
+            is NoteViewHolder -> {
+                holder.binding.simpleNote
+            }
+        }
+        val imageViews = listOf(
+            simpleNote.avatarIcon,
+            simpleNote.mediaPreview.thumbnailTopLeft,
+            simpleNote.mediaPreview.thumbnailTopRight,
+            simpleNote.mediaPreview.thumbnailBottomLeft,
+            simpleNote.mediaPreview.thumbnailBottomRight,
+            simpleNote.subAvatarIcon,
+            simpleNote.subNoteMediaPreview.thumbnailBottomLeft,
+            simpleNote.subNoteMediaPreview.thumbnailBottomRight,
+            simpleNote.subNoteMediaPreview.thumbnailBottomLeft,
+            simpleNote.subNoteMediaPreview.thumbnailBottomRight,
 
+        )
+
+        imageViews.map {
+            Glide.with(simpleNote.avatarIcon).clear(it)
+        }
+    }
 
 
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -215,9 +215,7 @@ class TimelineViewModel @AssistedInject constructor(
                 noteStreamingCollector.onSuspend()
             }
 
-            // TODO: misskeyの不整合問題が解決したらmisskey.ioの比較を削除する
-            // TODO: サーバから返ってくるデータが信用できないのでノートのキャプチャーを停止することができない
-            if (config?.isStopNoteCaptureWhenBackground == true  && currentAccountWatcher.getAccount().getHost() != "misskey.io") {
+            if (config?.isStopNoteCaptureWhenBackground == true) {
                 cache.suspendNoteCapture()
             }
         }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -214,7 +214,10 @@ class TimelineViewModel @AssistedInject constructor(
                 timelineStore.suspendStreaming()
                 noteStreamingCollector.onSuspend()
             }
-            if (config?.isStopNoteCaptureWhenBackground == true) {
+
+            // TODO: misskeyの不整合問題が解決したらmisskey.ioの比較を削除する
+            // TODO: サーバから返ってくるデータが信用できないのでノートのキャプチャーを停止することができない
+            if (config?.isStopNoteCaptureWhenBackground == true  && currentAccountWatcher.getAccount().getHost() != "misskey.io") {
                 cache.suspendNoteCapture()
             }
         }


### PR DESCRIPTION
## やったこと
ネストしたRecyclerViewのViewHolderのキャッシュ上の状態が共有されないため、
RecyclerView.RecycledViewPoolを用いてViewHolderが適切に再利用されるようにしました。
またMisskey ioでレスポンスやStreaming APIのデータが若干古いという問題が発生していたので、
応急的にmisskey ioからのデータの場合でキャッシュ上に存在するデータの場合は上書きしないようにしました。
またAPIから返ってくるデータが信用できないので、NoteCaptureを停止しないようにしキャッシュ自体の整合性を向上させることにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



