### PR TITLE
チャンネルの投稿をRenote, 引用Renoteした時はデフォルトで公開範囲にチャンネルを指定するようにした

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
@@ -281,7 +281,9 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
         }
         noteEditorViewModel.setReplyTo(replyToNoteId)
         noteEditorViewModel.setRenoteTo(quoteToNoteId)
-        noteEditorViewModel.setChannelId(channelId)
+        if (channelId != null) {
+            noteEditorViewModel.setChannelId(channelId)
+        }
         if (draftNoteId != null && savedInstanceState == null) {
             noteEditorViewModel.setDraftNoteId(draftNoteId!!)
         }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
@@ -343,6 +343,15 @@ class NoteEditorViewModel @Inject constructor(
 
     fun setRenoteTo(noteId: Note.Id?) {
         savedStateHandle.setRenoteId(noteId)
+        if (noteId == null) {
+            return
+        }
+        viewModelScope.launch {
+            noteRepository.find(noteId).onSuccess { note ->
+                savedStateHandle.setVisibility(note.visibility)
+                savedStateHandle.setChannelId(note.channelId)
+            }
+        }
     }
 
     fun setReplyTo(noteId: Note.Id?) {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/renote/CreateRenoteMultipleAccountUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/renote/CreateRenoteMultipleAccountUseCase.kt
@@ -62,6 +62,7 @@ class CreateRenoteMultipleAccountUseCase @Inject constructor(
                     text = null,
                     visibility = note.visibility,
                     renoteId = note.id,
+                    channelId = note.channelId
                 )
             ).getOrThrow()
         } else {


### PR DESCRIPTION
## やったこと
引用をする時は引用先のチャンネルのIdを引き継ぐようにしました。
またRenoteする時リノート元の投稿にチャンネルIdが割り当てられている場合はそれも引き継ぐようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1388 



