### PR TITLE
誕生日が変な値の時で例外が出る時は誕生日フィールドのデコードをスキップするようにした

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/UserDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/UserDTO.kt
@@ -53,6 +53,7 @@ data class UserDTO(
     val instance: InstanceInfo? = null,
     val fields: List<FieldDTO>? = null,
 
+    @kotlinx.serialization.Transient
     val birthday: LocalDate? = null,
 
     val createdAt: Instant? = null,


### PR DESCRIPTION
## やったこと


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1453 


