### PR TITLE
横長カスタム絵文字を比率を維持して表示できるようにした

### DIFF
--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/CustomEmojiDecorator.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/CustomEmojiDecorator.kt
@@ -33,7 +33,7 @@ class CustomEmojiDecorator {
         result.emojis.filter {
             HostWithVersion.isOverV13(accountHost)  || it.result is EmojiResolvedType.Resolved
         }.map {
-            val span = DrawableEmojiSpan(emojiAdapter)
+            val span = DrawableEmojiSpan(emojiAdapter, it.result.getUrl(accountHost))
             GlideApp.with(view)
                 .asDrawable()
                 .load(it.result.getUrl(accountHost))
@@ -54,7 +54,7 @@ class CustomEmojiDecorator {
         result.emojis.filter {
             HostWithVersion.isOverV13(accountHost) || it.result is EmojiResolvedType.Resolved
         }.map {
-            val span = DrawableEmojiSpan(emojiAdapter)
+            val span = DrawableEmojiSpan(emojiAdapter, it.result.getUrl(accountHost))
             GlideApp.with(view)
                 .asDrawable()
                 .override(min(view.textSize.toInt(), 640))
@@ -75,7 +75,7 @@ class CustomEmojiDecorator {
         result.emojis.filter {
             HostWithVersion.isOverV13(accountHost) || it.result is EmojiResolvedType.Resolved
         }.map {
-            val span = DrawableEmojiSpan(emojiAdapter)
+            val span = DrawableEmojiSpan(emojiAdapter, it.result.getUrl(accountHost))
             GlideApp.with(view)
                 .asDrawable()
                 .load(it.result.getUrl(accountHost))

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DateFormatHelper.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DateFormatHelper.kt
@@ -70,7 +70,7 @@ object DateFormatHelper {
             SpannableStringBuilder(target).apply {
                 val drawable = ContextCompat.getDrawable(context, visibilityIcon)
                 drawable?.setTint(currentTextColor)
-                val span = DrawableEmojiSpan(EmojiAdapter(this@setElapsedTimeAndVisibility))
+                val span = DrawableEmojiSpan(EmojiAdapter(this@setElapsedTimeAndVisibility), visibilityIcon)
                 setSpan(span, text.length + 1, target.length,0)
                 GlideApp.with(this@setElapsedTimeAndVisibility)
                     .load(drawable)

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DrawableEmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DrawableEmojiSpan.kt
@@ -9,7 +9,7 @@ import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 import com.github.penfeizhou.animation.apng.APNGDrawable
 
-class DrawableEmojiSpan(var adapter: EmojiAdapter?) : EmojiSpan<Drawable>(){
+class DrawableEmojiSpan(var adapter: EmojiAdapter?, k: Any?) : EmojiSpan<Any?>(k){
     //val weakReference: WeakReference<View> = WeakReference(view)
 
 

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DrawableEmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DrawableEmojiSpan.kt
@@ -86,7 +86,7 @@ private class DrawableEmojiTarget(
         resource.callback = object : Drawable.Callback {
             override fun invalidateDrawable(who: Drawable) {
                 callback?.invalidateDrawable(who)
-                span.adapter?.update()
+                span.adapter?.update(false)
             }
 
             override fun scheduleDrawable(who: Drawable, what: Runnable, `when`: Long) {

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiAdapter.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiAdapter.kt
@@ -9,9 +9,9 @@ class EmojiAdapter (view: View){
 
     private  var beforeExecute: Long = System.nanoTime()
 
-    fun update(){
+    fun update(invalidateForce: Boolean = true){
         val now = System.nanoTime()
-        if ((now - beforeExecute) > 60000) {
+        if ((now - beforeExecute) > 60000 || invalidateForce) {
             weakReference.get()?.invalidate()
 
         }

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
@@ -140,15 +140,17 @@ abstract class EmojiSpan<T: Any?>(val key: T) : ReplacementSpan(){
 
         val unknownEmojiSize = imageWidth <= 0 || imageHeight <= 0
         if (beforeTextSize != 0 && beforeTextSize != emojiHeight || unknownEmojiSize) {
-            beforeTextSize = emojiHeight
-            imageDrawable?.setBounds(0, 0, emojiHeight, emojiHeight)
+            if (!isSizeComputed) {
+                beforeTextSize = emojiHeight
+                imageDrawable?.setBounds(0, 0, emojiHeight, emojiHeight)
+                isSizeComputed = true
+            }
             return
         }
 
         val ratio = imageWidth.toFloat() / imageHeight.toFloat()
 
         val scaledImageWidth = (emojiHeight * ratio).toInt()
-
 
         if (!isSizeComputed) {
             textHeight = emojiHeight

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
@@ -119,13 +119,13 @@ abstract class EmojiSpan<T : Any> : ReplacementSpan(){
 
         val ratio = imageWidth.toFloat() / imageHeight.toFloat()
 
-        val width = (emojiHeight * ratio).toInt()
+        val scaledImageWidth = (emojiHeight * ratio).toInt()
 
 
-        if (width != textWidth || emojiHeight != textHeight) {
+        if (scaledImageWidth != textWidth || emojiHeight != textHeight) {
             textHeight = emojiHeight
-            textWidth = width
-            imageDrawable?.setBounds(0, 0, width, emojiHeight)
+            textWidth = scaledImageWidth
+            imageDrawable?.setBounds(0, 0, scaledImageWidth, emojiHeight)
         }
     }
 

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
@@ -35,13 +35,13 @@ abstract class EmojiSpan<T : Any> : ReplacementSpan(){
         }
         beforeTextSize = 0
 
-        val textHeight = paint.fontMetricsInt.bottom - paint.fontMetricsInt.top
+        val textHeight = paint.textSize
         val imageWidth = drawable.intrinsicWidth
         val imageHeight = drawable.intrinsicHeight
 
         // 画像がテキストの高さよりも大きい場合、画像をテキストと同じ高さに縮小する
-        val ratio = if (imageHeight > textHeight) {
-            textHeight.toFloat() / imageHeight.toFloat()
+        val scale = if (imageHeight > textHeight) {
+            textHeight / imageHeight.toFloat()
         } else {
             1.0f
         }
@@ -54,12 +54,12 @@ abstract class EmojiSpan<T : Any> : ReplacementSpan(){
             fm.bottom = metrics.bottom
         }
 
-        val scaledImageWidth = (imageWidth * ratio).toInt()
+        val scaledImageWidth = (imageWidth * scale).toInt()
 
         // テキストの高さに合わせた画像の幅
         val availableWidth = paint.measureText(text, start, end)
         return if (scaledImageWidth > availableWidth) {
-            (availableWidth / ratio).toInt()
+            (availableWidth / scale).toInt()
         } else {
             scaledImageWidth
         }

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
@@ -40,7 +40,7 @@ abstract class EmojiSpan<T : Any> : ReplacementSpan(){
         val imageHeight = drawable.intrinsicHeight
 
         // 画像がテキストの高さよりも大きい場合、画像をテキストと同じ高さに縮小する
-        val scale = if (imageHeight > textHeight) {
+        val ratio = if (imageHeight > textHeight) {
             textHeight.toFloat() / imageHeight.toFloat()
         } else {
             1.0f
@@ -54,12 +54,12 @@ abstract class EmojiSpan<T : Any> : ReplacementSpan(){
             fm.bottom = metrics.bottom
         }
 
-        val scaledImageWidth = (imageWidth * scale).toInt()
+        val scaledImageWidth = (imageWidth * ratio).toInt()
 
         // テキストの高さに合わせた画像の幅
         val availableWidth = paint.measureText(text, start, end)
         return if (scaledImageWidth > availableWidth) {
-            (availableWidth / scale).toInt()
+            (availableWidth / ratio).toInt()
         } else {
             scaledImageWidth
         }
@@ -92,38 +92,17 @@ abstract class EmojiSpan<T : Any> : ReplacementSpan(){
         canvas.translate(x, transY)
         drawable.draw(canvas)
         canvas.restore()
-//        val drawable = imageDrawable
-//        drawable ?: return
-//
-//        canvas.save()
-//
-//        updateImageDrawableSize(paint)
-//
-//        val textHeight = paint.fontMetricsInt.bottom - paint.fontMetricsInt.top
-//        val imageHeight = drawable.bounds.height()
-//
-//        // 画像がテキストの高さよりも大きい場合、画像をテキストと同じ高さに縮小する
-//        val scale = if (imageHeight > textHeight) {
-//            textHeight.toFloat() / imageHeight.toFloat()
-//        } else {
-//            1.0f
-//        }
-//
-//        canvas.translate(x, y + paint.fontMetricsInt.top + ((textHeight - imageHeight * scale) / 2))
-//        canvas.scale(scale, scale)
-//        drawable.draw(canvas)
-//
-//        canvas.restore()
+
     }
 
 
     private fun updateImageDrawableSize(paint: Paint) {
         val drawable = imageDrawable ?: return
-        val intrinsicWidth = drawable.intrinsicWidth
-        val intrinsicHeight = drawable.intrinsicHeight
+        val imageWidth = drawable.intrinsicWidth
+        val imageHeight = drawable.intrinsicHeight
         val emojiHeight = min((paint.textSize).toInt(), 640)
 
-        if (intrinsicWidth <= 0 || intrinsicHeight <= 0) {
+        if (imageWidth <= 0 || imageHeight <= 0) {
             if (beforeTextSize != 0 && beforeTextSize != emojiHeight) {
                 beforeTextSize = emojiHeight
                 imageDrawable?.setBounds(0, 0, emojiHeight, emojiHeight)
@@ -138,7 +117,7 @@ abstract class EmojiSpan<T : Any> : ReplacementSpan(){
             return
         }
 
-        val ratio = intrinsicWidth.toFloat() / intrinsicHeight.toFloat()
+        val ratio = imageWidth.toFloat() / imageHeight.toFloat()
 
         val width = (emojiHeight * ratio).toInt()
 

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
@@ -30,7 +30,7 @@ abstract class EmojiSpan<T : Any> : ReplacementSpan(){
 
     override fun getSize(paint: Paint, text: CharSequence?, start: Int, end: Int, fm: Paint.FontMetricsInt?): Int {
         val drawable = imageDrawable
-        if (drawable == null) {
+        if (drawable == null || beforeTextSize != 0) {
             beforeTextSize = (paint.textSize * 1.2).toInt()
             return beforeTextSize
         }

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
@@ -82,29 +82,38 @@ abstract class EmojiSpan<T : Any> : ReplacementSpan(){
         bottom: Int,
         paint: Paint
     ) {
-
         val drawable = imageDrawable
-        drawable ?: return
+        drawable?: return
 
         canvas.save()
-
         updateImageDrawableSize(paint)
-
-        val textHeight = paint.fontMetricsInt.bottom - paint.fontMetricsInt.top
-        val imageHeight = drawable.bounds.height()
-
-        // 画像がテキストの高さよりも大きい場合、画像をテキストと同じ高さに縮小する
-        val scale = if (imageHeight > textHeight) {
-            textHeight.toFloat() / imageHeight.toFloat()
-        } else {
-            1.0f
-        }
-
-        canvas.translate(x, y + paint.fontMetricsInt.top + ((textHeight - imageHeight * scale) / 2))
-        canvas.scale(scale, scale)
+        var transY = (bottom - drawable.bounds.bottom).toFloat()
+        transY -= paint.fontMetrics.descent / 2
+        canvas.translate(x, transY)
         drawable.draw(canvas)
-
         canvas.restore()
+//        val drawable = imageDrawable
+//        drawable ?: return
+//
+//        canvas.save()
+//
+//        updateImageDrawableSize(paint)
+//
+//        val textHeight = paint.fontMetricsInt.bottom - paint.fontMetricsInt.top
+//        val imageHeight = drawable.bounds.height()
+//
+//        // 画像がテキストの高さよりも大きい場合、画像をテキストと同じ高さに縮小する
+//        val scale = if (imageHeight > textHeight) {
+//            textHeight.toFloat() / imageHeight.toFloat()
+//        } else {
+//            1.0f
+//        }
+//
+//        canvas.translate(x, y + paint.fontMetricsInt.top + ((textHeight - imageHeight * scale) / 2))
+//        canvas.scale(scale, scale)
+//        drawable.draw(canvas)
+//
+//        canvas.restore()
     }
 
 
@@ -112,22 +121,32 @@ abstract class EmojiSpan<T : Any> : ReplacementSpan(){
         val drawable = imageDrawable ?: return
         val intrinsicWidth = drawable.intrinsicWidth
         val intrinsicHeight = drawable.intrinsicHeight
+        val emojiHeight = min((paint.textSize).toInt(), 640)
+
         if (intrinsicWidth <= 0 || intrinsicHeight <= 0) {
-            return
-        }
-        val ratio = intrinsicWidth.toFloat() / intrinsicHeight.toFloat()
-        val emojiSize = min((paint.textSize).toInt(), 640)
-        val width = (emojiSize * ratio).toInt()
-        if (beforeTextSize != 0 && beforeTextSize != emojiSize) {
-            beforeTextSize = emojiSize
-            imageDrawable?.setBounds(0, 0, emojiSize, emojiSize)
+            if (beforeTextSize != 0 && beforeTextSize != emojiHeight) {
+                beforeTextSize = emojiHeight
+                imageDrawable?.setBounds(0, 0, emojiHeight, emojiHeight)
+                return
+            }
             return
         }
 
-        if (width != textWidth || emojiSize != textHeight) {
-            textHeight = emojiSize
+        if (beforeTextSize != 0 && beforeTextSize != emojiHeight) {
+            beforeTextSize = emojiHeight
+            imageDrawable?.setBounds(0, 0, emojiHeight, emojiHeight)
+            return
+        }
+
+        val ratio = intrinsicWidth.toFloat() / intrinsicHeight.toFloat()
+
+        val width = (emojiHeight * ratio).toInt()
+
+
+        if (width != textWidth || emojiHeight != textHeight) {
+            textHeight = emojiHeight
             textWidth = width
-            imageDrawable?.setBounds(0, 0, width, emojiSize)
+            imageDrawable?.setBounds(0, 0, width, emojiHeight)
         }
     }
 

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
@@ -19,6 +19,7 @@ abstract class EmojiSpan<T : Any> : ReplacementSpan(){
      */
     private var textHeight: Int = 0
     private var textWidth: Int = 0
+    private var isSizeComputed = false
 
     /**
      * imageDrawableがnullの時にupdateImageDrawableSizeが呼び出されるとここに絵文字のサイズが代入される
@@ -102,16 +103,8 @@ abstract class EmojiSpan<T : Any> : ReplacementSpan(){
         val imageHeight = drawable.intrinsicHeight
         val emojiHeight = min((paint.textSize).toInt(), 640)
 
-        if (imageWidth <= 0 || imageHeight <= 0) {
-            if (beforeTextSize != 0 && beforeTextSize != emojiHeight) {
-                beforeTextSize = emojiHeight
-                imageDrawable?.setBounds(0, 0, emojiHeight, emojiHeight)
-                return
-            }
-            return
-        }
-
-        if (beforeTextSize != 0 && beforeTextSize != emojiHeight) {
+        val unknownEmojiSize = imageWidth <= 0 || imageHeight <= 0
+        if (beforeTextSize != 0 && beforeTextSize != emojiHeight || unknownEmojiSize) {
             beforeTextSize = emojiHeight
             imageDrawable?.setBounds(0, 0, emojiHeight, emojiHeight)
             return
@@ -122,9 +115,10 @@ abstract class EmojiSpan<T : Any> : ReplacementSpan(){
         val scaledImageWidth = (emojiHeight * ratio).toInt()
 
 
-        if (scaledImageWidth != textWidth || emojiHeight != textHeight) {
+        if (!isSizeComputed) {
             textHeight = emojiHeight
             textWidth = scaledImageWidth
+            isSizeComputed = true
             imageDrawable?.setBounds(0, 0, scaledImageWidth, emojiHeight)
         }
     }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
@@ -308,7 +308,7 @@ object MFMDecorator {
                 return
             }
             textView.get()?.let { textView ->
-                val emojiSpan = DrawableEmojiSpan(emojiAdapter)
+                val emojiSpan = DrawableEmojiSpan(emojiAdapter, emojiElement.emoji.url)
                 spannableString.setSpan(emojiSpan, skippedEmoji.start, skippedEmoji.end, 0)
                 GlideApp.with(textView)
                     .load(emojiElement.emoji.url)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/InstanceInfoHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/InstanceInfoHelper.kt
@@ -27,7 +27,7 @@ object InstanceInfoHelper {
         if (enable) {
             val emojiAdapter = EmojiAdapter(this)
 
-            val iconDrawable = DrawableEmojiSpan(emojiAdapter)
+            val iconDrawable = DrawableEmojiSpan(emojiAdapter, info?.faviconUrl)
             Glide.with(this)
                 .load(info!!.faviconUrl)
                 .override(min(this.textSize.toInt(), 640))

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/StatusMessageHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/StatusMessageHelper.kt
@@ -59,7 +59,7 @@ object StatusMessageHelper {
         this.text = if (icon != null) {
             SpannableStringBuilder(text).apply {
                 insert(0, "icon")
-                val span = DrawableEmojiSpan(EmojiAdapter(this@setStatusMessage))
+                val span = DrawableEmojiSpan(EmojiAdapter(this@setStatusMessage), icon)
                 val drawable = ContextCompat.getDrawable(context, icon)
                 drawable?.setTint(currentTextColor)
                 Glide.with(context)

--- a/modules/features/note/src/main/res/layout/item_detail_note.xml
+++ b/modules/features/note/src/main/res/layout/item_detail_note.xml
@@ -155,7 +155,7 @@
 
                 <TextView
                         android:id="@id/text"
-                        android:layout_width="wrap_content"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:textSize="15sp"
                         android:visibility='@{note.text == null ? View.GONE : View.VISIBLE}'

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -188,7 +188,7 @@
 
                     <TextView
                             android:id="@id/text"
-                            android:layout_width="wrap_content"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:textSize="15sp"
                             textTypeSource="@{note.textNode}"


### PR DESCRIPTION
## やったこと
横長カスタム絵文字を比率を維持したまま表示できるようにしました。
ただし下記懸念と不具合がまだ残っています。
- パフォーマンス的な問題
  - 即座にサイズを確定することができないので、レンダリング的に不利になる可能性がある
- 一部絵文字が正常に表示されないケースがある 
  - 一部絵文字が表示されなかったり（RecyclerViewの場合スクロールすると改善する）
  - 一部絵文字がはみ出て表示される。ただし同じような横長絵文字でもはみ出るものとはみ出ないものがある 

## 動作確認


## スクリーンショット(任意)


## 備考
パフォーマンス的な問題が頻発する場合は
ユーザ名の表示を1:1で表示したり、
設定のオプションで固定比率表示を選択できるようにする。

## Issue番号
Closed #1444 



