### PR TITLE
チャンネルとノートのURLをクリックしたときはアプリの画面を開くようにした

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -191,7 +191,7 @@
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="milktea" android:host="notes" />
+                <data android:scheme="milktea" android:pathPrefix="/notes/" android:host="*" />
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,8 +55,7 @@
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
-
-                <data android:scheme="milktea" />
+                <data android:scheme="milktea" android:host="channels" />
             </intent-filter>
         </activity>
 
@@ -187,6 +186,12 @@
                         android:host="*"
                         android:pathPrefix="/notes/"
                         android:scheme="https" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="milktea" android:host="notes" />
             </intent-filter>
         </activity>
         <activity

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/TextType.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/TextType.kt
@@ -1,6 +1,6 @@
 package net.pantasystem.milktea.common_android
 
-import jp.panta.misskeyandroidclient.mfm.Root
+import net.pantasystem.milktea.common_android.mfm.Root
 import net.pantasystem.milktea.common_android.html.MastodonHTML
 import net.pantasystem.milktea.common_android.html.MastodonHTMLParser
 import net.pantasystem.milktea.common_android.mfm.MFMParser

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Link.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Link.kt
@@ -7,6 +7,7 @@ class Link(
     override val insideStart: Int,
     override val insideEnd: Int,
     val url: String,
+    val rawUrl: String,
     val skipOgpLink: Boolean? = null,
 ) : Leaf(){
     override val elementType: ElementType = ElementType.LINK

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
@@ -618,7 +618,7 @@ object MFMParser {
             val id = url.substring(startsPattern.length, url.length)
             val matcher = idPattern.matcher(id)
             if (matcher.find()) {
-                return "milktea://notes/${matcher.group()}"
+                return "milktea://$accountHost/notes/${matcher.group()}"
             }
         }
         return null

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/MFMParser.kt
@@ -3,8 +3,6 @@ package net.pantasystem.milktea.common_android.mfm
 import jp.panta.misskeyandroidclient.mfm.*
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common_android.emoji.V13EmojiUrlResolver
-import net.pantasystem.milktea.model.channel.Channel
-import net.pantasystem.milktea.model.channel.generateChannelNavUrl
 import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.instance.HostWithVersion
 import java.net.URLDecoder
@@ -28,10 +26,7 @@ object MFMParser {
     private val spaceCRLFPattern = Pattern.compile("""\s""")
     private val hashTagPattern = Pattern.compile("""#[^\s.,!?'"#:/\[\]【】@]+""")
 
-    private const val hostPattern = """[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.+"""
-    private const val tldPattern = """[a-zA-Z]{2,}"""
-    private val channelLinkPattern = Pattern.compile("""(https?)(://)($hostPattern$tldPattern)/channels/([a-zA-Z0-9]+)""")
-    private val notesLinkPattern = Pattern.compile("""(https?)(://)($hostPattern$tldPattern)/notes/([a-zA-Z0-9]+)""")
+    private val idPattern = Pattern.compile("""^([a-zA-Z0-9]+)$""")
 
 
     fun parse(
@@ -604,24 +599,26 @@ object MFMParser {
     }
 
     fun convertAppChannelUriIfGiveChannelUrl(accountHost: String?, url: String): String? {
-        val channelLinkMatcher = channelLinkPattern.matcher(url)
-        if (channelLinkMatcher.find()) {
-            val host = channelLinkMatcher.nullableGroup(3)
-            val channelId = channelLinkMatcher.nullableGroup(4)
-            if (accountHost != null && host == accountHost && channelId != null) {
-                return Channel.generateChannelNavUrl(channelId, null)
+        accountHost?: return null
+        val startsPattern = "https://$accountHost/channels/"
+        if (url.startsWith(startsPattern)) {
+            val id = url.substring(startsPattern.length, url.length)
+            val matcher = idPattern.matcher(id)
+            if (matcher.find()) {
+                return "milktea://channels/${matcher.group()}"
             }
         }
         return null
     }
 
     fun convertAppNoteUriIfGiveNoteUrl(accountHost: String?, url: String): String? {
-        val noteLinkMatcher = notesLinkPattern.matcher(url)
-        if (noteLinkMatcher.find()) {
-            val host = noteLinkMatcher.nullableGroup(3)
-            val noteId = noteLinkMatcher.nullableGroup(4)
-            if (accountHost != null && host == accountHost && noteId != null) {
-                return "milktea://notes/${noteId}"
+        accountHost?: return null
+        val startsPattern = "https://$accountHost/notes/"
+        if (url.startsWith(startsPattern)) {
+            val id = url.substring(startsPattern.length, url.length)
+            val matcher = idPattern.matcher(id)
+            if (matcher.find()) {
+                return "milktea://notes/${matcher.group()}"
             }
         }
         return null

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Root.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/mfm/Root.kt
@@ -1,7 +1,6 @@
-package jp.panta.misskeyandroidclient.mfm
+package net.pantasystem.milktea.common_android.mfm
 
-import net.pantasystem.milktea.common_android.mfm.ElementType
-import net.pantasystem.milktea.common_android.mfm.Link
+import jp.panta.misskeyandroidclient.mfm.Node
 
 class Root(
     val sourceText: String
@@ -19,7 +18,7 @@ class Root(
                 getUrls(urls, el)
             }else if(el is Link){
                 if (el.skipOgpLink == null || !el.skipOgpLink) {
-                    urls.add(el.url)
+                    urls.add(el.rawUrl)
                 }
             }
         }

--- a/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
+++ b/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
@@ -85,9 +85,33 @@ class MFMParserTest {
     }
 
     @Test
-    fun convertAppNoteUriIfGiveNoteUrl_GiveSameHostAndChannelUrl() {
-        val result = MFMParser.convertAppChannelUriIfGiveChannelUrl("misskey.io", "https://misskey.io/channels/hgeoa390fj")
-        Assertions.assertEquals(result, "milktea://channels/hgeoa390fj")
-
+    fun convertAppNoteUriIfGiveNoteUrl_GiveSameHostAndNoteUrl() {
+        val result = MFMParser.convertAppNoteUriIfGiveNoteUrl("misskey.pantasystem.com", "https://misskey.pantasystem.com/notes/hoaA8u0faf")
+        Assertions.assertEquals("milktea://notes/hoaA8u0faf", result)
     }
+
+    @Test
+    fun convertAppNoteUriIfGiveNoteUrl_GiveBlankId() {
+        val result = MFMParser.convertAppNoteUriIfGiveNoteUrl("misskey.pantasystem.com", "https://misskey.pantasystem.com/notes/")
+        Assertions.assertNull(result)
+    }
+
+    @Test
+    fun convertAppChannelUriIfGiveChannelUrl_GiveSameHostAndChannelUrl() {
+        val result = MFMParser.convertAppChannelUriIfGiveChannelUrl("misskey.pantasystem.com", "https://misskey.pantasystem.com/channels/hgeoa390fj")
+        Assertions.assertEquals("milktea://channels/hgeoa390fj", result)
+    }
+
+    @Test
+    fun convertAppChannelUrlIfGiveChannelUrl_GiveBlankId() {
+        val result = MFMParser.convertAppChannelUriIfGiveChannelUrl("misskey.pantasystem.com", "https://misskey.pantasystem.com/channels/")
+        Assertions.assertNull(result)
+    }
+
+    @Test
+    fun convertAppChannelUriIfGiveChannelUrl_GiveNotesUrlReturnsNull() {
+        val result = MFMParser.convertAppChannelUriIfGiveChannelUrl("misskey.io", "https://misskey.io/notes/hoaA8u0faf")
+        Assertions.assertNull(result)
+    }
+
 }

--- a/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
+++ b/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
@@ -87,7 +87,7 @@ class MFMParserTest {
     @Test
     fun convertAppNoteUriIfGiveNoteUrl_GiveSameHostAndNoteUrl() {
         val result = MFMParser.convertAppNoteUriIfGiveNoteUrl("misskey.pantasystem.com", "https://misskey.pantasystem.com/notes/hoaA8u0faf")
-        Assertions.assertEquals("milktea://notes/hoaA8u0faf", result)
+        Assertions.assertEquals("milktea://misskey.pantasystem.com/notes/hoaA8u0faf", result)
     }
 
     @Test

--- a/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
+++ b/modules/common_android/src/test/java/net/pantasystem/milktea/common_android/mfm/MFMParserTest.kt
@@ -83,4 +83,11 @@ class MFMParserTest {
         )
         Assertions.assertEquals("@misskey.pantasystem.com", host)
     }
+
+    @Test
+    fun convertAppNoteUriIfGiveNoteUrl_GiveSameHostAndChannelUrl() {
+        val result = MFMParser.convertAppChannelUriIfGiveChannelUrl("misskey.io", "https://misskey.io/channels/hgeoa390fj")
+        Assertions.assertEquals(result, "milktea://channels/hgeoa390fj")
+
+    }
 }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
@@ -17,7 +17,7 @@ import com.bumptech.glide.load.resource.gif.GifDrawable
 import com.github.penfeizhou.animation.apng.APNGDrawable
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.internal.managers.FragmentComponentManager
-import jp.panta.misskeyandroidclient.mfm.Root
+import net.pantasystem.milktea.common_android.mfm.Root
 import net.pantasystem.milktea.common_android.TextType
 import net.pantasystem.milktea.common_android.mfm.MFMParser
 import net.pantasystem.milktea.common_android.ui.text.CustomEmojiDecorator

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
@@ -20,10 +20,7 @@ import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.internal.managers.FragmentComponentManager
 import jp.panta.misskeyandroidclient.mfm.*
 import net.pantasystem.milktea.common.glide.GlideApp
-import net.pantasystem.milktea.common_android.mfm.Element
-import net.pantasystem.milktea.common_android.mfm.ElementType
-import net.pantasystem.milktea.common_android.mfm.Leaf
-import net.pantasystem.milktea.common_android.mfm.Link
+import net.pantasystem.milktea.common_android.mfm.*
 import net.pantasystem.milktea.common_android.ui.Activities
 import net.pantasystem.milktea.common_android.ui.putActivity
 import net.pantasystem.milktea.common_android.ui.text.DrawableEmojiSpan

--- a/modules/features/channel/src/main/java/net/pantasystem/milktea/channel/ChannelActivity.kt
+++ b/modules/features/channel/src/main/java/net/pantasystem/milktea/channel/ChannelActivity.kt
@@ -27,6 +27,7 @@ import net.pantasystem.milktea.common_navigation.ChannelNavigation
 import net.pantasystem.milktea.common_viewmodel.confirm.ConfirmViewModel
 import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.model.channel.Channel
+import net.pantasystem.milktea.model.channel.generateChannelNavUrl
 import net.pantasystem.milktea.note.NoteEditorActivity
 import net.pantasystem.milktea.note.view.ActionNoteHandler
 import net.pantasystem.milktea.note.viewmodel.NotesViewModel
@@ -88,12 +89,13 @@ class ChannelActivity : AppCompatActivity() {
                         arguments = listOf(
                             navArgument(ChannelDetailArgs.accountId) {
                                 type = NavType.LongType
+                                defaultValue = accountStore.currentAccount?.accountId ?: 0
                             },
                             navArgument(ChannelDetailArgs.channelId) {
                                 type = NavType.StringType
                             }
                         ),
-                        deepLinks = listOf(navDeepLink { uriPattern = "milktea://accounts/{${ChannelDetailArgs.accountId}}/channels/{${ChannelDetailArgs.channelId}}" })
+                        deepLinks = listOf(navDeepLink { uriPattern = "milktea://channels/{${ChannelDetailArgs.channelId}}?accountId={${ChannelDetailArgs.accountId}}" })
                     ) {
                         val viewModel: ChannelDetailViewModel = hiltViewModel()
                         val channel by viewModel.channel.collectAsState()
@@ -136,7 +138,7 @@ class ChannelDetailNavigationImpl @Inject constructor(val activity: Activity) : 
     override fun newIntent(args: Channel.Id): Intent {
         return Intent(
             Intent.ACTION_VIEW,
-            "milktea://accounts/${args.accountId}/channels/${args.channelId}".toUri(),
+            Channel.generateChannelNavUrl(args.channelId, args.accountId).toUri(),
             activity,
             ChannelActivity::class.java,
         )

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/NoteDetailActivity.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/NoteDetailActivity.kt
@@ -91,7 +91,7 @@ class NoteDetailActivity : AppCompatActivity() {
         mParentActivity = intent.getParentActivity()
 
         val noteId = intent.getStringExtra(EXTRA_NOTE_ID)
-            ?: intent.data?.path?.replace("/notes/", "")
+            ?: intent.data?.path?.split("/notes/")?.lastOrNull()
         Log.d(TAG, "受け取ったnoteId: $noteId")
         mNoteId = noteId
         mAccountId = intent.getLongExtra(EXTRA_ACCOUNT_ID, -1).let {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/channel/Channel.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/channel/Channel.kt
@@ -22,6 +22,8 @@ data class Channel(
     val isFollowing: Boolean?,
     val hasUnreadNote: Boolean?,
 ) {
+    companion object;
+
     data class Id(
         val accountId: Long,
         val channelId: String
@@ -32,4 +34,12 @@ data class Channel(
         name.getRGB()
     }
 
+}
+
+fun Channel.Companion.generateChannelNavUrl(channelId: String, accountId: Long?): String {
+    return if (accountId == null) {
+        "milktea://channels/${channelId}"
+    } else {
+        "milktea://channels/${channelId}?accountId=$accountId"
+    }
 }


### PR DESCRIPTION
## やったこと
URLのパターンが現在のアカウントと同一のインスタンスで
パスが/channels/ or /notes/で始まりその後の文字列が[a-zA-Z0-9]+のパターンにマッチするURLの場合
アプリが対応している暗黙的なDeepLinkに変換するようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1389 

