### PR TITLE
メディアの上に表示されるメッセージの視認性の問題を解決しました

### DIFF
--- a/modules/features/note/src/main/res/drawable/shape_media_message_background.xml
+++ b/modules/features/note/src/main/res/drawable/shape_media_message_background.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+    <item>
+        <shape android:shape="rectangle">
+            <corners
+                    android:topRightRadius="4dp"
+                    android:bottomRightRadius="4dp"
+                    android:topLeftRadius="4dp"
+                    android:bottomLeftRadius="4dp"
+
+                    />
+            <solid
+                    android:color="#BF000000"
+                    tools:ignore="PrivateResource"/>
+        </shape>
+    </item>
+</selector>

--- a/modules/features/note/src/main/res/layout/item_media_preview.xml
+++ b/modules/features/note/src/main/res/layout/item_media_preview.xml
@@ -57,6 +57,9 @@
                 android:text="@string/sensitive_content"
                 hideImageMessageImageSource="@{previewAbleFile}"
                 config="@{mediaViewData.config}"
+                android:background="@drawable/shape_media_message_background"
+                android:padding="4dp"
+                android:textColor="@android:color/white"
                 />
         <ImageButton
                 android:id="@+id/toggleVisibilityButton"

--- a/modules/features/note/src/main/res/layout/media_preview.xml
+++ b/modules/features/note/src/main/res/layout/media_preview.xml
@@ -74,6 +74,9 @@
                         config="@{media.config}"
                         android:text="@string/sensitive_content"
                         app:emojiCompatEnabled="false"
+                        android:background="@drawable/shape_media_message_background"
+                        android:padding="4dp"
+                        android:textColor="@android:color/white"
                         />
                 <ImageButton
                         android:layout_width="40dp"
@@ -132,6 +135,9 @@
                         android:layout_gravity="center"
                         memoVisibility="@{ SafeUnbox.unbox(media.fileThree.isHiding) ? View.VISIBLE : View.GONE }"
                         app:emojiCompatEnabled="false"
+                        android:background="@drawable/shape_media_message_background"
+                        android:padding="4dp"
+                        android:textColor="@android:color/white"
                         />
                 <ImageButton
                         android:layout_width="40dp"
@@ -203,6 +209,9 @@
                         hideImageMessageImageSource="@{media.fileTwo}"
                         config="@{media.config}"
                         app:emojiCompatEnabled="false"
+                        android:background="@drawable/shape_media_message_background"
+                        android:padding="4dp"
+                        android:textColor="@android:color/white"
                         />
                 <ImageButton
                         android:layout_width="40dp"
@@ -263,6 +272,9 @@
                         config="@{media.config}"
                         memoVisibility="@{ SafeUnbox.unbox(media.fileFour.isHiding) ? View.VISIBLE : View.GONE}"
                         app:emojiCompatEnabled="false"
+                        android:background="@drawable/shape_media_message_background"
+                        android:padding="4dp"
+                        android:textColor="@android:color/white"
                         />
                 <ImageButton
                         android:layout_width="40dp"


### PR DESCRIPTION
## やったこと
メディアの上に表示されるメッセージと背景画像の色が一致してしまい
メッセージの視認性が悪くなってしまうケースがあったため
あらかじめメッセージに透明な黒背景を設定し
メッセージの文字色を白色にしました。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1462 



