### PR TITLE
カスタム絵文字のDrawableをWeakReferenceで保持するようにした

### DIFF
--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/AutoCollapsingLayout.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/AutoCollapsingLayout.kt
@@ -77,10 +77,14 @@ class AutoCollapsingLayout : FrameLayout {
             maxHeight = limitedMaxPxHeight.toInt()
             if (expandedButton != null) {
                 measureChildWithMargins(expandedButton, widthMeasureSpec, 0, heightMeasureSpec, 0)
-                expandedButton.isVisible = true
+                if (!expandedButton.isVisible) {
+                    expandedButton.isVisible = true
+                }
             }
         } else {
-            expandedButton?.isVisible = false
+            if (expandedButton?.isVisible == true) {
+                expandedButton.isVisible = false
+            }
         }
 
         setMeasuredDimension(

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
@@ -5,6 +5,7 @@ import android.graphics.Paint
 import android.graphics.drawable.Drawable
 import android.text.TextPaint
 import android.text.style.ReplacementSpan
+import java.lang.ref.WeakReference
 import kotlin.math.min
 
 abstract class EmojiSpan<T: Any?>(val key: T) : ReplacementSpan(){
@@ -13,7 +14,12 @@ abstract class EmojiSpan<T: Any?>(val key: T) : ReplacementSpan(){
         private val drawableSizeCache = mutableMapOf<Any, EmojiSizeCache>()
     }
 
-    var imageDrawable: Drawable? = null
+    private var _imageDrawable: WeakReference<Drawable?>? = null
+    var imageDrawable: Drawable?
+        get() = _imageDrawable?.get()
+        set(value) {
+            _imageDrawable = WeakReference(value)
+        }
 
 
     /**


### PR DESCRIPTION
## やったこと
カスタム絵文字のDrawableをWeakReferenceで保持するようにしました。
またAutoCollapsingLayout上に表示されるButtonのvisibilityを変更する時に
前回のvisibilityと比較して変化がなければ何もしないようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



