### PR TITLE
ノートの区切り線の有無を設定から変えられるようにした

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -437,5 +437,7 @@
     <string name="show_more_reactions">もっとリアクションを見る</string>
     <string name="pick_file_from_device">端末からファイルを選択</string>
     <string name="note_editor_file_max_size_validation_error_message">%d個を超えるファイルを添付できません</string>
+    <string name="settings_note">ノート</string>
+    <string name="settings_note_divider">ノートに横区切り線を表示する</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -434,5 +434,7 @@
     <string name="show_more_reactions">显示更多反应</string>
     <string name="pick_file_from_device">从设备中选择文件</string>
     <string name="note_editor_file_max_size_validation_error_message">不能附加超过 %d 个文件</string>
+    <string name="settings_note_divider">在笔记中显示水平分隔线</string>
+    <string name="settings_note">笔记</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -428,4 +428,6 @@
     <string name="show_more_reactions">Show more Reactions</string>
     <string name="pick_file_from_device">Pick file from device</string>
     <string name="note_editor_file_max_size_validation_error_message">Cannot attach more than %d files</string>
+    <string name="settings_note">Note</string>
+    <string name="settings_note_divider">Show horizontal separator lines in notes</string>
 </resources>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
@@ -108,7 +108,10 @@ fun Config.Companion.from(map: Map<Keys, PrefType?>): Config {
         )?.value ?: DefaultConfig.config.isStopNoteCaptureWhenBackground,
         isEnableStreamingAPIAndNoteCapture = map.getValue<PrefType.BoolPref>(
             Keys.IsEnableStreamingAPIAndNoteCapture
-        )?.value ?: DefaultConfig.config.isEnableStreamingAPIAndNoteCapture
+        )?.value ?: DefaultConfig.config.isEnableStreamingAPIAndNoteCapture,
+        isEnableNoteDivider = map.getValue<PrefType.BoolPref>(
+            Keys.IsEnableNoteDivider
+        )?.value ?: DefaultConfig.config.isEnableNoteDivider
     )
 }
 
@@ -195,6 +198,9 @@ fun Config.pref(key: Keys): PrefType {
         }
         Keys.IsEnableStreamingAPIAndNoteCapture -> {
             PrefType.BoolPref(isEnableStreamingAPIAndNoteCapture)
+        }
+        Keys.IsEnableNoteDivider -> {
+            PrefType.BoolPref(isEnableNoteDivider)
         }
     }
 }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
@@ -127,6 +127,10 @@ class ConfigKtTest {
                     config.isEnableStreamingAPIAndNoteCapture,
                     (u as PrefType.BoolPref).value
                 )
+                Keys.IsEnableNoteDivider -> Assertions.assertEquals(
+                    config.isEnableNoteDivider,
+                    (u as PrefType.BoolPref).value
+                )
             }
         }
     }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
@@ -88,6 +88,10 @@ class KeysKtTest {
                     "IsEnableStreamingAPIAndNoteCapture",
                     key.str()
                 )
+                Keys.IsEnableNoteDivider -> Assertions.assertEquals(
+                    "IsEnableNoteDivider",
+                    key.str()
+                )
             }
         }
     }
@@ -95,8 +99,8 @@ class KeysKtTest {
 
     @Test
     fun checkAllKeysCount() {
-        Assertions.assertEquals(24, Keys.allKeys.size)
-        Assertions.assertEquals(24, Keys.allKeys.map { it.str() }.toSet().size)
+        Assertions.assertEquals(25, Keys.allKeys.size)
+        Assertions.assertEquals(25, Keys.allKeys.map { it.str() }.toSet().size)
     }
 
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteConversationViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteConversationViewData.kt
@@ -8,6 +8,7 @@ import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.notes.NoteCaptureAPIAdapter
 import net.pantasystem.milktea.model.notes.NoteDataSource
 import net.pantasystem.milktea.model.notes.NoteRelation
+import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
 
 //viewはRecyclerView
@@ -19,6 +20,7 @@ class NoteConversationViewData(
     instanceEmojis: List<Emoji>,
     coroutineScope: CoroutineScope,
     noteDataSource: NoteDataSource,
+    configRepository: LocalConfigRepository,
 ) : PlaneNoteViewData(
     noteRelation,
     account,
@@ -26,6 +28,7 @@ class NoteConversationViewData(
     translationStore,
     instanceEmojis,
     noteDataSource,
+    configRepository,
     coroutineScope
 ) {
     val conversation = MutableLiveData<List<PlaneNoteViewData>>()

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewData.kt
@@ -7,6 +7,7 @@ import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.notes.NoteCaptureAPIAdapter
 import net.pantasystem.milktea.model.notes.NoteDataSource
 import net.pantasystem.milktea.model.notes.NoteRelation
+import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
 
 /**
@@ -21,6 +22,7 @@ class NoteDetailViewData(
     translationStore: NoteTranslationStore,
     instanceEmojis: List<Emoji>,
     noteDataSource: NoteDataSource,
+    configRepository: LocalConfigRepository,
     coroutineScope: CoroutineScope,
 ) : PlaneNoteViewData(
     note,
@@ -29,6 +31,7 @@ class NoteDetailViewData(
     translationStore,
     instanceEmojis,
     noteDataSource,
+    configRepository,
     coroutineScope
 ) {
     init {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewModel.kt
@@ -16,6 +16,7 @@ import net.pantasystem.milktea.model.account.CurrentAccountWatcher
 import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.model.instance.MetaRepository
 import net.pantasystem.milktea.model.notes.*
+import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewDataCache
 
@@ -27,6 +28,7 @@ class NoteDetailViewModel @AssistedInject constructor(
     private val noteTranslationStore: NoteTranslationStore,
     val metaRepository: MetaRepository,
     private val noteDataSource: NoteDataSource,
+    private val configRepository: LocalConfigRepository,
     planeNoteViewDataCacheFactory: PlaneNoteViewDataCache.Factory,
     @Assisted val show: Pageable.Show,
     @Assisted val accountId: Long? = null,
@@ -95,6 +97,7 @@ class NoteDetailViewModel @AssistedInject constructor(
                         metaRepository.get(currentAccountWatcher.getAccount().normalizedInstanceDomain)?.emojis ?: emptyList(),
                         viewModelScope,
                         noteDataSource,
+                        configRepository,
                     ).also {
                         it.capture()
                         cache.put(it)
@@ -116,6 +119,7 @@ class NoteDetailViewModel @AssistedInject constructor(
                         noteTranslationStore,
                         metaRepository.get(currentAccountWatcher.getAccount().normalizedInstanceDomain)?.emojis ?: emptyList(),
                         noteDataSource,
+                        configRepository,
                         viewModelScope,
                     ).also {
                         it.capture()

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/InstanceInfoHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/InstanceInfoHelper.kt
@@ -7,23 +7,22 @@ import androidx.core.graphics.ColorUtils
 import androidx.core.view.isVisible
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
-import dagger.hilt.android.EntryPointAccessors
 import net.pantasystem.milktea.common_android.ui.text.DrawableEmojiSpan
 import net.pantasystem.milktea.common_android.ui.text.EmojiAdapter
-import net.pantasystem.milktea.common_android_ui.BindingProvider
 import net.pantasystem.milktea.model.user.User
 import kotlin.math.min
 
 object InstanceInfoHelper {
 
     @JvmStatic
-    @BindingAdapter("instanceInfo")
-    fun TextView.setInstanceInfo(info: User.InstanceInfo?) {
-        val provider = EntryPointAccessors.fromApplication(this.context.applicationContext, BindingProvider::class.java)
+    @BindingAdapter("instanceInfo", "isEnable")
+    fun TextView.setInstanceInfo(info: User.InstanceInfo?, isEnable: Boolean? = null) {
+
+
 
         val enable = info?.name != null
                 && info.faviconUrl != null
-                && provider.settingStore().configState.value.isEnableInstanceTicker
+                && isEnable == true
         this.isVisible = enable
         if (enable) {
             val emojiAdapter = EmojiAdapter(this)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/HasReplyToNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/HasReplyToNoteViewData.kt
@@ -8,6 +8,7 @@ import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.notes.NoteCaptureAPIAdapter
 import net.pantasystem.milktea.model.notes.NoteDataSource
 import net.pantasystem.milktea.model.notes.NoteRelation
+import net.pantasystem.milktea.model.setting.LocalConfigRepository
 
 class HasReplyToNoteViewData(
     noteRelation: NoteRelation,
@@ -16,6 +17,7 @@ class HasReplyToNoteViewData(
     noteTranslationStore: NoteTranslationStore,
     instanceEmojis: List<Emoji>,
     noteDataSource: NoteDataSource,
+    configRepository: LocalConfigRepository,
     coroutineScope: CoroutineScope,
 ) : PlaneNoteViewData(
     noteRelation,
@@ -24,6 +26,7 @@ class HasReplyToNoteViewData(
     noteTranslationStore,
     instanceEmojis,
     noteDataSource,
+    configRepository,
     coroutineScope
 ) {
     val reply = noteRelation.reply
@@ -41,6 +44,7 @@ class HasReplyToNoteViewData(
             noteTranslationStore,
             instanceEmojis,
             noteDataSource,
+            configRepository,
             coroutineScope
         )
     }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -19,6 +19,7 @@ import net.pantasystem.milktea.model.file.FilePreviewSource
 import net.pantasystem.milktea.model.notes.*
 import net.pantasystem.milktea.model.notes.poll.Poll
 import net.pantasystem.milktea.model.notes.reaction.ReactionCount
+import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.model.url.UrlPreview
 import net.pantasystem.milktea.model.url.UrlPreviewLoadTask
 import net.pantasystem.milktea.model.user.User
@@ -31,6 +32,7 @@ open class PlaneNoteViewData(
     private val noteTranslationStore: NoteTranslationStore,
     private val instanceEmojis: List<Emoji>,
     noteDataSource: NoteDataSource,
+    configRepository: LocalConfigRepository,
     coroutineScope: CoroutineScope,
 ) : NoteViewData {
 
@@ -195,6 +197,9 @@ open class PlaneNoteViewData(
         (it.type as? Note.Type.Misskey)?.channel
     }
 
+    val isVisibleNoteDivider = configRepository.observe().map {
+        it.isEnableNoteDivider
+    }.distinctUntilChanged().asLiveData(coroutineScope.coroutineContext)
 
     fun changeContentFolding() {
         val isFolding = contentFolding.value ?: return

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -201,6 +201,10 @@ open class PlaneNoteViewData(
         it.isEnableNoteDivider
     }.distinctUntilChanged().asLiveData(coroutineScope.coroutineContext)
 
+    val isVisibleInstanceTicker = configRepository.observe().map {
+        it.isEnableInstanceTicker
+    }.distinctUntilChanged().asLiveData(coroutineScope.coroutineContext)
+
     fun changeContentFolding() {
         val isFolding = contentFolding.value ?: return
         contentFolding.value = !isFolding

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewDataCache.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewDataCache.kt
@@ -159,6 +159,7 @@ class PlaneNoteViewDataCache(
                 translationStore,
                 metaRepository.get(account.normalizedInstanceDomain)?.emojis ?: emptyList(),
                 noteDataSource,
+                configRepository,
                 coroutineScope,
             )
         } else {
@@ -169,6 +170,7 @@ class PlaneNoteViewDataCache(
                 translationStore,
                 metaRepository.get(account.normalizedInstanceDomain)?.emojis ?: emptyList(),
                 noteDataSource,
+                configRepository,
                 coroutineScope
             )
         }.also {

--- a/modules/features/note/src/main/res/layout/item_detail_note.xml
+++ b/modules/features/note/src/main/res/layout/item_detail_note.xml
@@ -502,7 +502,7 @@
             </LinearLayout>
             <View
                     android:layout_width="match_parent"
-                    android:layout_height="0.5dp"
+                    android:layout_height="@dimen/note_divider_height"
                     android:background="?android:attr/listDivider"
                     android:layout_below="@id/noteActionButtonBaseLayout"
                     android:visibility="@{ note.isVisibleNoteDivider ? View.VISIBLE : View.GONE}" />

--- a/modules/features/note/src/main/res/layout/item_detail_note.xml
+++ b/modules/features/note/src/main/res/layout/item_detail_note.xml
@@ -118,6 +118,7 @@
                     android:gravity="center_vertical"
                     android:padding="2dp"
                     instanceInfo="@{note.toShowNote.user.instance}"
+                    isEnable="@{note.isVisibleInstanceTicker}"
                     android:layout_below="@id/avatarIcon"
                     android:layout_marginTop="4dp"
                     />

--- a/modules/features/note/src/main/res/layout/item_detail_note.xml
+++ b/modules/features/note/src/main/res/layout/item_detail_note.xml
@@ -30,7 +30,6 @@
             android:layout_marginEnd="5dp"
             app:cardUseCompatPadding="false"
             app:cardCornerRadius="0dp"
-            android:layout_marginTop="0.5dp"
             android:elevation="0dp"
             app:cardBackgroundColor="?attr/colorSurface"
 
@@ -376,6 +375,7 @@
                     />
 
             <LinearLayout
+                    android:id="@+id/noteActionButtonBaseLayout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_below="@+id/reaction_view"
@@ -500,6 +500,12 @@
                         app:srcCompat="@drawable/ic_more_horiz_black_24dp"
                         app:tint="?attr/normalIconTint" />
             </LinearLayout>
+            <View
+                    android:layout_width="match_parent"
+                    android:layout_height="0.5dp"
+                    android:background="?android:attr/listDivider"
+                    android:layout_below="@id/noteActionButtonBaseLayout"
+                    android:visibility="@{ note.isVisibleNoteDivider ? View.VISIBLE : View.GONE}" />
         </RelativeLayout>
     </androidx.cardview.widget.CardView>
 

--- a/modules/features/note/src/main/res/layout/item_has_reply_to_note.xml
+++ b/modules/features/note/src/main/res/layout/item_has_reply_to_note.xml
@@ -144,7 +144,7 @@
 
             <View
                     android:layout_width="match_parent"
-                    android:layout_height="0.5dp"
+                    android:layout_height="@dimen/note_divider_height"
                     android:background="?android:attr/listDivider"
                     android:visibility="@{ hasReplyToNote.isVisibleNoteDivider ? View.VISIBLE : View.GONE}" />
         </LinearLayout>

--- a/modules/features/note/src/main/res/layout/item_has_reply_to_note.xml
+++ b/modules/features/note/src/main/res/layout/item_has_reply_to_note.xml
@@ -14,7 +14,6 @@
     <androidx.cardview.widget.CardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="0.5dp"
             app:cardUseCompatPadding="false"
             app:cardCornerRadius="0dp"
             android:elevation="0dp"
@@ -143,7 +142,11 @@
                     />
 
 
-
+            <View
+                    android:layout_width="match_parent"
+                    android:layout_height="0.5dp"
+                    android:background="?android:attr/listDivider"
+                    android:visibility="@{ hasReplyToNote.isVisibleNoteDivider ? View.VISIBLE : View.GONE}" />
         </LinearLayout>
     </androidx.cardview.widget.CardView>
 

--- a/modules/features/note/src/main/res/layout/item_note.xml
+++ b/modules/features/note/src/main/res/layout/item_note.xml
@@ -48,7 +48,7 @@
 
             <View
                     android:layout_width="match_parent"
-                    android:layout_height="0.5dp"
+                    android:layout_height="@dimen/note_divider_height"
                     android:background="?android:attr/listDivider"
                     android:visibility="@{ note.isVisibleNoteDivider ? View.VISIBLE : View.GONE}" />
         </LinearLayout>

--- a/modules/features/note/src/main/res/layout/item_note.xml
+++ b/modules/features/note/src/main/res/layout/item_note.xml
@@ -20,7 +20,6 @@
             android:layout_height="wrap_content"
             app:cardUseCompatPadding="false"
             app:cardCornerRadius="0dp"
-            android:layout_marginTop="0.5dp"
             android:elevation="0dp"
             setCardViewSurfaceColor="@{null}"
     >
@@ -47,6 +46,11 @@
                     android:visibility="@{note.isOnlyVisibleRenoteStatusMessage ? View.GONE : View.VISIBLE }"
                     />
 
+            <View
+                    android:layout_width="match_parent"
+                    android:layout_height="0.5dp"
+                    android:background="?android:attr/listDivider"
+                    android:visibility="@{ note.isVisibleNoteDivider ? View.VISIBLE : View.GONE}" />
         </LinearLayout>
     </androidx.cardview.widget.CardView>
 

--- a/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
+++ b/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
@@ -148,6 +148,7 @@
                         android:gravity="center_vertical"
                         android:padding="2dp"
                         instanceInfo="@{note.toShowNote.user.instance}"
+                        isEnable="@{note.isVisibleInstanceTicker}"
                         android:singleLine="true"
                         />
                 <TextView

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -152,6 +152,7 @@
                         android:gravity="center_vertical"
                         android:padding="2dp"
                         instanceInfo="@{note.toShowNote.user.instance}"
+                        isEnable="@{note.isVisibleInstanceTicker}"
                         android:maxLines="1"
                         />
                 <TextView

--- a/modules/features/note/src/main/res/values/dimens.xml
+++ b/modules/features/note/src/main/res/values/dimens.xml
@@ -11,4 +11,6 @@
 
     <dimen name="note_avatar_icon_size">50dp</dimen>
 
+    <dimen name="note_divider_height">0.8dp</dimen>
+
 </resources>

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
@@ -241,6 +241,18 @@ class SettingAppearanceActivity : AppCompatActivity() {
                                 modifier = Modifier.padding(horizontal = 16.dp)
                             )
 
+                            SettingTitleTile(text = stringResource(id = R.string.settings_note))
+                            SwitchTile(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp),
+                                checked = currentConfigState.isEnableNoteDivider,
+                                onChanged = {
+                                    currentConfigState = currentConfigState.copy(isEnableNoteDivider = it)
+                                }
+                            ) {
+                                Text(stringResource(id = R.string.settings_note_divider))
+                            }
                         }
 
 

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingMovementActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingMovementActivity.kt
@@ -10,14 +10,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -149,18 +147,26 @@ class SettingMovementActivity : AppCompatActivity() {
                                     .padding(horizontal = 16.dp)
                             ) {
                                 Text(text = stringResource(id = R.string.height_limit))
-                                TextField(
-                                    placeholder = { Text(text = stringResource(id = R.string.height_limit)) },
-                                    value = currentConfigState.noteExpandedHeightSize.toString(),
-                                    keyboardOptions = KeyboardOptions
-                                        .Default.copy(keyboardType = KeyboardType.Number),
-                                    onValueChange = {
-                                        currentConfigState = currentConfigState.copy(
-                                            noteExpandedHeightSize = it.toIntOrNull()
-                                                ?: DefaultConfig.config.noteExpandedHeightSize
-                                        )
+                                Slider(
+                                    value = currentConfigState.noteExpandedHeightSize.let {
+                                        val v =
+                                            currentConfigState.noteExpandedHeightSize.toFloat() / 1000f
+                                        if (it in 0..1000) {
+                                            v
+                                        } else {
+                                            1f
+                                        }
                                     },
-                                    modifier = Modifier.fillMaxWidth()
+                                    onValueChange = {
+                                        val v = (it * 1000f).toInt()
+                                        currentConfigState = currentConfigState.copy(
+                                            noteExpandedHeightSize = if (v > 50) {
+                                                v
+                                            } else 50
+                                        )
+
+                                    },
+                                    modifier = Modifier.fillMaxWidth(),
                                 )
                             }
                         }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
@@ -47,6 +47,7 @@ data class IsAnalyticsCollectionEnabled(
  * @param isStopNoteCaptureWhenBackground バックグラウンド移行時にノートのキャプチャーを停止する
  * @param isStopStreamingApiWhenBackground バックグルアンド移行時にストリーミングを中止する
  * @param isEnableStreamingAPIAndNoteCapture 自動更新のON/OFF
+ * @Param isEnableNoteDivider ノートの区切り線の有無 trueで有り falseで無し
  */
 data class Config(
     val isSimpleEditorEnabled: Boolean,
@@ -71,6 +72,7 @@ data class Config(
     val isStopStreamingApiWhenBackground: Boolean,
     val isStopNoteCaptureWhenBackground: Boolean,
     val isEnableStreamingAPIAndNoteCapture: Boolean,
+    val isEnableNoteDivider: Boolean,
 ) {
     companion object
 
@@ -123,6 +125,7 @@ object DefaultConfig {
         isStopNoteCaptureWhenBackground = true,
         isStopStreamingApiWhenBackground = true,
         isEnableStreamingAPIAndNoteCapture = true,
+        isEnableNoteDivider = true
     )
 
     fun getRememberVisibilityConfig(accountId: Long): RememberVisibility.Remember {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
@@ -26,6 +26,7 @@ val Keys.Companion.allKeys by lazy {
         Keys.IsStopStreamingApiWhenBackground,
         Keys.IsStopNoteCaptureWhenBackground,
         Keys.IsEnableStreamingAPIAndNoteCapture,
+        Keys.IsEnableNoteDivider
     )
 }
 
@@ -73,6 +74,8 @@ sealed interface Keys {
 
     object IsEnableStreamingAPIAndNoteCapture : Keys
 
+    object IsEnableNoteDivider: Keys
+
     companion object
 }
 
@@ -102,5 +105,6 @@ fun Keys.str(): String {
         is Keys.IsStopNoteCaptureWhenBackground -> "IsStopNoteCaptureWhenBackground"
         is Keys.IsStopStreamingApiWhenBackground -> "IsStopStreamingApiWhenBackground"
         is Keys.IsEnableStreamingAPIAndNoteCapture -> "IsEnableStreamingAPIAndNoteCapture"
+        is Keys.IsEnableNoteDivider -> "IsEnableNoteDivider"
     }
 }


### PR DESCRIPTION
## やったこと
ノートの区切り線の有無を設定から変えられるようにしました。
またそのために設定を表現するオブジェクトに有無の状態を合わすフィールドを追加し、
それをSharedPreferencesに保存するためのロジックの実装を行いました。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1412 


