### PR TITLE
フォローリクエストを一覧表示できるようにした

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -255,4 +255,10 @@ interface MastodonAPI {
         @Query("limit") limit: Int? = null,
         @Query("offset") offset: Int? = null
     ): Response<SearchResponse>
+
+    @POST("api/v1/follow_requests/{accountId}/authorize")
+    suspend fun acceptFollowRequest(@Path("accountId") accountId: String): Response<MastodonAccountRelationshipDTO>
+
+    @POST("api/v1/follow_requests/{accountId}/reject")
+    suspend fun rejectFollowRequest(@Path("accountId") accountId: String): Response<MastodonAccountRelationshipDTO>
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -261,4 +261,7 @@ interface MastodonAPI {
 
     @POST("api/v1/follow_requests/{accountId}/reject")
     suspend fun rejectFollowRequest(@Path("accountId") accountId: String): Response<MastodonAccountRelationshipDTO>
+
+    @GET("api/v1/follow_requests")
+    suspend fun getFollowRequests(@Query("max_id") maxId: String? = null, @Query("min_id") minId: String? = null): Response<List<MastodonAccountDTO>>
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
@@ -103,6 +103,9 @@ interface MisskeyAPI {
 
     @POST("api/following/requests/reject")
     suspend fun rejectFollowRequest(@Body rejectFollowRequest: RejectFollowRequest) : Response<Unit>
+
+    @POST("api/following/requests/list")
+    suspend fun getFollowRequestsList(@Body body: GetFollowRequest): Response<List<FollowRequestDTO>>
     //account
     @POST("api/i/favorites")
     suspend fun favorites(@Body noteRequest: NoteRequest): Response<List<Favorite>?>

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/FollowRequestDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/FollowRequestDTO.kt
@@ -1,0 +1,8 @@
+package net.pantasystem.milktea.api.misskey.users
+
+@kotlinx.serialization.Serializable
+class FollowRequestDTO(
+    val id: String,
+    val follower: UserDTO,
+    val followee: UserDTO
+)

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/GetFollowRequest.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/users/GetFollowRequest.kt
@@ -1,0 +1,9 @@
+package net.pantasystem.milktea.api.misskey.users
+
+@kotlinx.serialization.Serializable
+data class GetFollowRequest(
+    val i: String,
+    val sinceId: String? = null,
+    val untilId: String? = null,
+    val limit: Int? = null,
+)

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/user/FollowRequestsFragmentFactory.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/user/FollowRequestsFragmentFactory.kt
@@ -1,0 +1,7 @@
+package net.pantasystem.milktea.common_android_ui.user
+
+import androidx.fragment.app.Fragment
+
+interface FollowRequestsFragmentFactory {
+    fun create(): Fragment
+}

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -456,6 +456,7 @@
     <string name="settings_hide_media_when_mobile_network">モバイル ネットワーク時にメディアを非表示にする</string>
     <string name="notes_media_click_to_load_image">クリックして画像を読み込み</string>
     <string name="notifications_follow_requests">フォローリクエスト</string>
+    <string name="content_not_exists_message">何もありません</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -455,6 +455,7 @@
     <string name="settings_visible_instance_domain_in_toolbar">ツールバーにインスタンスのドメインを表示する</string>
     <string name="settings_hide_media_when_mobile_network">モバイル ネットワーク時にメディアを非表示にする</string>
     <string name="notes_media_click_to_load_image">クリックして画像を読み込み</string>
+    <string name="notifications_follow_requests">フォローリクエスト</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -452,6 +452,7 @@
     <string name="settings_visible_instance_domain_in_toolbar">在工具栏中显示实例的域</string>
     <string name="settings_hide_media_when_mobile_network">移动网络时隐藏媒体</string>
     <string name="notes_media_click_to_load_image">点击加载图片</string>
+    <string name="notifications_follow_requests">按照要求</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -453,6 +453,7 @@
     <string name="settings_hide_media_when_mobile_network">移动网络时隐藏媒体</string>
     <string name="notes_media_click_to_load_image">点击加载图片</string>
     <string name="notifications_follow_requests">按照要求</string>
+    <string name="content_not_exists_message">无内容</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -447,5 +447,6 @@
     <string name="settings_hide_media_when_mobile_network">Hide media when mobile network</string>
     <string name="notes_media_click_to_load_image">Click to load Image</string>
     <string name="notifications_follow_requests">Follow request</string>
+    <string name="content_not_exists_message">No content</string>
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -446,5 +446,6 @@
     <string name="settings_visible_instance_domain_in_toolbar">Show the instance\'s domain in the toolbar</string>
     <string name="settings_hide_media_when_mobile_network">Hide media when mobile network</string>
     <string name="notes_media_click_to_load_image">Click to load Image</string>
+    <string name="notifications_follow_requests">Follow request</string>
 
 </resources>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
@@ -6,10 +6,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import net.pantasystem.milktea.app_store.user.FollowFollowerPagingStore
 import net.pantasystem.milktea.app_store.user.UserReactionPagingStore
-import net.pantasystem.milktea.data.infrastructure.user.FollowFollowerPagingStoreImpl
-import net.pantasystem.milktea.data.infrastructure.user.MediatorUserDataSource
-import net.pantasystem.milktea.data.infrastructure.user.UserReactionPagingStoreImpl
-import net.pantasystem.milktea.data.infrastructure.user.UserRepositoryImpl
+import net.pantasystem.milktea.data.infrastructure.user.*
+import net.pantasystem.milktea.model.user.FollowRequestRepository
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.model.user.UserRepository
 import javax.inject.Singleton
@@ -39,4 +37,10 @@ abstract class UserModule {
     abstract fun provideUserReactionPagingStoreFactory(
         impl: UserReactionPagingStoreImpl.Factory
     ) : UserReactionPagingStore.Factory
+
+    @Binds
+    @Singleton
+    abstract fun bindFollowRequestRepository(
+        impl: FollowRequestRepositoryImpl
+    ): FollowRequestRepository
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/FollowRequestApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/FollowRequestApiAdapter.kt
@@ -1,0 +1,70 @@
+package net.pantasystem.milktea.data.infrastructure.user
+
+import net.pantasystem.milktea.api.mastodon.accounts.MastodonAccountRelationshipDTO
+import net.pantasystem.milktea.api.misskey.users.AcceptFollowRequest
+import net.pantasystem.milktea.api.misskey.users.RejectFollowRequest
+import net.pantasystem.milktea.common.throwIfHasError
+import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
+import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.user.User
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FollowRequestApiAdapter @Inject constructor(
+    val accountRepository: AccountRepository,
+    val mastodonAPIProvider: MastodonAPIProvider,
+    val misskeyAPIProvider: MisskeyAPIProvider,
+
+) {
+
+    suspend fun accept(userId: User.Id): FollowRequestResult {
+        val account = accountRepository.get(userId.accountId).getOrThrow()
+        return when(account.instanceType) {
+            Account.InstanceType.MISSKEY -> {
+                val res = misskeyAPIProvider.get(account)
+                    .acceptFollowRequest(
+                        AcceptFollowRequest(
+                            i = account.token,
+                            userId = userId.id
+                        )
+                    ).throwIfHasError()
+                FollowRequestResult.Misskey
+            }
+            Account.InstanceType.MASTODON -> {
+                val body = mastodonAPIProvider.get(account).acceptFollowRequest(userId.id)
+                    .throwIfHasError()
+                    .body()
+                FollowRequestResult.Mastodon(requireNotNull(body))
+            }
+        }
+    }
+
+    suspend fun reject(userId: User.Id): FollowRequestResult {
+        val account = accountRepository.get(userId.accountId).getOrThrow()
+        return when(account.instanceType) {
+            Account.InstanceType.MISSKEY -> {
+                misskeyAPIProvider.get(account).rejectFollowRequest(
+                    RejectFollowRequest(
+                        i = account.token,
+                        userId = userId.id
+                    )
+                ).throwIfHasError()
+                FollowRequestResult.Misskey
+            }
+            Account.InstanceType.MASTODON -> {
+                val body = mastodonAPIProvider.get(account).rejectFollowRequest(userId.id)
+                    .throwIfHasError()
+                    .body()
+                FollowRequestResult.Mastodon(requireNotNull(body))
+            }
+        }
+    }
+}
+
+sealed interface FollowRequestResult {
+    data class Mastodon(val relationshipDTO: MastodonAccountRelationshipDTO) : FollowRequestResult
+    object Misskey : FollowRequestResult
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/FollowRequestRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/FollowRequestRepositoryImpl.kt
@@ -1,0 +1,80 @@
+package net.pantasystem.milktea.data.infrastructure.user
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import net.pantasystem.milktea.api.misskey.users.AcceptFollowRequest
+import net.pantasystem.milktea.api.misskey.users.RejectFollowRequest
+import net.pantasystem.milktea.common.throwIfHasError
+import net.pantasystem.milktea.common_android.hilt.IODispatcher
+import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.user.FollowRequestRepository
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.UserDataSource
+import net.pantasystem.milktea.model.user.UserRepository
+import javax.inject.Inject
+
+class FollowRequestRepositoryImpl @Inject constructor(
+    private val misskeyAPIProvider: MisskeyAPIProvider,
+    private val userRepository: UserRepository,
+    private val accountRepository: AccountRepository,
+    private val userDataSource: UserDataSource,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher,
+): FollowRequestRepository {
+
+    override suspend fun accept(userId: User.Id): Boolean =
+        withContext(ioDispatcher) {
+            val account = accountRepository.get(userId.accountId).getOrThrow()
+            val user = userRepository.find(userId, true) as User.Detail
+            if (user.related?.hasPendingFollowRequestToYou != true) {
+                return@withContext false
+            }
+            val res = misskeyAPIProvider.get(account)
+                .acceptFollowRequest(
+                    AcceptFollowRequest(
+                        i = account.token,
+                        userId = userId.id
+                    )
+                )
+                .throwIfHasError()
+            if (res.isSuccessful) {
+                userDataSource.add(
+                    user.copy(
+                        related = user.related?.copy(
+                            hasPendingFollowRequestToYou = false,
+                            isFollower = true
+                        )
+                    )
+                )
+            }
+            return@withContext res.isSuccessful
+
+        }
+
+    override suspend fun reject(userId: User.Id): Boolean =
+        withContext(ioDispatcher) {
+            val account = accountRepository.get(userId.accountId).getOrThrow()
+            val user = userRepository.find(userId, true) as User.Detail
+            if (user.related?.hasPendingFollowRequestToYou != true) {
+                return@withContext false
+            }
+            val res = misskeyAPIProvider.get(account).rejectFollowRequest(
+                RejectFollowRequest(
+                    i = account.token,
+                    userId = userId.id
+                )
+            )
+                .throwIfHasError()
+            if (res.isSuccessful) {
+                userDataSource.add(
+                    user.copy(
+                        related = user.related?.copy(
+                            hasPendingFollowRequestToYou = false,
+                            isFollower = false
+                        )
+                    )
+                )
+            }
+            return@withContext res.isSuccessful
+        }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/FollowRequestRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/FollowRequestRepositoryImpl.kt
@@ -2,12 +2,8 @@ package net.pantasystem.milktea.data.infrastructure.user
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import net.pantasystem.milktea.api.misskey.users.AcceptFollowRequest
-import net.pantasystem.milktea.api.misskey.users.RejectFollowRequest
-import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
-import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
-import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.data.infrastructure.toUserRelated
 import net.pantasystem.milktea.model.user.FollowRequestRepository
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserDataSource
@@ -15,66 +11,65 @@ import net.pantasystem.milktea.model.user.UserRepository
 import javax.inject.Inject
 
 class FollowRequestRepositoryImpl @Inject constructor(
-    private val misskeyAPIProvider: MisskeyAPIProvider,
     private val userRepository: UserRepository,
-    private val accountRepository: AccountRepository,
     private val userDataSource: UserDataSource,
+    private val followRequestApiAdapter: FollowRequestApiAdapter,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher,
 ): FollowRequestRepository {
 
     override suspend fun accept(userId: User.Id): Boolean =
         withContext(ioDispatcher) {
-            val account = accountRepository.get(userId.accountId).getOrThrow()
             val user = userRepository.find(userId, true) as User.Detail
             if (user.related?.hasPendingFollowRequestToYou != true) {
                 return@withContext false
             }
-            val res = misskeyAPIProvider.get(account)
-                .acceptFollowRequest(
-                    AcceptFollowRequest(
-                        i = account.token,
-                        userId = userId.id
-                    )
-                )
-                .throwIfHasError()
-            if (res.isSuccessful) {
-                userDataSource.add(
-                    user.copy(
-                        related = user.related?.copy(
-                            hasPendingFollowRequestToYou = false,
-                            isFollower = true
+            when(val result = followRequestApiAdapter.accept(userId)) {
+                is FollowRequestResult.Mastodon -> {
+                    userDataSource.add(
+                        user.copy(
+                            related = result.relationshipDTO.toUserRelated()
                         )
                     )
-                )
+                }
+                FollowRequestResult.Misskey -> {
+                    userDataSource.add(
+                        user.copy(
+                            related = user.related?.copy(
+                                hasPendingFollowRequestToYou = false,
+                                isFollower = true
+                            )
+                        )
+                    )
+                }
             }
-            return@withContext res.isSuccessful
-
+            true
         }
 
     override suspend fun reject(userId: User.Id): Boolean =
         withContext(ioDispatcher) {
-            val account = accountRepository.get(userId.accountId).getOrThrow()
             val user = userRepository.find(userId, true) as User.Detail
             if (user.related?.hasPendingFollowRequestToYou != true) {
                 return@withContext false
             }
-            val res = misskeyAPIProvider.get(account).rejectFollowRequest(
-                RejectFollowRequest(
-                    i = account.token,
-                    userId = userId.id
-                )
-            )
-                .throwIfHasError()
-            if (res.isSuccessful) {
-                userDataSource.add(
-                    user.copy(
-                        related = user.related?.copy(
-                            hasPendingFollowRequestToYou = false,
-                            isFollower = false
+            when(val result = followRequestApiAdapter.reject(userId)) {
+                is FollowRequestResult.Mastodon -> {
+                    userDataSource.add(
+                        user.copy(
+                            related = result.relationshipDTO.toUserRelated()
                         )
                     )
-                )
+                }
+                FollowRequestResult.Misskey -> {
+                    userDataSource.add(
+                        user.copy(
+                            related = user.related?.copy(
+                                hasPendingFollowRequestToYou = false,
+                                isFollower = false
+                            )
+                        )
+                    )
+                }
             }
-            return@withContext res.isSuccessful
+            true
         }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserRepositoryImpl.kt
@@ -247,61 +247,7 @@ class UserRepositoryImpl @Inject constructor(
         isSuccessful
     }
 
-    override suspend fun acceptFollowRequest(userId: User.Id): Boolean =
-        withContext(ioDispatcher) {
-            val account = accountRepository.get(userId.accountId).getOrThrow()
-            val user = find(userId, true) as User.Detail
-            if (user.related?.hasPendingFollowRequestToYou != true) {
-                return@withContext false
-            }
-            val res = misskeyAPIProvider.get(account)
-                .acceptFollowRequest(
-                    AcceptFollowRequest(
-                        i = account.token,
-                        userId = userId.id
-                    )
-                )
-                .throwIfHasError()
-            if (res.isSuccessful) {
-                userDataSource.add(
-                    user.copy(
-                        related = user.related?.copy(
-                            hasPendingFollowRequestToYou = false,
-                            isFollower = true
-                        )
-                    )
-                )
-            }
-            return@withContext res.isSuccessful
 
-        }
-
-    override suspend fun rejectFollowRequest(userId: User.Id): Boolean =
-        withContext(ioDispatcher) {
-            val account = accountRepository.get(userId.accountId).getOrThrow()
-            val user = find(userId, true) as User.Detail
-            if (user.related?.hasPendingFollowRequestToYou != true) {
-                return@withContext false
-            }
-            val res = misskeyAPIProvider.get(account).rejectFollowRequest(
-                RejectFollowRequest(
-                    i = account.token,
-                    userId = userId.id
-                )
-            )
-                .throwIfHasError()
-            if (res.isSuccessful) {
-                userDataSource.add(
-                    user.copy(
-                        related = user.related?.copy(
-                            hasPendingFollowRequestToYou = false,
-                            isFollower = false
-                        )
-                    )
-                )
-            }
-            return@withContext res.isSuccessful
-        }
 
     private suspend fun updateCacheFrom(userId: User.Id, result: UserActionResult, reducer: suspend (User.Detail) -> User.Detail) {
         val user = find(userId, true) as User.Detail

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationMentionFragment.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationMentionFragment.kt
@@ -18,6 +18,7 @@ import net.pantasystem.milktea.app_store.account.AccountStore
 import net.pantasystem.milktea.common.ui.ToolbarSetter
 import net.pantasystem.milktea.common_android_ui.PageableFragmentFactory
 import net.pantasystem.milktea.common_android_ui.account.page.PageTypeHelper
+import net.pantasystem.milktea.common_android_ui.user.FollowRequestsFragmentFactory
 import net.pantasystem.milktea.model.account.page.PageType
 import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.model.account.page.PageableTemplate
@@ -36,20 +37,32 @@ class NotificationMentionFragment : Fragment(R.layout.fragment_notification_ment
     @Inject
     lateinit var pageableFragmentFactory: PageableFragmentFactory
 
+    @Inject
+    lateinit var followRequestsFragmentFactory: FollowRequestsFragmentFactory
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
 
         val pagerItems = listOf(
-            TitleWithPageable(
+            TabType.TitleWithPageable(
                 PageTypeHelper.nameByPageType(requireContext(), PageType.NOTIFICATION),
                 PageableTemplate(null)
-                    .notification(PageTypeHelper.nameByPageType(requireContext(), PageType.NOTIFICATION)).pageable(),
+                    .notification(
+                        PageTypeHelper.nameByPageType(
+                            requireContext(),
+                            PageType.NOTIFICATION
+                        )
+                    ).pageable(),
             ),
-            TitleWithPageable(
+            TabType.TitleWithPageable(
                 PageTypeHelper.nameByPageType(requireContext(), PageType.MENTION),
                 PageableTemplate(null)
-                    .mention(PageTypeHelper.nameByPageType(requireContext(), PageType.MENTION)).pageable(),
+                    .mention(PageTypeHelper.nameByPageType(requireContext(), PageType.MENTION))
+                    .pageable(),
+            ),
+            TabType.FollowRequests(
+                getString(R.string.notifications_follow_requests)
             )
         )
 
@@ -74,11 +87,18 @@ class NotificationMentionFragment : Fragment(R.layout.fragment_notification_ment
         }
 
     }
-    inner class PagerAdapter(val pages: List<TitleWithPageable>) :
+    inner class PagerAdapter(val pages: List<TabType>) :
         FragmentStatePagerAdapter(childFragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
 
         private fun createFragment(position: Int): Fragment {
-            return pageableFragmentFactory.create(pages[position].pageable)
+            return when(val tabItem = pages[position]) {
+                is TabType.FollowRequests -> {
+                    followRequestsFragmentFactory.create()
+                }
+                is TabType.TitleWithPageable -> {
+                    pageableFragmentFactory.create(tabItem.pageable)
+                }
+            }
         }
 
         override fun getPageTitle(position: Int): CharSequence {
@@ -97,7 +117,16 @@ class NotificationMentionFragment : Fragment(R.layout.fragment_notification_ment
     }
 }
 
-data class TitleWithPageable(
-    val title: String,
-    val pageable: Pageable,
-)
+
+
+sealed interface TabType {
+    val title: String
+    data class TitleWithPageable(
+        override val title: String,
+        val pageable: Pageable,
+    ) : TabType
+
+    data class FollowRequests(
+        override val title: String,
+    ) : TabType
+}

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/viewmodel/NotificationViewModel.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/viewmodel/NotificationViewModel.kt
@@ -18,7 +18,7 @@ import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.account.UnauthorizedException
 import net.pantasystem.milktea.model.group.GroupRepository
 import net.pantasystem.milktea.model.notification.*
-import net.pantasystem.milktea.model.user.UserRepository
+import net.pantasystem.milktea.model.user.FollowRequestRepository
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewDataCache
 import javax.inject.Inject
 
@@ -26,9 +26,9 @@ import javax.inject.Inject
 @HiltViewModel
 class NotificationViewModel @Inject constructor(
     private val accountRepository: AccountRepository,
-    private val userRepository: UserRepository,
     private val groupRepository: GroupRepository,
     private val notificationStreaming: NotificationStreaming,
+    private val followRequestRepository: FollowRequestRepository,
     planeNoteViewDataCacheFactory: PlaneNoteViewDataCache.Factory,
     loggerFactory: Logger.Factory,
     accountStore: AccountStore,
@@ -125,7 +125,7 @@ class NotificationViewModel @Inject constructor(
         if (notification is ReceiveFollowRequestNotification) {
             viewModelScope.launch {
                 runCancellableCatching {
-                    userRepository.acceptFollowRequest(notification.userId)
+                    followRequestRepository.accept(notification.userId)
                 }.onSuccess {
                     loadInit()
                 }.onFailure {
@@ -141,7 +141,7 @@ class NotificationViewModel @Inject constructor(
         if (notification is ReceiveFollowRequestNotification) {
             viewModelScope.launch(Dispatchers.IO) {
                 runCancellableCatching {
-                    userRepository.rejectFollowRequest(notification.userId)
+                    followRequestRepository.reject(notification.userId)
                 }.onSuccess {
                     loadInit()
                 }.onFailure {

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/di/module/FollowRequestModule.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/di/module/FollowRequestModule.kt
@@ -1,0 +1,16 @@
+package net.pantasystem.milktea.user.di.module
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+import net.pantasystem.milktea.common_android_ui.user.FollowRequestsFragmentFactory
+import net.pantasystem.milktea.user.follow_requests.FollowRequestFragmentFactoryImpl
+
+@InstallIn(ActivityComponent::class)
+@Module
+abstract class FollowRequestModule {
+
+    @Binds
+    abstract fun bindFollowRequestFragmentFactory(impl: FollowRequestFragmentFactoryImpl): FollowRequestsFragmentFactory
+}

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestItem.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestItem.kt
@@ -1,0 +1,107 @@
+package net.pantasystem.milktea.user.follow_requests
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.rememberAsyncImagePainter
+import net.pantasystem.milktea.common_compose.CustomEmojiText
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.user.R
+
+@Composable
+fun FollowRequestItem(
+    currentAccount: Account?,
+    user: User,
+    onAccept: (User.Id) -> Unit,
+    onReject: (User.Id) -> Unit,
+    onAvatarClicked: (User.Id) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colors.surface
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    vertical = 12.dp,
+                    horizontal = 14.dp,
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Image(
+                rememberAsyncImagePainter(model = user.avatarUrl),
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(64.dp)
+                    .clip(CircleShape)
+                    .border(2.dp, MaterialTheme.colors.surface, CircleShape)
+                    .clickable {
+                        onAvatarClicked(user.id)
+                    },
+                contentDescription = null,
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                CustomEmojiText(text = user.displayName, emojis = user.emojis, accountHost = currentAccount?.getHost(), sourceHost = user.host, fontSize = 16.sp)
+                Text(text = user.displayUserName, fontSize = 14.sp)
+            }
+            Spacer(modifier = Modifier.width(4.dp))
+            Row {
+                IconButton(onClick = {
+                    onAccept(user.id)
+                }) {
+                    Icon(Icons.Default.Check, contentDescription = stringResource(id = R.string.accept))
+                }
+                Spacer(modifier = Modifier.width(4.dp))
+                IconButton(onClick = {
+                    onReject(user.id)
+                }) {
+                    Icon(Icons.Default.Close, contentDescription = stringResource(id = R.string.reject))
+                }
+            }
+
+        }
+    }
+}
+
+@Preview
+@Composable
+fun Preview_FollowRequestItem() {
+    FollowRequestItem(
+        currentAccount = Account(remoteId = "", instanceDomain = "", userName = "", instanceType = Account.InstanceType.MISSKEY, token = ""),
+        user = User.Simple(
+            id = User.Id(accountId = 0, id = ""),
+            userName = "Panta",
+            name = "Panta",
+            avatarUrl = null,
+            emojis = listOf(),
+            isCat = null,
+            isBot = null,
+            host = "",
+            nickname = null,
+            isSameHost = false,
+            instance = null,
+            avatarBlurhash = null
+        ), onAccept = {}, onReject = {}, onAvatarClicked = {}
+    )
+}

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestItem.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestItem.kt
@@ -28,6 +28,7 @@ import net.pantasystem.milktea.user.R
 fun FollowRequestItem(
     currentAccount: Account?,
     user: User,
+    isUserNameDefault: Boolean,
     onAccept: (User.Id) -> Unit,
     onReject: (User.Id) -> Unit,
     onAvatarClicked: (User.Id) -> Unit,
@@ -62,8 +63,14 @@ fun FollowRequestItem(
             Column(
                 modifier = Modifier.weight(1f)
             ) {
-                CustomEmojiText(text = user.displayName, emojis = user.emojis, accountHost = currentAccount?.getHost(), sourceHost = user.host, fontSize = 16.sp)
-                Text(text = user.displayUserName, fontSize = 14.sp)
+                if (isUserNameDefault) {
+                    Text(text = user.displayUserName, fontSize = 16.sp)
+                    CustomEmojiText(text = user.displayName, emojis = user.emojis, accountHost = currentAccount?.getHost(), sourceHost = user.host, fontSize = 14.sp)
+                } else {
+                    CustomEmojiText(text = user.displayName, emojis = user.emojis, accountHost = currentAccount?.getHost(), sourceHost = user.host, fontSize = 16.sp)
+                    Text(text = user.displayUserName, fontSize = 14.sp)
+                }
+
             }
             Spacer(modifier = Modifier.width(4.dp))
             Row {
@@ -89,6 +96,7 @@ fun FollowRequestItem(
 fun Preview_FollowRequestItem() {
     FollowRequestItem(
         currentAccount = Account(remoteId = "", instanceDomain = "", userName = "", instanceType = Account.InstanceType.MISSKEY, token = ""),
+        isUserNameDefault = true,
         user = User.Simple(
             id = User.Id(accountId = 0, id = ""),
             userName = "Panta",

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsErrorHandler.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsErrorHandler.kt
@@ -1,0 +1,29 @@
+package net.pantasystem.milktea.user.follow_requests
+
+import android.content.Context
+import android.widget.Toast
+import net.pantasystem.milktea.common.APIError
+import net.pantasystem.milktea.common_android_ui.APIErrorStringConverter
+import net.pantasystem.milktea.model.account.UnauthorizedException
+import net.pantasystem.milktea.note.R
+
+class FollowRequestsErrorHandler(val context: Context) {
+
+    operator fun invoke(throwable: Throwable) {
+        when (throwable) {
+            is APIError -> {
+                Toast.makeText(context, APIErrorStringConverter()(throwable).getString(context), Toast.LENGTH_LONG)
+                    .show()
+            }
+
+            is UnauthorizedException -> {
+                Toast.makeText(
+                    context,
+                    R.string.unauthorized_error,
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+            else -> Unit
+        }
+    }
+}

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsFragment.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsFragment.kt
@@ -16,6 +16,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
+import net.pantasystem.milktea.common_android_ui.user.FollowRequestsFragmentFactory
 import net.pantasystem.milktea.common_navigation.UserDetailNavigation
 import net.pantasystem.milktea.common_navigation.UserDetailNavigationArgs
 import javax.inject.Inject
@@ -57,5 +58,11 @@ class FollowRequestsFragment : Fragment() {
                 }
             }
         }
+    }
+}
+
+class FollowRequestFragmentFactoryImpl @Inject constructor() : FollowRequestsFragmentFactory {
+    override fun create(): Fragment {
+        return FollowRequestsFragment()
     }
 }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsFragment.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsFragment.kt
@@ -1,0 +1,61 @@
+package net.pantasystem.milktea.user.follow_requests
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.google.android.material.composethemeadapter.MdcTheme
+import dagger.hilt.android.AndroidEntryPoint
+import net.pantasystem.milktea.common_navigation.UserDetailNavigation
+import net.pantasystem.milktea.common_navigation.UserDetailNavigationArgs
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class FollowRequestsFragment : Fragment() {
+
+    @Inject
+    lateinit var userDetailNavigation: UserDetailNavigation
+
+    val viewModel by viewModels<FollowRequestsViewModel>()
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MdcTheme {
+                    val uiState by viewModel.uiState.collectAsState()
+                    FollowRequestsScreen(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .nestedScroll(
+                                rememberNestedScrollInteropConnection()
+                            ),
+                        uiState = uiState,
+                        onAccept = viewModel::accept,
+                        onReject = viewModel::reject,
+                        onAvatarClicked = {
+                            startActivity(
+                                userDetailNavigation.newIntent(UserDetailNavigationArgs.UserId(it))
+                            )
+                        },
+                        onRefresh = viewModel::refresh
+                    )
+                }
+            }
+        }
+    }
+}

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsFragment.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsFragment.kt
@@ -14,8 +14,13 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import net.pantasystem.milktea.common_android_ui.user.FollowRequestsFragmentFactory
 import net.pantasystem.milktea.common_navigation.UserDetailNavigation
 import net.pantasystem.milktea.common_navigation.UserDetailNavigationArgs
@@ -35,6 +40,10 @@ class FollowRequestsFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        viewModel.errors.onEach {
+            FollowRequestsErrorHandler(requireContext())(it)
+        }.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED).launchIn(lifecycleScope)
+
         return ComposeView(requireContext()).apply {
             setContent {
                 MdcTheme {

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsScreen.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsScreen.kt
@@ -39,11 +39,12 @@ fun FollowRequestsScreen(
         LazyColumn(modifier) {
             when(val content = uiState.pagingState.content) {
                 is StateContent.Exist -> {
-                    if (!content.rawContent.isEmpty()) {
+                    if (content.rawContent.isNotEmpty()) {
                         items(content.rawContent) { item ->
                             FollowRequestItem(
                                 currentAccount = uiState.currentAccount,
                                 user = item,
+                                isUserNameDefault = uiState.config.isUserNameDefault,
                                 onAccept = onAccept,
                                 onReject = onReject,
                                 onAvatarClicked = onAvatarClicked

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsScreen.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsScreen.kt
@@ -10,11 +10,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import net.pantasystem.milktea.common.PageableState
 import net.pantasystem.milktea.common.StateContent
 import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.user.R
 
 @Composable
 fun FollowRequestsScreen(
@@ -37,11 +39,7 @@ fun FollowRequestsScreen(
         LazyColumn(modifier) {
             when(val content = uiState.pagingState.content) {
                 is StateContent.Exist -> {
-                    if (content.rawContent.isEmpty()) {
-                        item {
-                            ContentNone()
-                        }
-                    } else {
+                    if (!content.rawContent.isEmpty()) {
                         items(content.rawContent) { item ->
                             FollowRequestItem(
                                 currentAccount = uiState.currentAccount,
@@ -53,32 +51,36 @@ fun FollowRequestsScreen(
                         }
                     }
                 }
-                is StateContent.NotExist -> {
-                    item {
-                        ContentNone()
-                    }
-                }
+                is StateContent.NotExist -> Unit
             }
-            if (uiState.pagingState is PageableState.Loading) {
-                item {
-                    Box(
-                        modifier = Modifier.fillMaxWidth(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        CircularProgressIndicator()
+
+            item {
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    when(uiState.pagingState) {
+                        is PageableState.Error -> {
+                            Text(stringResource(id = R.string.error_s, uiState.pagingState.throwable.localizedMessage ?: ""))
+                        }
+                        is PageableState.Fixed -> {
+                            val showMessage = when(val content = uiState.pagingState.content) {
+                                is StateContent.Exist -> {
+                                    content.rawContent.isEmpty()
+                                }
+                                is StateContent.NotExist -> true
+                            }
+                            if (showMessage) {
+                                Text(stringResource(id = R.string.content_not_exists_message))
+                            }
+                        }
+                        is PageableState.Loading -> {
+                            CircularProgressIndicator()
+                        }
                     }
                 }
+
             }
         }
-    }
-}
-
-@Composable
-private fun ContentNone() {
-    Box(
-        modifier = Modifier.fillMaxWidth(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text("Follow requests not exists.")
     }
 }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsScreen.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsScreen.kt
@@ -1,0 +1,80 @@
+package net.pantasystem.milktea.user.follow_requests
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
+import net.pantasystem.milktea.common.PageableState
+import net.pantasystem.milktea.common.StateContent
+import net.pantasystem.milktea.model.user.User
+
+@Composable
+fun FollowRequestsScreen(
+    uiState: FollowRequestsUiState,
+    onAccept: (User.Id) -> Unit,
+    onReject: (User.Id) -> Unit,
+    onAvatarClicked: (User.Id) -> Unit,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SwipeRefresh(
+        state = rememberSwipeRefreshState(
+            isRefreshing = uiState.pagingState is PageableState.Loading.Init
+        ),
+        onRefresh = onRefresh
+    ) {
+        LazyColumn(modifier) {
+            when(val content = uiState.pagingState.content) {
+                is StateContent.Exist -> {
+                    if (content.rawContent.isEmpty()) {
+                        item {
+                            ContentNone()
+                        }
+                    } else {
+                        items(content.rawContent) { item ->
+                            FollowRequestItem(
+                                currentAccount = uiState.currentAccount,
+                                user = item,
+                                onAccept = onAccept,
+                                onReject = onReject,
+                                onAvatarClicked = onAvatarClicked
+                            )
+                        }
+                    }
+                }
+                is StateContent.NotExist -> {
+                    item {
+                        ContentNone()
+                    }
+                }
+            }
+            if (uiState.pagingState is PageableState.Loading) {
+                item {
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContentNone() {
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text("Follow requests not exists.")
+    }
+}

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsScreen.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.google.accompanist.swiperefresh.SwipeRefresh
@@ -24,6 +25,9 @@ fun FollowRequestsScreen(
     onRefresh: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    LaunchedEffect(null) {
+        onRefresh()
+    }
     SwipeRefresh(
         state = rememberSwipeRefreshState(
             isRefreshing = uiState.pagingState is PageableState.Loading.Init

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsViewModel.kt
@@ -33,6 +33,8 @@ class FollowRequestsViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _errors = MutableSharedFlow<Throwable>(extraBufferCapacity = 10, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    val errors = _errors.asSharedFlow()
+
     private val pagingStore = followRequestPagingStoreFactory.create {
         accountRepository.getCurrentAccount().getOrThrow()
     }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsViewModel.kt
@@ -60,6 +60,12 @@ class FollowRequestsViewModel @Inject constructor(
         FollowRequestsUiState(null, emptyList(), PageableState.Loading.Init())
     )
 
+    init {
+        accountStore.observeCurrentAccount.distinctUntilChanged().onEach {
+            refresh()
+        }.launchIn(viewModelScope)
+    }
+
     fun refresh() {
         viewModelScope.launch {
             pagingStore.clear()

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsViewModel.kt
@@ -1,0 +1,83 @@
+package net.pantasystem.milktea.user.follow_requests
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import net.pantasystem.milktea.common.PageableState
+import net.pantasystem.milktea.common.StateContent
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.account.CurrentAccountWatcher
+import net.pantasystem.milktea.model.user.FollowRequestRepository
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.UserDataSource
+import net.pantasystem.milktea.model.user.follow_requests.FollowRequestPagingStore
+import javax.inject.Inject
+
+@HiltViewModel
+class FollowRequestsViewModel @Inject constructor(
+    accountRepository: AccountRepository,
+    followRequestPagingStoreFactory: FollowRequestPagingStore.Factory,
+    private val userDataSource: UserDataSource,
+    private val followRequestRepository: FollowRequestRepository,
+) : ViewModel() {
+
+    private val _errors = MutableSharedFlow<Throwable>(extraBufferCapacity = 10, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    private val accountWatcher = CurrentAccountWatcher(null, accountRepository)
+    private val pagingStore = followRequestPagingStoreFactory.create {
+        accountWatcher.getAccount()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val users = pagingStore.state.map { state ->
+        (state.content as? StateContent.Exist)?.rawContent ?: emptyList()
+    }.flatMapLatest { ids ->
+        accountWatcher.account.flatMapLatest { account ->
+            userDataSource.observeIn(account.accountId, ids.map { it.id })
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val state = combine(users, pagingStore.state) { users, state ->
+        state.convert {
+            users
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), PageableState.Loading.Init())
+
+    fun refresh() {
+        viewModelScope.launch {
+            pagingStore.clear()
+            pagingStore.loadPrevious().onFailure {
+                _errors.tryEmit(it)
+            }
+        }
+    }
+
+    fun accept(userId: User.Id) {
+        viewModelScope.launch {
+            runCancellableCatching {
+                followRequestRepository.accept(userId)
+            }.onFailure {
+                _errors.tryEmit(it)
+            }.onSuccess {
+                refresh()
+            }
+        }
+    }
+
+    fun reject(userId: User.Id) {
+        viewModelScope.launch {
+            runCancellableCatching {
+                followRequestRepository.reject(userId)
+            }.onFailure {
+                _errors.tryEmit(it)
+            }.onSuccess {
+                refresh()
+            }
+        }
+    }
+
+}

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import net.pantasystem.milktea.common.PageableState
 import net.pantasystem.milktea.common.StateContent
 import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.account.CurrentAccountWatcher
 import net.pantasystem.milktea.model.user.FollowRequestRepository
@@ -47,6 +48,19 @@ class FollowRequestsViewModel @Inject constructor(
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), PageableState.Loading.Init())
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val uiState = combine(accountWatcher.account, state, users) { ac, state, users ->
+        FollowRequestsUiState(
+            ac,
+            users,
+            state
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        FollowRequestsUiState(null, emptyList(), PageableState.Loading.Init())
+    )
+
     fun refresh() {
         viewModelScope.launch {
             pagingStore.clear()
@@ -81,3 +95,9 @@ class FollowRequestsViewModel @Inject constructor(
     }
 
 }
+
+data class FollowRequestsUiState(
+    val currentAccount: Account?,
+    val users: List<User>,
+    val pagingState: PageableState<List<User>>,
+)

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/FollowRequestRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/FollowRequestRepository.kt
@@ -5,4 +5,16 @@ interface FollowRequestRepository {
     suspend fun accept(userId: User.Id) : Boolean
 
     suspend fun reject(userId: User.Id) : Boolean
+
+    suspend fun find(
+        accountId: Long,
+        sinceId: String? = null,
+        untilId: String? = null,
+    ): FollowRequestsResult
 }
+
+data class FollowRequestsResult(
+    val users: List<User.Detail>,
+    val sinceId: String? = null,
+    val untilId: String? = null,
+)

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/FollowRequestRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/FollowRequestRepository.kt
@@ -1,0 +1,8 @@
+package net.pantasystem.milktea.model.user
+
+interface FollowRequestRepository {
+
+    suspend fun accept(userId: User.Id) : Boolean
+
+    suspend fun reject(userId: User.Id) : Boolean
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/FollowRequestRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/FollowRequestRepository.kt
@@ -14,7 +14,7 @@ interface FollowRequestRepository {
 }
 
 data class FollowRequestsResult(
-    val users: List<User.Detail>,
+    val users: List<User>,
     val sinceId: String? = null,
     val untilId: String? = null,
 )

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/UserRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/UserRepository.kt
@@ -26,10 +26,6 @@ interface UserRepository {
 
     suspend fun unblock(userId: User.Id): Boolean
 
-    suspend fun acceptFollowRequest(userId: User.Id) : Boolean
-
-    suspend fun rejectFollowRequest(userId: User.Id) : Boolean
-
     suspend fun report(report: Report) : Boolean
 
     suspend fun findUsers(accountId: Long, query: FindUsersQuery): List<User>

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/follow_requests/FollowRequestPagingStore.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/follow_requests/FollowRequestPagingStore.kt
@@ -1,0 +1,97 @@
+package net.pantasystem.milktea.model.user.follow_requests
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import net.pantasystem.milktea.common.PageableState
+import net.pantasystem.milktea.common.paginator.*
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.user.FollowRequestRepository
+import net.pantasystem.milktea.model.user.User
+import javax.inject.Inject
+
+
+class FollowRequestPagingStore(
+    val getAccount: suspend () -> Account,
+    followRequestRepository: FollowRequestRepository,
+){
+
+    class Factory @Inject constructor(
+        private val followRequestRepository: FollowRequestRepository
+    ) {
+        fun create(getAccount: suspend () -> Account): FollowRequestPagingStore {
+            return FollowRequestPagingStore(getAccount, followRequestRepository)
+        }
+    }
+
+    private val impl = FollowRequestPagingStoreImpl(getAccount, followRequestRepository)
+    private val previousController = PreviousPagingController(
+        impl,
+        impl,
+        impl,
+        impl,
+    )
+
+    val state = impl.state
+
+    suspend fun loadPrevious(): Result<Unit> = runCancellableCatching {
+        previousController.loadPrevious().getOrThrow()
+    }
+    suspend fun clear() {
+        impl.mutex.withLock {
+            impl.setState(PageableState.Loading.Init())
+            impl.untilId = null
+            impl.sinceId = null
+        }
+    }
+}
+
+class FollowRequestPagingStoreImpl(
+    val getAccount: suspend () -> Account,
+    private val followRequestRepository: FollowRequestRepository,
+): StateLocker, PaginationState<User.Id>, PreviousLoader<User>, EntityConverter<User, User.Id>, IdGetter<String> {
+
+
+    override val mutex: Mutex = Mutex()
+
+    private val _state = MutableStateFlow<PageableState<List<User.Id>>>(PageableState.Loading.Init())
+
+    var sinceId: String? = null
+    var untilId: String? = null
+
+    override val state: Flow<PageableState<List<User.Id>>>
+        get() = _state
+
+    override suspend fun convertAll(list: List<User>): List<User.Id> {
+        return list.map {
+            it.id
+        }
+    }
+
+    override fun getState(): PageableState<List<User.Id>> {
+        return _state.value
+    }
+
+    override suspend fun loadPrevious(): Result<List<User>> = runCancellableCatching {
+        val result = followRequestRepository.find(
+            getAccount().accountId,
+            untilId = getUntilId()
+        )
+        untilId = result.untilId
+        result.users
+    }
+
+    override fun setState(state: PageableState<List<User.Id>>) {
+        _state.value = state
+    }
+
+    override suspend fun getSinceId(): String? {
+        return sinceId
+    }
+
+    override suspend fun getUntilId(): String? {
+        return untilId
+    }
+}


### PR DESCRIPTION
## やったこと
フォローリクエストを通知タブで一覧表示できるようにしました。
そのためにMastodonとMisskeyのそれぞれの実装を行い取得できるようにしました。
元々フォローリクエスト周りの実装をUserRepositoryに配置していたのを、
FollowRequestRepositoryに移動しました(リファクタ)。
またフォローリクエスト一覧はComposeで実装しました。

## 動作確認


## スクリーンショット(任意)


## 備考
Fedibirdだと何故か403が返ってくる


## Issue番号
Closed #1218 
