### PR TITLE
絵文字更新、削除イベントに対応しました

### DIFF
--- a/modules/api_streaming/src/main/java/net/pantasystem/milktea/api_streaming/events.kt
+++ b/modules/api_streaming/src/main/java/net/pantasystem/milktea/api_streaming/events.kt
@@ -285,3 +285,26 @@ data class EmojiAdded(
         val emoji: Emoji
     )
 }
+
+@SerialName("emojiDeleted")
+@Serializable
+data class EmojiDeleted(
+    val body: Body
+) : StreamingEvent() {
+    @Serializable
+    data class Body(
+        val emojis: List<Emoji>,
+    )
+}
+
+@SerialName("emojiUpdated")
+@Serializable
+data class EmojiUpdated(
+    val body: Body
+) : StreamingEvent() {
+
+    @Serializable
+    data class Body(
+        val emojis: List<Emoji>,
+    )
+}

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -432,7 +432,7 @@
     <string name="auth_error">認証エラー</string>
     <string name="parameter_error">パラメーターエラー</string>
     <string name="unauthorized_error">未認証エラー</string>
-    <string name="rate_limit_error">レートリミットエラー</string>
+    <string name="rate_limit_error">時間をおいてから再度お試してください(レートリミットエラー)</string>
     <string name="not_found_error">404 見つからないエラー</string>
     <string name="show_more_reactions">もっとリアクションを見る</string>
 

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -428,7 +428,7 @@
     <string name="clip">クリップ</string>
 
     <string name="server_error">サーバーエラー</string>
-    <string name="bot_error">ボットですか？</string>
+    <string name="bot_error">サーバに人間であることを疑われています</string>
     <string name="auth_error">認証エラー</string>
     <string name="parameter_error">パラメーターエラー</string>
     <string name="unauthorized_error">未認証エラー</string>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiRepositoryImpl.kt
@@ -119,6 +119,22 @@ class CustomEmojiRepositoryImpl @Inject constructor(
         return customEmojiCache.get(host)
     }
 
+    override suspend fun addEmojis(host: String, emojis: List<Emoji>): Result<Unit> = runCancellableCatching {
+        withContext(ioDispatcher) {
+            upInsert(host, emojis)
+            // NOTE: inMemキャッシュなどを更新したい
+            findBy(host).getOrThrow()
+        }
+    }
+
+    override suspend fun deleteEmojis(host: String, emojis: List<Emoji>): Result<Unit> = runCancellableCatching {
+        withContext(ioDispatcher) {
+            customEmojiDAO.deleteByHostAndNames(host, emojis.map { it.name })
+            // NOTE: inMemキャッシュなどを更新したい
+            findBy(host).getOrThrow()
+        }
+    }
+
     private suspend fun upInsert(host: String, emojis: List<Emoji>) {
         val record = emojis.map {
             it.toRecord(host)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/EmojiEventHandlerImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/EmojiEventHandlerImpl.kt
@@ -1,20 +1,29 @@
 package net.pantasystem.milktea.data.infrastructure.emoji
 
-import net.pantasystem.milktea.api_streaming.EmojiAdded
-import net.pantasystem.milktea.api_streaming.SocketMessageEventListener
-import net.pantasystem.milktea.api_streaming.StreamingEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import net.pantasystem.milktea.api_streaming.*
+import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.data.streaming.SocketWithAccountProvider
 import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.emoji.CustomEmojiRepository
 import net.pantasystem.milktea.model.emoji.EmojiEventHandler
 import net.pantasystem.milktea.model.instance.SyncMetaExecutor
 import javax.inject.Inject
 
 class EmojiEventHandlerImpl @Inject constructor(
     private val socketProvider: SocketWithAccountProvider,
-    private val executor: SyncMetaExecutor
+    private val executor: SyncMetaExecutor,
+    private val customEmojiRepository: CustomEmojiRepository,
+    private val loggerFactory: Logger.Factory
 ) : EmojiEventHandler, SocketMessageEventListener {
 
     private var currentAccount: Account? = null
+    private val coroutineScope = CoroutineScope(SupervisorJob())
+    private val logger by lazy {
+        loggerFactory.create("EmojiEventHandlerImpl")
+    }
 
     override fun observe(account: Account?) {
         synchronized(this) {
@@ -34,6 +43,32 @@ class EmojiEventHandlerImpl @Inject constructor(
             is EmojiAdded -> {
                 if (currentAccount != null) {
                     executor.invoke(requireNotNull(currentAccount).normalizedInstanceDomain)
+                }
+                true
+            }
+            is EmojiUpdated -> {
+                if (currentAccount != null) {
+                    coroutineScope.launch {
+                        customEmojiRepository.addEmojis(
+                            requireNotNull(currentAccount?.getHost()),
+                            e.body.emojis
+                        ).onFailure {
+                            logger.error("addEmojis failed", it)
+                        }
+                    }
+                }
+               true
+            }
+            is EmojiDeleted -> {
+                if (currentAccount != null) {
+                    coroutineScope.launch {
+                        customEmojiRepository.deleteEmojis(
+                            requireNotNull(currentAccount?.getHost()),
+                            e.body.emojis
+                        ).onFailure {
+                            logger.error("deleteEmojis failed", it)
+                        }
+                    }
                 }
                 true
             }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/db/CustomEmojiDAO.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/db/CustomEmojiDAO.kt
@@ -35,6 +35,9 @@ interface CustomEmojiDAO {
     @Query("delete from custom_emojis where emojiHost = :host")
     suspend fun deleteByHost(host: String)
 
+    @Query("delete from custom_emojis where emojiHost = :host and name in (:names)")
+    suspend fun deleteByHostAndNames(host: String, names: List<String>)
+
     @Update
     suspend fun update(customEmoji: CustomEmojiRecord)
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/MediaPreviewHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/MediaPreviewHelper.kt
@@ -147,6 +147,7 @@ object MediaPreviewHelper {
         this.adapter = adapter
         val layoutManager = this.layoutManager as? GridLayoutManager
             ?: GridLayoutManager(context, 2)
+        layoutManager.recycleChildrenOnDetach = true
         this.layoutManager = layoutManager
 
         adapter.submitList(previewAbleList)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/poll/PollHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/poll/PollHelper.kt
@@ -25,7 +25,7 @@ object PollHelper {
         }
         val layoutManager = this.layoutManager as? LinearLayoutManager
             ?: LinearLayoutManager(this.context)
-
+        layoutManager.recycleChildrenOnDetach = true
         this.adapter = adapter
         this.layoutManager = layoutManager
         adapter.submitList(poll.choices)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/url/UrlPreviewHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/url/UrlPreviewHelper.kt
@@ -26,6 +26,7 @@ object UrlPreviewHelper {
 
             val layoutManager = this.layoutManager as? LinearLayoutManager
                 ?: LinearLayoutManager(this.context)
+            layoutManager.recycleChildrenOnDetach = true
             this.layoutManager = layoutManager
             this.adapter = adapter
         }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -152,12 +152,10 @@ open class PlaneNoteViewData(
         }
     }
 
-    val reactionCount = Transformations.map(reactionCounts) {
-        var sum = 0
-        it?.forEach { count ->
-            sum += count.count
+    val reactionCount = currentNote.map { note ->
+        note.reactionCounts.sumOf {
+            it.count
         }
-        return@map sum
     }
 
     val myReaction: LiveData<String?> = Transformations.map(currentNote) {

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationErrorHandler.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationErrorHandler.kt
@@ -18,13 +18,7 @@ class NotificationErrorHandler(
                     Toast.LENGTH_SHORT
                 ).show()
             }
-            else -> {
-                Toast.makeText(
-                    context,
-                    "Error: $error",
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
+            else -> Unit
         }
     }
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/CustomEmojiRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/CustomEmojiRepository.kt
@@ -8,6 +8,10 @@ interface CustomEmojiRepository {
 
     suspend fun sync(host: String): Result<Unit>
 
+    suspend fun addEmojis(host: String, emojis: List<Emoji>): Result<Unit>
+
+    suspend fun deleteEmojis(host: String, emojis: List<Emoji>): Result<Unit>
+
     fun observeBy(host: String): Flow<List<Emoji>>
 
     fun get(host: String): List<Emoji>?


### PR DESCRIPTION
## やったこと
Streaming APIから流れてくる絵文字更新イベント、削除イベントの実装ができていなかったため下記のような問題が発生していました。
- 追加されてすぐの絵文字をUI上に表示することができない。
- 追加されてすぐの絵文字をカスタム絵文字として表示することができない。

emojiUpdated, emojiDeletedのイベントを受信できるようにし、
受信したイベントを元にキャッシュ（CustomEmojiRepository）に更新を依頼するようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



