### PR TITLE
カスタム絵文字がはみ出て描画される問題を修正

### DIFF
--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
@@ -31,11 +31,17 @@ abstract class EmojiSpan<T: Any?>(val key: T) : ReplacementSpan(){
     private var beforeTextSize: Int = 0
 
 
-    override fun getSize(paint: Paint, text: CharSequence?, start: Int, end: Int, fm: Paint.FontMetricsInt?): Int {
+    override fun getSize(
+        paint: Paint,
+        text: CharSequence?,
+        start: Int,
+        end: Int,
+        fm: Paint.FontMetricsInt?
+    ): Int {
         val drawable = imageDrawable
         val size = key?.let {
             drawableSizeCache[key]
-        }?: drawable?.let {
+        } ?: drawable?.let {
             EmojiSizeCache(
                 intrinsicHeight = it.intrinsicHeight,
                 intrinsicWidth = it.intrinsicWidth
@@ -50,7 +56,7 @@ abstract class EmojiSpan<T: Any?>(val key: T) : ReplacementSpan(){
             }
         }
         val metrics = paint.fontMetricsInt
-        if(fm != null){
+        if (fm != null) {
             fm.top = metrics.top
             fm.ascent = metrics.ascent
             fm.descent = metrics.descent
@@ -78,15 +84,8 @@ abstract class EmojiSpan<T: Any?>(val key: T) : ReplacementSpan(){
             1.0f
         }
 
-        val scaledImageWidth = (imageWidth * scale).toInt()
-
         // テキストの高さに合わせた画像の幅
-        val availableWidth = paint.measureText(text, start, end)
-        return if (scaledImageWidth > availableWidth) {
-            (availableWidth / scale).toInt()
-        } else {
-            scaledImageWidth
-        }
+        return (imageWidth * scale).toInt()
     }
 
     override fun updateDrawState(ds: TextPaint) {


### PR DESCRIPTION
## やったこと
getSizeで返される値と設定される値の実態が異なることが原因でした

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



