### PR TITLE
モバイル回線時にメディアの画像を表示しないオプションを追加しました

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/infos/InstanceInfosResponse.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/infos/InstanceInfosResponse.kt
@@ -27,7 +27,7 @@ data class InstanceInfosResponse(
         @SerialName("nodeinfo") val nodeInfo: NodeInfoDTO,
         val name: String,
         val description: String? = null,
-        val langs: List<String>,
+//        val langs: Map<String, String?>,
         val isAlive: Boolean,
         val banner: Boolean,
         val icon: Boolean,

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/platform/NetworkStatusUtil.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/platform/NetworkStatusUtil.kt
@@ -1,0 +1,20 @@
+package net.pantasystem.milktea.common_android.platform
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+
+@Suppress("DEPRECATION")
+fun Context.isWifiConnected(): Boolean {
+    val connectivityManager = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        val network = connectivityManager.activeNetwork
+        val capabilities = connectivityManager.getNetworkCapabilities(network)
+        capabilities != null && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+    } else {
+        val networkInfo = connectivityManager.activeNetworkInfo
+        networkInfo != null && networkInfo.isConnected && networkInfo.type == ConnectivityManager.TYPE_WIFI
+    }
+}

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -453,6 +453,8 @@
 
     <string name="note_editor_poll_choice_n">候補%d</string>
     <string name="settings_visible_instance_domain_in_toolbar">ツールバーにインスタンスのドメインを表示する</string>
+    <string name="settings_hide_media_when_mobile_network">モバイル ネットワーク時にメディアを非表示にする</string>
+
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -454,7 +454,7 @@
     <string name="note_editor_poll_choice_n">候補%d</string>
     <string name="settings_visible_instance_domain_in_toolbar">ツールバーにインスタンスのドメインを表示する</string>
     <string name="settings_hide_media_when_mobile_network">モバイル ネットワーク時にメディアを非表示にする</string>
-
+    <string name="notes_media_click_to_load_image">クリックして画像を読み込み</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -451,6 +451,7 @@
     <string name="note_editor_poll_choice_n">选择%d</string>
     <string name="settings_visible_instance_domain_in_toolbar">在工具栏中显示实例的域</string>
     <string name="settings_hide_media_when_mobile_network">移动网络时隐藏媒体</string>
+    <string name="notes_media_click_to_load_image">点击加载图片</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -450,6 +450,7 @@
 
     <string name="note_editor_poll_choice_n">选择%d</string>
     <string name="settings_visible_instance_domain_in_toolbar">在工具栏中显示实例的域</string>
+    <string name="settings_hide_media_when_mobile_network">移动网络时隐藏媒体</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -445,5 +445,6 @@
     <string name="note_editor_poll_choice_n">Choice %d</string>
     <string name="settings_visible_instance_domain_in_toolbar">Show the instance\'s domain in the toolbar</string>
     <string name="settings_hide_media_when_mobile_network">Hide media when mobile network</string>
+    <string name="notes_media_click_to_load_image">Click to load Image</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -444,5 +444,6 @@
 
     <string name="note_editor_poll_choice_n">Choice %d</string>
     <string name="settings_visible_instance_domain_in_toolbar">Show the instance\'s domain in the toolbar</string>
+    <string name="settings_hide_media_when_mobile_network">Hide media when mobile network</string>
 
 </resources>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
@@ -114,7 +114,10 @@ fun Config.Companion.from(map: Map<Keys, PrefType?>): Config {
         )?.value ?: DefaultConfig.config.isEnableNoteDivider,
         isVisibleInstanceUrlInToolbar = map.getValue<PrefType.BoolPref>(
             Keys.IsVisibleInstanceUrlInToolbar
-        )?.value ?: DefaultConfig.config.isVisibleInstanceUrlInToolbar
+        )?.value ?: DefaultConfig.config.isVisibleInstanceUrlInToolbar,
+        isHideMediaWhenMobileNetwork = map.getValue<PrefType.BoolPref>(
+            Keys.IsHideMediaWhenMobileNetwork
+        )?.value ?: DefaultConfig.config.isHideMediaWhenMobileNetwork
     )
 }
 
@@ -207,6 +210,9 @@ fun Config.pref(key: Keys): PrefType {
         }
         Keys.IsVisibleInstanceUrlInToolbar -> {
             PrefType.BoolPref(isVisibleInstanceUrlInToolbar)
+        }
+        Keys.IsHideMediaWhenMobileNetwork -> {
+            PrefType.BoolPref(isHideMediaWhenMobileNetwork)
         }
     }
 }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
@@ -135,6 +135,10 @@ class ConfigKtTest {
                     config.isVisibleInstanceUrlInToolbar,
                     (u as PrefType.BoolPref).value
                 )
+                Keys.IsHideMediaWhenMobileNetwork -> Assertions.assertEquals(
+                    config.isHideMediaWhenMobileNetwork,
+                    (u as PrefType.BoolPref).value
+                )
             }
         }
     }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
@@ -96,6 +96,10 @@ class KeysKtTest {
                     "IsVisibleInstanceUrlInToolbar",
                     key.str()
                 )
+                Keys.IsHideMediaWhenMobileNetwork -> Assertions.assertEquals(
+                    "IsHideMediaWhenMobileNetwork",
+                    key.str()
+                )
             }
         }
     }
@@ -103,8 +107,8 @@ class KeysKtTest {
 
     @Test
     fun checkAllKeysCount() {
-        Assertions.assertEquals(26, Keys.allKeys.size)
-        Assertions.assertEquals(26, Keys.allKeys.map { it.str() }.toSet().size)
+        Assertions.assertEquals(27, Keys.allKeys.size)
+        Assertions.assertEquals(27, Keys.allKeys.map { it.str() }.toSet().size)
     }
 
 

--- a/modules/features/note/src/main/AndroidManifest.xml
+++ b/modules/features/note/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-        package="net.pantasystem.milktea.note">
+<manifest package="net.pantasystem.milktea.note"
+        xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
 </manifest>

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/MediaPreviewHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/MediaPreviewHelper.kt
@@ -1,6 +1,7 @@
 
 package net.pantasystem.milktea.note.media
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.view.View
 import android.widget.FrameLayout
@@ -18,6 +19,7 @@ import dagger.hilt.android.internal.managers.FragmentComponentManager
 import jp.wasabeef.glide.transformations.BlurTransformation
 import net.pantasystem.milktea.common.glide.GlideApp
 import net.pantasystem.milktea.common.glide.blurhash.BlurHashSource
+import net.pantasystem.milktea.common_android.platform.isWifiConnected
 import net.pantasystem.milktea.common_android_ui.NavigationEntryPointForBinding
 import net.pantasystem.milktea.common_navigation.MediaNavigationArgs
 import net.pantasystem.milktea.note.media.viewmodel.MediaViewData
@@ -93,11 +95,19 @@ object MediaPreviewHelper {
         }
     }
 
+    @SuppressLint("MissingPermission")
     @BindingAdapter("thumbnailView")
     @JvmStatic
     fun ImageView.setPreview(file: PreviewAbleFile?) {
         file ?: return
-        if (file.isHiding) {
+        val isHiding = when(file.visibleType) {
+            PreviewAbleFile.VisibleType.Visible -> false
+            PreviewAbleFile.VisibleType.Fixed -> {
+                !context.isWifiConnected()
+            }
+            PreviewAbleFile.VisibleType.SensitiveHide -> true
+        }
+        if (isHiding) {
             Glide.with(this)
                 .let {
                     when (val blurhash = file.source.blurhash) {
@@ -157,3 +167,5 @@ object MediaPreviewHelper {
 
 
 }
+
+

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewData.kt
@@ -5,8 +5,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import net.pantasystem.milktea.model.file.FilePreviewSource
 import net.pantasystem.milktea.model.file.isSensitive
+import net.pantasystem.milktea.model.setting.Config
 
-class MediaViewData(files: List<FilePreviewSource>) {
+class MediaViewData(files: List<FilePreviewSource>, val config: Config?) {
 
     // NOTE: サイズが変わることは決してない
     private val _files = MutableLiveData(files.map{

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewData.kt
@@ -10,7 +10,7 @@ class MediaViewData(files: List<FilePreviewSource>) {
 
     // NOTE: サイズが変わることは決してない
     private val _files = MutableLiveData(files.map{
-        PreviewAbleFile(it, it.isSensitive)
+        PreviewAbleFile(it, if (it.isSensitive) PreviewAbleFile.VisibleType.SensitiveHide else PreviewAbleFile.VisibleType.Visible)
     })
     val files: LiveData<List<PreviewAbleFile>> = _files
 
@@ -37,7 +37,7 @@ class MediaViewData(files: List<FilePreviewSource>) {
         val list = (_files.value ?: emptyList()).toMutableList()
         _files.value = list.mapIndexed { i, previewAbleFile ->
             if (i == index) {
-                previewAbleFile.copy(isHiding = false)
+                previewAbleFile.copy(visibleType = PreviewAbleFile.VisibleType.Visible)
             } else {
                 previewAbleFile
             }
@@ -48,7 +48,13 @@ class MediaViewData(files: List<FilePreviewSource>) {
         val list = (_files.value ?: emptyList()).toMutableList()
         _files.value = list.mapIndexed { i, previewAbleFile ->
             if (i == index) {
-                previewAbleFile.copy(isHiding = !previewAbleFile.isHiding)
+                previewAbleFile.copy(
+                    visibleType = when(val type = previewAbleFile.visibleType) {
+                        PreviewAbleFile.VisibleType.Visible -> if (previewAbleFile.initialVisibleType == type) PreviewAbleFile.VisibleType.SensitiveHide else previewAbleFile.initialVisibleType
+                        PreviewAbleFile.VisibleType.Hide -> if (previewAbleFile.initialVisibleType == type) PreviewAbleFile.VisibleType.Visible else previewAbleFile.initialVisibleType
+                        PreviewAbleFile.VisibleType.SensitiveHide -> if (previewAbleFile.initialVisibleType == type) PreviewAbleFile.VisibleType.Visible else previewAbleFile.initialVisibleType
+                    }
+                )
             } else {
                 previewAbleFile
             }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewData.kt
@@ -10,7 +10,7 @@ class MediaViewData(files: List<FilePreviewSource>) {
 
     // NOTE: サイズが変わることは決してない
     private val _files = MutableLiveData(files.map{
-        PreviewAbleFile(it, if (it.isSensitive) PreviewAbleFile.VisibleType.SensitiveHide else PreviewAbleFile.VisibleType.Visible)
+        PreviewAbleFile(it, if (it.isSensitive) PreviewAbleFile.VisibleType.SensitiveHide else PreviewAbleFile.VisibleType.Fixed)
     })
     val files: LiveData<List<PreviewAbleFile>> = _files
 
@@ -49,10 +49,10 @@ class MediaViewData(files: List<FilePreviewSource>) {
         _files.value = list.mapIndexed { i, previewAbleFile ->
             if (i == index) {
                 previewAbleFile.copy(
-                    visibleType = when(val type = previewAbleFile.visibleType) {
-                        PreviewAbleFile.VisibleType.Visible -> if (previewAbleFile.initialVisibleType == type) PreviewAbleFile.VisibleType.SensitiveHide else previewAbleFile.initialVisibleType
-                        PreviewAbleFile.VisibleType.Hide -> if (previewAbleFile.initialVisibleType == type) PreviewAbleFile.VisibleType.Visible else previewAbleFile.initialVisibleType
-                        PreviewAbleFile.VisibleType.SensitiveHide -> if (previewAbleFile.initialVisibleType == type) PreviewAbleFile.VisibleType.Visible else previewAbleFile.initialVisibleType
+                    visibleType = when(previewAbleFile.visibleType) {
+                        PreviewAbleFile.VisibleType.Visible -> PreviewAbleFile.VisibleType.SensitiveHide
+                        PreviewAbleFile.VisibleType.Fixed -> PreviewAbleFile.VisibleType.Visible
+                        PreviewAbleFile.VisibleType.SensitiveHide -> PreviewAbleFile.VisibleType.Visible
                     }
                 )
             } else {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewData.kt
@@ -11,7 +11,7 @@ class MediaViewData(files: List<FilePreviewSource>, val config: Config?) {
 
     // NOTE: サイズが変わることは決してない
     private val _files = MutableLiveData(files.map{
-        PreviewAbleFile(it, if (it.isSensitive) PreviewAbleFile.VisibleType.SensitiveHide else PreviewAbleFile.VisibleType.Fixed)
+        PreviewAbleFile(it, if (it.isSensitive) PreviewAbleFile.VisibleType.SensitiveHide else if (config?.isHideMediaWhenMobileNetwork == true) PreviewAbleFile.VisibleType.HideWhenMobileNetwork else PreviewAbleFile.VisibleType.Visible)
     })
     val files: LiveData<List<PreviewAbleFile>> = _files
 
@@ -52,7 +52,7 @@ class MediaViewData(files: List<FilePreviewSource>, val config: Config?) {
                 previewAbleFile.copy(
                     visibleType = when(previewAbleFile.visibleType) {
                         PreviewAbleFile.VisibleType.Visible -> PreviewAbleFile.VisibleType.SensitiveHide
-                        PreviewAbleFile.VisibleType.Fixed -> PreviewAbleFile.VisibleType.Visible
+                        PreviewAbleFile.VisibleType.HideWhenMobileNetwork -> PreviewAbleFile.VisibleType.Visible
                         PreviewAbleFile.VisibleType.SensitiveHide -> PreviewAbleFile.VisibleType.Visible
                     }
                 )

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/PreviewAbleFile.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/PreviewAbleFile.kt
@@ -15,13 +15,13 @@ data class PreviewAbleFile(
 
 
     private val isVideo = type == AboutMediaType.VIDEO
-    val isHiding = visibleType != VisibleType.Visible
+    val isHiding = visibleType == VisibleType.SensitiveHide
     val isVisiblePlayButton: Boolean
         get() = isVideo && !isHiding
 
     enum class VisibleType {
         Visible,
-        Hide,
+        Fixed,
         SensitiveHide,
     }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/PreviewAbleFile.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/PreviewAbleFile.kt
@@ -21,7 +21,7 @@ data class PreviewAbleFile(
 
     enum class VisibleType {
         Visible,
-        Fixed,
+        HideWhenMobileNetwork,
         SensitiveHide,
     }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/PreviewAbleFile.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/PreviewAbleFile.kt
@@ -4,14 +4,24 @@ import net.pantasystem.milktea.model.file.AboutMediaType
 import net.pantasystem.milktea.model.file.FilePreviewSource
 
 
-data class PreviewAbleFile(val source: FilePreviewSource, val isHiding: Boolean) {
+data class PreviewAbleFile(
+    val source: FilePreviewSource,
+    val visibleType: VisibleType,
+    val initialVisibleType: VisibleType = visibleType
+) {
 
 
     private val type = this.source.aboutMediaType
 
 
     private val isVideo = type == AboutMediaType.VIDEO
+    val isHiding = visibleType != VisibleType.Visible
     val isVisiblePlayButton: Boolean
         get() = isVideo && !isHiding
 
+    enum class VisibleType {
+        Visible,
+        Hide,
+        SensitiveHide,
+    }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -101,7 +101,7 @@ open class PlaneNoteViewData(
     }?.filter {
         it.aboutMediaType == AboutMediaType.IMAGE || it.aboutMediaType == AboutMediaType.VIDEO
     } ?: emptyList()
-    val media = MediaViewData(previewableFiles)
+    val media = MediaViewData(previewableFiles, configRepository.get().getOrNull())
 
     val isOnlyVisibleRenoteStatusMessage = MutableLiveData<Boolean>(false)
 
@@ -194,7 +194,7 @@ open class PlaneNoteViewData(
     val subNoteFiles = subNote?.files ?: emptyList()
     val subNoteMedia = MediaViewData(subNote?.files?.map {
         FilePreviewSource.Remote(AppFile.Remote(it.id), it)
-    } ?: emptyList())
+    } ?: emptyList(), configRepository.get().getOrNull())
 
     val channelInfo: LiveData<Note.Type.Misskey.SimpleChannelInfo?> = currentNote.map {
         (it.type as? Note.Type.Misskey)?.channel

--- a/modules/features/note/src/main/res/layout/item_media_preview.xml
+++ b/modules/features/note/src/main/res/layout/item_media_preview.xml
@@ -34,6 +34,7 @@
                 android:scaleType="centerCrop"
                 tools:srcCompat="@drawable/ic_baseline_hide_image_24"
                 thumbnailView="@{previewAbleFile}"
+                config="@{mediaViewData.config}"
                 />
         <ImageButton
                 android:id="@+id/actionButton"
@@ -54,6 +55,8 @@
                 android:layout_gravity="center"
                 memoVisibility="@{SafeUnbox.unbox(previewAbleFile.isHiding) ? View.VISIBLE : View.GONE }"
                 android:text="@string/sensitive_content"
+                hideImageMessageImageSource="@{previewAbleFile}"
+                config="@{mediaViewData.config}"
                 />
         <ImageButton
                 android:id="@+id/toggleVisibilityButton"

--- a/modules/features/note/src/main/res/layout/media_preview.xml
+++ b/modules/features/note/src/main/res/layout/media_preview.xml
@@ -49,7 +49,7 @@
                         android:contentDescription="@string/thumbnail"
                         android:scaleType="centerCrop"
                         tools:srcCompat="@drawable/ic_baseline_hide_image_24"
-
+                        config="@{media.config}"
                         thumbnailView="@{ media.fileOne }"
                         />
                 <ImageButton
@@ -70,6 +70,8 @@
                         tools:text="クリックで表示"
                         android:layout_gravity="center"
                         memoVisibility="@{SafeUnbox.unbox(media.fileOne.isHiding) ? View.VISIBLE : View.GONE }"
+                        hideImageMessageImageSource="@{media.fileOne}"
+                        config="@{media.config}"
                         android:text="@string/sensitive_content"
                         app:emojiCompatEnabled="false"
                         />
@@ -105,7 +107,7 @@
                         android:contentDescription="@string/thumbnail"
                         android:scaleType="centerCrop"
                         tools:srcCompat="@drawable/ic_baseline_hide_image_24"
-
+                        config="@{media.config}"
                         thumbnailView="@{ media.fileThree }"
                         />
 
@@ -125,7 +127,8 @@
                         android:id="@+id/nsfwMessageBottomLeft"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/sensitive_content"
+                        hideImageMessageImageSource="@{media.fileThree}"
+                        config="@{media.config}"
                         android:layout_gravity="center"
                         memoVisibility="@{ SafeUnbox.unbox(media.fileThree.isHiding) ? View.VISIBLE : View.GONE }"
                         app:emojiCompatEnabled="false"
@@ -176,7 +179,7 @@
                         android:contentDescription="@string/thumbnail"
                         android:scaleType="centerCrop"
                         tools:srcCompat="@drawable/ic_baseline_hide_image_24"
-
+                        config="@{media.config}"
                         thumbnailView="@{media.fileTwo}"
                         />
                 <ImageButton
@@ -197,7 +200,8 @@
                         tools:text="クリックで表示"
                         android:layout_gravity="center"
                         memoVisibility="@{SafeUnbox.unbox(media.fileTwo.isHiding) ? View.VISIBLE : View.GONE }"
-                        android:text="@string/sensitive_content"
+                        hideImageMessageImageSource="@{media.fileTwo}"
+                        config="@{media.config}"
                         app:emojiCompatEnabled="false"
                         />
                 <ImageButton
@@ -235,6 +239,8 @@
                         android:scaleType="centerCrop"
                         tools:srcCompat="@drawable/ic_baseline_hide_image_24"
                         thumbnailView="@{ media.fileFour }"
+                        config="@{media.config}"
+
                         />
                 <ImageButton
                         android:id="@+id/actionButtonBottomRight"
@@ -253,7 +259,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:text="@string/sensitive_content"
+                        hideImageMessageImageSource="@{media.fileFour}"
+                        config="@{media.config}"
                         memoVisibility="@{ SafeUnbox.unbox(media.fileFour.isHiding) ? View.VISIBLE : View.GONE}"
                         app:emojiCompatEnabled="false"
                         />

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingMovementActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingMovementActivity.kt
@@ -201,6 +201,16 @@ class SettingMovementActivity : AppCompatActivity() {
                                 }
                             }
                         }
+                        SettingSection(title = stringResource(id = R.string.media)) {
+                            SettingSwitchTile(
+                                checked = currentConfigState.isHideMediaWhenMobileNetwork,
+                                onChanged = {
+                                    currentConfigState = currentConfigState.copy(isHideMediaWhenMobileNetwork = it)
+                                }
+                            ) {
+                                Text(stringResource(id = R.string.settings_hide_media_when_mobile_network))
+                            }
+                        }
                     }
 
                 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
@@ -49,6 +49,7 @@ data class IsAnalyticsCollectionEnabled(
  * @param isEnableStreamingAPIAndNoteCapture 自動更新のON/OFF
  * @Param isEnableNoteDivider ノートの区切り線の有無 trueで有り falseで無し
  * @param isVisibleInstanceUrlInToolbar toolbar内にインスタンス情報を表示するか？
+ * @param isHideMediaWhenMobileNetwork モバイルネットワークの時はメディアを表示しない
  */
 data class Config(
     val isSimpleEditorEnabled: Boolean,
@@ -75,6 +76,7 @@ data class Config(
     val isEnableStreamingAPIAndNoteCapture: Boolean,
     val isEnableNoteDivider: Boolean,
     val isVisibleInstanceUrlInToolbar: Boolean,
+    val isHideMediaWhenMobileNetwork: Boolean,
 ) {
     companion object
 
@@ -129,6 +131,7 @@ object DefaultConfig {
         isEnableStreamingAPIAndNoteCapture = true,
         isEnableNoteDivider = true,
         isVisibleInstanceUrlInToolbar = true,
+        isHideMediaWhenMobileNetwork = false
     )
 
     fun getRememberVisibilityConfig(accountId: Long): RememberVisibility.Remember {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
@@ -28,6 +28,7 @@ val Keys.Companion.allKeys by lazy {
         Keys.IsEnableStreamingAPIAndNoteCapture,
         Keys.IsEnableNoteDivider,
         Keys.IsVisibleInstanceUrlInToolbar,
+        Keys.IsHideMediaWhenMobileNetwork,
     )
 }
 

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
@@ -79,6 +79,8 @@ sealed interface Keys {
 
     object IsVisibleInstanceUrlInToolbar : Keys
 
+    object IsHideMediaWhenMobileNetwork : Keys
+
     companion object
 }
 
@@ -109,6 +111,7 @@ fun Keys.str(): String {
         is Keys.IsStopStreamingApiWhenBackground -> "IsStopStreamingApiWhenBackground"
         is Keys.IsEnableStreamingAPIAndNoteCapture -> "IsEnableStreamingAPIAndNoteCapture"
         is Keys.IsEnableNoteDivider -> "IsEnableNoteDivider"
-        Keys.IsVisibleInstanceUrlInToolbar -> "IsVisibleInstanceUrlInToolbar"
+        is Keys.IsVisibleInstanceUrlInToolbar -> "IsVisibleInstanceUrlInToolbar"
+        is Keys.IsHideMediaWhenMobileNetwork -> "IsHideMediaWhenMobileNetwork"
     }
 }


### PR DESCRIPTION
## やったこと
モバイル回線時にメディアの画像を表示しない（読み込まない）オプションを追加しました。
またこれを追加するために、設定の状態を表現するConfigオブジェクトにBoolean型のフィールドを追加しました。
この変更によって3値を表現する必要性が出てきたため、
メディアに状態を表すenumを追加しました。
また作成したenumでは表示, モバイル回線時は非表示、センシティブのため非表示の状態を表すようにしました。
これら変更に応じて各種View、クリックリスナー周りの実装の変更を行いました。
またモバイル回線時 & モバイル回線時に画像を表示しないオプションをONにした時はセンシティブとは異なるメッセージを表示するようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1450 



