### PR TITLE
GlideのcircleCropに依存しないようにした

### DIFF
--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -42,6 +42,7 @@
                     android:layout_gravity="start"
                     android:paddingTop="@dimen/nav_header_vertical_spacing"
                     android:layout_marginTop="20dp"
+                    android:scaleType="centerCrop"
                     android:onClick="@{()-> accountViewModel.showProfile(accountViewModel.currentAccount)}"
                     tools:ignore="ContentDescription" />
 

--- a/modules/common/src/main/java/net/pantasystem/milktea/common/ui/CircleImageIconHelper.kt
+++ b/modules/common/src/main/java/net/pantasystem/milktea/common/ui/CircleImageIconHelper.kt
@@ -1,9 +1,11 @@
 package net.pantasystem.milktea.common.ui
 
+import android.graphics.Outline
+import android.view.View
+import android.view.ViewOutlineProvider
 import android.widget.ImageView
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
-import com.bumptech.glide.request.RequestOptions
 import net.pantasystem.milktea.common.R
 
 object CircleImageIconHelper {
@@ -15,7 +17,19 @@ object CircleImageIconHelper {
         Glide.with(this.context)
             .load(url)
             .error(R.drawable.ic_cloud_off_black_24dp)
-            .apply(RequestOptions().circleCrop())
             .into(this)
+
+        outlineProvider = CircleOutlineProvider
+        clipToOutline = true
+    }
+}
+
+
+object CircleOutlineProvider : ViewOutlineProvider() {
+
+    override fun getOutline(view: View?, outline: Outline?) {
+        view ?: return
+        outline ?: return
+        outline.setOval(0, 0, view.width, view.height)
     }
 }

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/CircleOutlineHelper.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/CircleOutlineHelper.kt
@@ -9,7 +9,7 @@ object CircleOutlineHelper {
     @BindingAdapter("rect")
     fun ViewGroup.setCircleOutline(rect: Float?){
 
-        outlineProvider = CircleOutlineProvider.getInstance(rect?: 20F)
+        outlineProvider = RoundedOutlineProvider.getInstance(rect?: 20F)
     }
 
     @JvmStatic
@@ -18,7 +18,7 @@ object CircleOutlineHelper {
         rect?: return
         val r = context.resources.displayMetrics.density * rect
 
-        outlineProvider = CircleOutlineProvider.getInstance(r)
+        outlineProvider = RoundedOutlineProvider.getInstance(r)
     }
 
     @JvmStatic
@@ -26,6 +26,6 @@ object CircleOutlineHelper {
     fun View.setCircleOutline(rect: Int?) {
         rect?: return
         val r = context.resources.displayMetrics.density * rect
-        outlineProvider = CircleOutlineProvider.getInstance(r)
+        outlineProvider = RoundedOutlineProvider.getInstance(r)
     }
 }

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/RoundedOutlineProvider.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/RoundedOutlineProvider.kt
@@ -5,16 +5,16 @@ import android.view.View
 import android.view.ViewOutlineProvider
 import java.util.concurrent.ConcurrentHashMap
 
-class CircleOutlineProvider(val rect: Float) : ViewOutlineProvider(){
+class RoundedOutlineProvider(val rect: Float) : ViewOutlineProvider(){
 
     companion object{
 
-        private val rectMap = ConcurrentHashMap<Float, CircleOutlineProvider>()
+        private val rectMap = ConcurrentHashMap<Float, RoundedOutlineProvider>()
 
-        fun getInstance(rect: Float): CircleOutlineProvider {
+        fun getInstance(rect: Float): RoundedOutlineProvider {
             var provider = rectMap[rect]
             if(provider == null){
-                provider = CircleOutlineProvider(rect)
+                provider = RoundedOutlineProvider(rect)
                 rectMap[rect] = provider
             }
             return provider

--- a/modules/features/note/src/main/res/layout/item_detail_note.xml
+++ b/modules/features/note/src/main/res/layout/item_detail_note.xml
@@ -71,7 +71,9 @@
                     android:contentDescription="@string/avataricon"
                     app:circleIcon='@{note.avatarUrl}'
                     app:transitionDestinationUser="@{note.toShowNote.user}"
-                    tools:srcCompat="@android:drawable/sym_def_app_icon" />
+                    tools:srcCompat="@android:drawable/sym_def_app_icon"
+                    android:scaleType="centerCrop"
+                    />
 
             <TextView
                     android:id="@+id/mainName"
@@ -240,7 +242,9 @@
                             android:layout_marginEnd="5dp"
                             android:contentDescription="@string/avataricon"
                             app:circleIcon='@{note.subNoteAvatarUrl}'
-                            app:transitionDestinationUser="@{note.subNote.user}" />
+                            app:transitionDestinationUser="@{note.subNote.user}"
+                            android:scaleType="centerCrop"
+                            />
 
                     <TextView
                             android:id="@+id/subNoteMainName"

--- a/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
+++ b/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
@@ -45,7 +45,9 @@
                 android:contentDescription="@string/avataricon"
                 app:transitionDestinationUser="@{note.toShowNote.user}"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                android:scaleType="centerCrop"
+                />
 
         <TextView
                 android:layout_width="wrap_content"
@@ -62,6 +64,7 @@
                 android:layout_marginStart="@dimen/note_avatar_icon_right_margin_size"
                 app:layout_constraintEnd_toStartOf="@id/elapsedTime"
                 app:layout_constraintHorizontal_bias="0"
+
                 />
 
         <TextView
@@ -266,7 +269,9 @@
                                 android:contentDescription="@string/avataricon"
                                 app:transitionDestinationUser="@{note.subNote.user}"
                                 app:layout_constraintStart_toStartOf="parent"
-                                app:layout_constraintTop_toTopOf="parent"/>
+                                app:layout_constraintTop_toTopOf="parent"
+                                android:scaleType="centerCrop"
+                                />
 
                         <TextView
                                 android:layout_width="wrap_content"

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -48,7 +48,9 @@
                 android:contentDescription="@string/avataricon"
                 app:transitionDestinationUser="@{note.toShowNote.user}"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                android:scaleType="centerCrop"
+                />
 
         <TextView
                 android:layout_width="wrap_content"
@@ -271,7 +273,9 @@
                                 android:contentDescription="@string/avataricon"
                                 app:transitionDestinationUser="@{note.subNote.user}"
                                 app:layout_constraintStart_toStartOf="parent"
-                                app:layout_constraintTop_toTopOf="parent"/>
+                                app:layout_constraintTop_toTopOf="parent"
+                                android:scaleType="centerCrop"
+                                />
 
                         <TextView
                                 android:layout_width="wrap_content"

--- a/modules/features/note/src/main/res/layout/view_note_editor_toolbar.xml
+++ b/modules/features/note/src/main/res/layout/view_note_editor_toolbar.xml
@@ -49,6 +49,8 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 android:layout_marginStart="8dp"
+                android:scaleType="centerCrop"
+
                 />
 
         <TextView

--- a/modules/features/notification/src/main/res/layout/item_notification.xml
+++ b/modules/features/notification/src/main/res/layout/item_notification.xml
@@ -85,7 +85,9 @@
                         app:circleIcon="@{notification.avatarIconUrl}"
                         android:onClick="@{()-> noteCardActionListener.onUserClicked(notification.user)}"
                         android:visibility="@{ notification.user == null ? View.GONE : View.VISIBLE }"
-                        tools:ignore="ContentDescription" />
+                        tools:ignore="ContentDescription"
+                        android:scaleType="centerCrop"
+                        />
 
 
 

--- a/modules/features/user/src/main/res/layout/activity_user_detail.xml
+++ b/modules/features/user/src/main/res/layout/activity_user_detail.xml
@@ -104,7 +104,9 @@
                             tools:ignore="ContentDescription"
                             android:transitionName="user"
                             app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/headerView"/>
+                            app:layout_constraintTop_toBottomOf="@id/headerView"
+                            android:scaleType="centerCrop"
+                            />
                     <LinearLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"


### PR DESCRIPTION
## やったこと
GlideのcircleCropに依存しないように円形にくり抜くことによって、
animated webpな画像でも表示できるようにしました。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



