### PR TITLE
リアクションカウンター周りの不具合を修正

### DIFF
--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteEventReducer.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteEventReducer.kt
@@ -74,7 +74,9 @@ fun Note.onEmojiReacted(account: Account, e: EmojiReaction): Note {
         else -> (this.emojis ?: emptyList()) + emoji
     }
     return this.copy(
-        reactionCounts = list,
+        reactionCounts = list.filter {
+            it.count > 0
+        },
         myReaction = e.myReaction(account.remoteId),
         emojis = emojis
     )

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
@@ -17,12 +17,11 @@ import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
 object NoteReactionViewHelper {
 
     @JvmStatic
-    @BindingAdapter("reactionTextTypeView", "reactionImageTypeView", "reaction", "note")
-    fun LinearLayout.setReactionCount(
+    @BindingAdapter("reactionTextTypeView", "reactionImageTypeView", "reaction")
+    fun LinearLayout.bindReactionCount(
         reactionTextTypeView: TextView,
         reactionImageTypeView: ImageView,
         reaction: ReactionViewData,
-        note: PlaneNoteViewData
     ) {
         setReactionCount(reactionTextTypeView, reactionImageTypeView, reaction)
     }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/ReactionViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/ReactionViewData.kt
@@ -18,8 +18,10 @@ data class ReactionViewData(
             reactions: List<ReactionCount>,
             note: Note,
             instanceEmojis: Map<String, Emoji>?,
-            noteEmojis: Map<String, Emoji>?,
         ): List<ReactionViewData> {
+            val noteEmojis = note.emojis?.associateBy {
+                it.name
+            }
             return reactions.map { reactionCount ->
 
                 val textReaction = LegacyReaction.reactionMap[reactionCount.reaction] ?: reactionCount.reaction

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -152,7 +152,7 @@ open class PlaneNoteViewData(
             } else {
                 n.getShortReactionCounts(note.note.isRenoteOnly())
             }
-            ReactionViewData.from(reactions, n, emojiRepository.getAndConvertToMap(account.getHost()), emojiMap)
+            ReactionViewData.from(reactions, n, emojiRepository.getAndConvertToMap(account.getHost()))
         }
     }
 

--- a/modules/features/note/src/main/res/layout/item_reaction.xml
+++ b/modules/features/note/src/main/res/layout/item_reaction.xml
@@ -24,7 +24,6 @@
             reactionImageTypeView="@{reactionImage}"
             reactionTextTypeView="@{reactionText}"
             reaction="@{reaction}"
-            note="@{note}"
             android:layout_marginStart="4dp"
             android:layout_marginBottom="2dp"
             android:layout_marginTop="2dp"


### PR DESCRIPTION
## やったこと
アプリがバックグラウンドに行ったタイミングかつ
Noteのキャプチャーがキャンセルされるギリギリのタイミングでリアクションが流れてくる
あるいはノートのキャプチャーが再開され画面の状態がObserveされるギリギリのタイミングで
リアクションが流れてくるとemojisの反映が遅れて反映されてしまうため
テキストのまま表示されてしまう問題を修正しました

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号




