### PR TITLE
OGP画像読み込みエラー発生時はエラー画像を表示するように

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/url/UrlPreviewHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/url/UrlPreviewHelper.kt
@@ -6,6 +6,7 @@ import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.viewmodel.Preview
 
 object UrlPreviewHelper {
@@ -36,19 +37,19 @@ object UrlPreviewHelper {
     @JvmStatic
     @BindingAdapter("urlPreviewThumbnailUrl")
     fun ImageView.setUrlPreviewThumbnail(url: String?){
-        url?: return
         Glide.with(this)
             .load(url)
             .centerCrop()
+            .error(R.drawable.ic_cloud_off_black_24dp)
             .into(this)
     }
 
     @JvmStatic
     @BindingAdapter("siteIconUrl")
     fun ImageView.setSiteIcon(url: String?){
-        url?: return
         Glide.with(this)
             .load(url)
+            .error(R.drawable.ic_cloud_off_black_24dp)
             .centerCrop()
             .into(this)
     }


### PR DESCRIPTION
## やったこと
urlがnullの場合はImageViewの更新がスキップされてしまい
前回表示した画像が表示されてしまっていた。
そこでnullの時もそのまま読み込みを続行し
エラーが発生した時はエラー画像を表示するようにした

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1426 