### PR TITLE
メディアタイムラインの実装を行いました

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/impl/PageDefaultStringsOnAndroid.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/impl/PageDefaultStringsOnAndroid.kt
@@ -16,4 +16,7 @@ class PageDefaultStringsOnAndroid(val context: Context) :
         get() = context.getString(R.string.local_timeline)
     override val recommendedTimeline: String
         get() = context.getString(R.string.calckey_recomended_timeline)
+
+    override val media: String
+        get() = context.getString(R.string.media)
 }

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -61,7 +61,8 @@ interface MastodonAPI {
     suspend fun getHashtagTimeline(
         @Path("tag") tag: String,
         @Query("min_id") minId: String? = null,
-        @Query("max_id") maxId: String? = null
+        @Query("max_id") maxId: String? = null,
+        @Query("only_media") onlyMedia: Boolean = false,
     ): Response<List<TootStatusDTO>>
 
     /**

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/MastodonTimelineStorePagingStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/MastodonTimelineStorePagingStoreImpl.kt
@@ -54,7 +54,7 @@ internal class MastodonTimelineStorePagingStoreImpl(
             )
             Pageable.Mastodon.HomeTimeline -> api.getHomeTimeline(
                 minId = getSinceId(),
-                visibilities = getVisibilitiesParameter(getAccount())
+                visibilities = getVisibilitiesParameter(getAccount()),
             )
             is Pageable.Mastodon.ListTimeline -> api.getListTimeline(
                 minId = getSinceId(),
@@ -63,11 +63,13 @@ internal class MastodonTimelineStorePagingStoreImpl(
             is Pageable.Mastodon.LocalTimeline -> api.getPublicTimeline(
                 local = true,
                 minId = getSinceId(),
-                visibilities = getVisibilitiesParameter(getAccount())
+                visibilities = getVisibilitiesParameter(getAccount()),
+                onlyMedia = pageableTimeline.getOnlyMedia()
             )
             is Pageable.Mastodon.PublicTimeline -> api.getPublicTimeline(
                 minId = getSinceId(),
-                visibilities = getVisibilitiesParameter(getAccount())
+                visibilities = getVisibilitiesParameter(getAccount()),
+                onlyMedia = pageableTimeline.getOnlyMedia()
             )
             is Pageable.Mastodon.UserTimeline -> {
                 api.getAccountTimeline(
@@ -119,7 +121,8 @@ internal class MastodonTimelineStorePagingStoreImpl(
         when (pageableTimeline) {
             is Pageable.Mastodon.HashTagTimeline -> api.getHashtagTimeline(
                 pageableTimeline.hashtag,
-                maxId = maxId
+                maxId = maxId,
+                onlyMedia = pageableTimeline.getOnlyMedia()
             )
             Pageable.Mastodon.HomeTimeline -> api.getHomeTimeline(
                 maxId = maxId,
@@ -132,11 +135,13 @@ internal class MastodonTimelineStorePagingStoreImpl(
             is Pageable.Mastodon.LocalTimeline -> api.getPublicTimeline(
                 local = true,
                 maxId = maxId,
-                visibilities = getVisibilitiesParameter(getAccount())
+                visibilities = getVisibilitiesParameter(getAccount()),
+                onlyMedia = pageableTimeline.getOnlyMedia()
             )
             is Pageable.Mastodon.PublicTimeline -> api.getPublicTimeline(
                 maxId = maxId,
-                visibilities = getVisibilitiesParameter(getAccount())
+                visibilities = getVisibilitiesParameter(getAccount()),
+                onlyMedia = pageableTimeline.getOnlyMedia()
             )
             is Pageable.Mastodon.UserTimeline -> {
                 api.getAccountTimeline(

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteStreamingImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteStreamingImpl.kt
@@ -10,6 +10,7 @@ import net.pantasystem.milktea.api_streaming.mastodon.Event
 import net.pantasystem.milktea.data.streaming.ChannelAPIWithAccountProvider
 import net.pantasystem.milktea.data.streaming.StreamingAPIProvider
 import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.account.page.CanOnlyMedia
 import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.NoteStreaming
@@ -105,6 +106,16 @@ class NoteStreamingImpl @Inject constructor(
                     }
                 }
                 else -> throw IllegalStateException("Global, Hybrid, Local, Homeは以外のStreamは対応していません。")
+            }
+        }.filter {
+            if (pageable is CanOnlyMedia<*>) {
+                if (pageable.getOnlyMedia()) {
+                    !it.fileIds.isNullOrEmpty()
+                } else {
+                    true
+                }
+            } else {
+                true
             }
         }
     }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteStreamingImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteStreamingImpl.kt
@@ -44,44 +44,44 @@ class NoteStreamingImpl @Inject constructor(
             when (pageable) {
                 is Pageable.GlobalTimeline -> {
                     requireNotNull(channelAPIProvider.get(ac)).connect(ChannelAPI.Type.Global)
-                        .convertToNote(getAccount)
+                        .convertToNote(getAccount, pageable)
                 }
                 is Pageable.HybridTimeline -> {
                     requireNotNull(channelAPIProvider.get(ac)).connect(ChannelAPI.Type.Hybrid)
-                        .convertToNote(getAccount)
+                        .convertToNote(getAccount, pageable)
                 }
                 is Pageable.LocalTimeline -> {
                     requireNotNull(channelAPIProvider.get(ac)).connect(ChannelAPI.Type.Local)
-                        .convertToNote(getAccount)
+                        .convertToNote(getAccount, pageable)
                 }
                 is Pageable.HomeTimeline -> {
                     requireNotNull(channelAPIProvider.get(ac)).connect(ChannelAPI.Type.Home)
-                        .convertToNote(getAccount)
+                        .convertToNote(getAccount, pageable)
                 }
                 is Pageable.UserListTimeline -> {
                     requireNotNull(channelAPIProvider.get(ac))
                         .connect(ChannelAPI.Type.UserList(userListId = pageable.listId))
-                        .convertToNote(getAccount)
+                        .convertToNote(getAccount, pageable)
                 }
                 is Pageable.Antenna -> {
                     requireNotNull(channelAPIProvider.get(ac))
                         .connect(ChannelAPI.Type.Antenna(antennaId = pageable.antennaId))
-                        .convertToNote(getAccount)
+                        .convertToNote(getAccount, pageable)
                 }
                 is Pageable.UserTimeline -> {
                     requireNotNull(channelAPIProvider.get(ac))
-                        .connectUserTimeline(pageable.userId).convertToNote(getAccount)
+                        .connectUserTimeline(pageable.userId).convertToNote(getAccount, pageable)
                 }
                 is Pageable.ChannelTimeline -> {
                     requireNotNull(channelAPIProvider.get(ac))
                         .connect(ChannelAPI.Type.Channel(channelId = pageable.channelId))
-                        .convertToNote(getAccount)
+                        .convertToNote(getAccount, pageable)
                 }
                 is Pageable.Mastodon -> {
                     when (pageable) {
                         is Pageable.Mastodon.HashTagTimeline -> {
                             requireNotNull(streamingAPIProvider.get(ac)).connectHashTag(pageable.hashtag)
-                                .convertToNoteFromStatus(getAccount)
+                                .convertToNoteFromStatus(getAccount, pageable)
                         }
                         Pageable.Mastodon.HomeTimeline -> {
                             requireNotNull(streamingAPIProvider.get(ac)).connectUser()
@@ -91,45 +91,55 @@ class NoteStreamingImpl @Inject constructor(
                             streamingAPIProvider.get(
                                 ac
                             )
-                        ).connectUserList(pageable.listId).convertToNoteFromStatus(getAccount)
+                        ).connectUserList(pageable.listId).convertToNoteFromStatus(getAccount, pageable)
                         is Pageable.Mastodon.LocalTimeline -> requireNotNull(
                             streamingAPIProvider.get(
                                 ac
                             )
-                        ).connectLocalPublic().convertToNoteFromStatus(getAccount)
+                        ).connectLocalPublic().convertToNoteFromStatus(getAccount, pageable)
                         is Pageable.Mastodon.PublicTimeline -> requireNotNull(
                             streamingAPIProvider.get(
                                 ac
                             )
-                        ).connectPublic().convertToNoteFromStatus(getAccount)
+                        ).connectPublic().convertToNoteFromStatus(getAccount, pageable)
                         else -> throw IllegalStateException("Global, Hybrid, Local, Homeは以外のStreamは対応していません。")
                     }
                 }
                 else -> throw IllegalStateException("Global, Hybrid, Local, Homeは以外のStreamは対応していません。")
             }
+        }
+    }
+
+    private fun Flow<ChannelBody>.convertToNote(getAccount: suspend () -> Account, pageable: Pageable): Flow<Note> {
+        return mapNotNull {
+            it as? ChannelBody.ReceiveNote
         }.filter {
             if (pageable is CanOnlyMedia<*>) {
                 if (pageable.getOnlyMedia()) {
-                    !it.fileIds.isNullOrEmpty()
+                    !it.body.fileIds.isNullOrEmpty()
                 } else {
                     true
                 }
             } else {
                 true
             }
-        }
-    }
-
-    private fun Flow<ChannelBody>.convertToNote(getAccount: suspend () -> Account): Flow<Note> {
-        return mapNotNull {
-            it as? ChannelBody.ReceiveNote
         }.map {
             noteDataSourceAdder.addNoteDtoToDataSource(getAccount(), it.body)
         }
     }
 
-    private fun Flow<TootStatusDTO>.convertToNoteFromStatus(getAccount: suspend () -> Account): Flow<Note> {
-        return map {
+    private fun Flow<TootStatusDTO>.convertToNoteFromStatus(getAccount: suspend () -> Account, pageable: Pageable): Flow<Note> {
+        return filter {
+            if (pageable is CanOnlyMedia<*>) {
+                if (pageable.getOnlyMedia()) {
+                    it.mediaAttachments.isNotEmpty()
+                } else {
+                    true
+                }
+            } else {
+                true
+            }
+        }.map {
             noteDataSourceAdder.addTootStatusDtoIntoDataSource(getAccount(), it)
         }
     }

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/EditTabSettingDialog.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/EditTabSettingDialog.kt
@@ -4,14 +4,17 @@ import android.app.Dialog
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.activityViewModels
 import dagger.hilt.android.AndroidEntryPoint
+import net.pantasystem.milktea.model.account.page.CanOnlyMedia
+import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.setting.databinding.DialogEditTabNameBinding
 import net.pantasystem.milktea.setting.viewmodel.page.PageSettingViewModel
 
 @AndroidEntryPoint
-class EditTabNameDialog : AppCompatDialogFragment(){
+class EditTabSettingDialog : AppCompatDialogFragment(){
 
     private val pageSettingViewModel: PageSettingViewModel by activityViewModels()
 
@@ -29,10 +32,31 @@ class EditTabNameDialog : AppCompatDialogFragment(){
         }
         binding.editTabName.setText(page.title)
 
+         when(val pageable = page.pageable()) {
+            is CanOnlyMedia<*> -> {
+                binding.toggleOnlyMedia.isVisible = true
+                binding.toggleOnlyMedia.isChecked = pageable.getOnlyMedia()
+            }
+            else -> {
+                binding.toggleOnlyMedia.isVisible = false
+            }
+        }
+
+
+
         binding.okButton.setOnClickListener {
             val name = binding.editTabName.text?.toString()
             if(name?.isNotBlank() == true){
-                val updated = page.copy(title = name)
+                var target = page
+                when(val pageable = target.pageable()) {
+                    is CanOnlyMedia<*> -> {
+                        target = target.copy(
+                            pageParams = (pageable.setOnlyMedia(binding.toggleOnlyMedia.isChecked) as Pageable).toParams()
+                        )
+                    }
+                    else -> Unit
+                }
+                val updated = target.copy(title = name)
                 pageSettingViewModel.updatePage(updated)
             }
             dismiss()

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/PageSettingActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/PageSettingActivity.kt
@@ -17,7 +17,7 @@ import net.pantasystem.milktea.common.ui.ApplyTheme
 import net.pantasystem.milktea.common_navigation.*
 import net.pantasystem.milktea.common_navigation.SearchAndSelectUserNavigation.Companion.EXTRA_SELECTED_USER_CHANGED_DIFF
 import net.pantasystem.milktea.model.account.page.PageType
-import net.pantasystem.milktea.setting.EditTabNameDialog
+import net.pantasystem.milktea.setting.EditTabSettingDialog
 import net.pantasystem.milktea.setting.PageSettingActionDialog
 import net.pantasystem.milktea.setting.compose.tab.TabItemsListScreen
 import net.pantasystem.milktea.setting.compose.tab.rememberDragDropListState
@@ -62,7 +62,7 @@ class PageSettingActivity : AppCompatActivity() {
         }
 
         mPageSettingViewModel.pageOnUpdateEvent.observe(this) {
-            EditTabNameDialog().show(supportFragmentManager, "ETD")
+            EditTabSettingDialog().show(supportFragmentManager, "ETD")
         }
 //
         mPageSettingViewModel.pageAddedEvent.observe(this) { pt ->

--- a/modules/features/setting/src/main/res/layout/dialog_edit_tab_name.xml
+++ b/modules/features/setting/src/main/res/layout/dialog_edit_tab_name.xml
@@ -15,12 +15,20 @@
                 android:layout_marginBottom="8dp"
                 android:text="@string/edit_tab_name"
                 />
+
+        <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/toggleOnlyMedia"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/titleView"
+                android:text="@string/settings_edit_tab_only_media"/>
+
         <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/tabNameInput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="8dp"
-                android:layout_below="@id/titleView"
+                android:layout_below="@id/toggleOnlyMedia"
                 >
             <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/editTabName"
@@ -30,22 +38,22 @@
                     android:singleLine="true"/>
         </com.google.android.material.textfield.TextInputLayout>
 
-        <Button
+        <com.google.android.material.button.MaterialButton
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_below="@id/tabNameInput"
                 android:id="@+id/cancelButton"
                 android:layout_toStartOf="@id/okButton"
                 android:layout_marginEnd="8dp"
-                style="@style/Widget.AppCompat.Button.Borderless"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
                 android:text="@android:string/cancel"/>
-        <Button
+        <com.google.android.material.button.MaterialButton
                 android:id="@+id/okButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_below="@id/tabNameInput"
                 android:layout_alignParentEnd="true"
-                style="@style/Widget.AppCompat.Button.Borderless"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
                 android:text="@android:string/ok"/>
     </RelativeLayout>
 </layout>

--- a/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
+++ b/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
@@ -12,5 +12,6 @@
     <string name="is_stop_note_capture_when_background">バックグラウンドでノートをキャプチャしない</string>
     <string name="enable_automic_updates">自動更新を有効にする</string>
     <string name="please_login">ログインしてください</string>
+    <string name="settings_edit_tab_only_media">Only Media</string>
 
 </resources>

--- a/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
+++ b/modules/features/setting/src/main/res/values-ja-rJP/strings.xml
@@ -12,6 +12,6 @@
     <string name="is_stop_note_capture_when_background">バックグラウンドでノートをキャプチャしない</string>
     <string name="enable_automic_updates">自動更新を有効にする</string>
     <string name="please_login">ログインしてください</string>
-    <string name="settings_edit_tab_only_media">Only Media</string>
+    <string name="settings_edit_tab_only_media">ファイルが添付されたノートのみ表示する</string>
 
 </resources>

--- a/modules/features/setting/src/main/res/values-zh/strings.xml
+++ b/modules/features/setting/src/main/res/values-zh/strings.xml
@@ -12,5 +12,6 @@
     <string name="is_stop_note_capture_when_background">不要在后台捕捉笔记</string>
     <string name="enable_automic_updates">启用自动更新</string>
     <string name="please_login">请登录</string>
+    <string name="settings_edit_tab_only_media">Only Media</string>
 
 </resources>

--- a/modules/features/setting/src/main/res/values/strings.xml
+++ b/modules/features/setting/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="is_stop_note_capture_when_background">Do not capture notes in background</string>
     <string name="enable_automic_updates">Enable automatic updates</string>
     <string name="please_login">Please login</string>
+    <string name="settings_edit_tab_only_media">Only Media</string>
 </resources>

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/MakeDefaultPagesUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/MakeDefaultPagesUseCase.kt
@@ -13,6 +13,7 @@ interface PageDefaultStrings {
     val globalTimeline: String
     val localTimeline: String
     val recommendedTimeline: String
+    val media: String
 }
 
 
@@ -28,6 +29,9 @@ class PageDefaultStringsJp : PageDefaultStrings {
         get() = "ローカル"
     override val recommendedTimeline: String
         get() = "一押し"
+
+    override val media: String
+        get() = "メディア"
 }
 
 class MakeDefaultPagesUseCase(
@@ -46,6 +50,11 @@ class MakeDefaultPagesUseCase(
                 defaultPages.add(PageableTemplate(account).homeTimeline(pageDefaultStrings.homeTimeline))
                 if (isLocalEnabled) {
                     defaultPages.add(PageableTemplate(account).hybridTimeline(pageDefaultStrings.hybridThrowable))
+                }
+                if (isLocalEnabled) {
+                    defaultPages.add(PageableTemplate(account).hybridTimeline(pageDefaultStrings.media, withFiles = true))
+                } else {
+                    defaultPages.add(PageableTemplate(account).homeTimeline(pageDefaultStrings.media, withFiles = true))
                 }
                 if (isGlobalEnabled) {
                     defaultPages.add(PageableTemplate(account).globalTimeline(pageDefaultStrings.globalTimeline))

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
@@ -11,9 +11,23 @@ sealed class Pageable : Serializable {
 
         var withFiles: Boolean? = null
 
-    ) : Pageable(), UntilPaginate, SincePaginate {
+    ) : Pageable(), UntilPaginate, SincePaginate, CanOnlyMedia<GlobalTimeline> {
         override fun toParams(): PageParams {
             return PageParams(withFiles = withFiles, type = PageType.GLOBAL)
+        }
+
+        override fun setOnlyMedia(isOnlyMedia: Boolean): GlobalTimeline {
+            // NOTE: Misskeyの場合falseを指定してしまうとファイルを除外してしまう
+            // NOTE: setMediaOnlyなのにファイルを除外してしまう挙動をしてしまうのは不自然なのでfalseの場合はnullを指定している
+            return copy(
+                withFiles = isOnlyMedia.takeIf {
+                    it
+                }
+            )
+        }
+
+        override fun getOnlyMedia(): Boolean {
+            return withFiles ?: false
         }
     }
 
@@ -22,9 +36,21 @@ sealed class Pageable : Serializable {
         var withFiles: Boolean? = null,
         var excludeNsfw: Boolean? = null
 
-    ) : Pageable(), UntilPaginate, SincePaginate {
+    ) : Pageable(), UntilPaginate, SincePaginate, CanOnlyMedia<LocalTimeline> {
         override fun toParams(): PageParams {
             return PageParams(PageType.LOCAL, withFiles = withFiles, excludeNsfw = excludeNsfw)
+        }
+
+        override fun setOnlyMedia(isOnlyMedia: Boolean): LocalTimeline {
+            return copy(
+                withFiles = isOnlyMedia.takeIf {
+                    it
+                }
+            )
+        }
+
+        override fun getOnlyMedia(): Boolean {
+            return withFiles ?: false
         }
     }
 
@@ -35,7 +61,7 @@ sealed class Pageable : Serializable {
         var includeMyRenotes: Boolean? = null,
         var includeRenotedMyRenotes: Boolean? = null
 
-    ) : Pageable(), UntilPaginate, SincePaginate {
+    ) : Pageable(), UntilPaginate, SincePaginate, CanOnlyMedia<HybridTimeline> {
         override fun toParams(): PageParams {
             return PageParams(
                 type = PageType.SOCIAL,
@@ -44,6 +70,18 @@ sealed class Pageable : Serializable {
                 includeMyRenotes = includeMyRenotes,
                 includeRenotedMyRenotes = includeRenotedMyRenotes
             )
+        }
+
+        override fun setOnlyMedia(isOnlyMedia: Boolean): HybridTimeline {
+            return copy(
+                withFiles = isOnlyMedia.takeIf {
+                    it
+                }
+            )
+        }
+
+        override fun getOnlyMedia(): Boolean {
+            return withFiles ?: false
         }
     }
 
@@ -54,7 +92,7 @@ sealed class Pageable : Serializable {
         var includeMyRenotes: Boolean? = null,
         var includeRenotedMyRenotes: Boolean? = null
 
-    ) : Pageable(), UntilPaginate, SincePaginate {
+    ) : Pageable(), UntilPaginate, SincePaginate, CanOnlyMedia<HomeTimeline> {
 
         override fun toParams(): PageParams {
             return PageParams(
@@ -64,6 +102,18 @@ sealed class Pageable : Serializable {
                 includeLocalRenotes = includeLocalRenotes,
                 includeMyRenotes = includeMyRenotes
             )
+        }
+
+        override fun setOnlyMedia(isOnlyMedia: Boolean): HomeTimeline {
+            return copy(
+                withFiles = isOnlyMedia.takeIf {
+                    it
+                }
+            )
+        }
+
+        override fun getOnlyMedia(): Boolean {
+            return withFiles ?: false
         }
     }
 
@@ -75,7 +125,7 @@ sealed class Pageable : Serializable {
         var includeMyRenotes: Boolean? = null,
         var includeRenotedMyRenotes: Boolean? = null
 
-    ) : Pageable(), UntilPaginate, SincePaginate {
+    ) : Pageable(), UntilPaginate, SincePaginate, CanOnlyMedia<UserListTimeline> {
 
         override fun toParams(): PageParams {
             return PageParams(
@@ -86,6 +136,18 @@ sealed class Pageable : Serializable {
                 includeMyRenotes = includeMyRenotes,
                 includeRenotedMyRenotes = includeRenotedMyRenotes
             )
+        }
+
+        override fun setOnlyMedia(isOnlyMedia: Boolean): UserListTimeline {
+            return copy(
+                withFiles = isOnlyMedia.takeIf {
+                    it
+                }
+            )
+        }
+
+        override fun getOnlyMedia(): Boolean {
+            return withFiles ?: false
         }
     }
 
@@ -135,7 +197,7 @@ sealed class Pageable : Serializable {
         var withFiles: Boolean? = null,
         var poll: Boolean? = null
 
-    ) : Pageable(), UntilPaginate, SincePaginate {
+    ) : Pageable(), UntilPaginate, SincePaginate, CanOnlyMedia<SearchByTag> {
         override fun toParams(): PageParams {
             return PageParams(
                 PageType.SEARCH_HASH,
@@ -145,6 +207,18 @@ sealed class Pageable : Serializable {
                 withFiles = withFiles,
                 poll = poll
             )
+        }
+
+        override fun setOnlyMedia(isOnlyMedia: Boolean): SearchByTag {
+            return copy(
+                withFiles = isOnlyMedia.takeIf {
+                    it
+                }
+            )
+        }
+
+        override fun getOnlyMedia(): Boolean {
+            return withFiles ?: false
         }
     }
 
@@ -183,7 +257,7 @@ sealed class Pageable : Serializable {
         var includeMyRenotes: Boolean? = true,
         var withFiles: Boolean? = null
 
-    ) : Pageable(), SincePaginate, UntilPaginate {
+    ) : Pageable(), SincePaginate, UntilPaginate, CanOnlyMedia<UserTimeline> {
         override fun toParams(): PageParams {
             return PageParams(
                 PageType.USER,
@@ -192,6 +266,18 @@ sealed class Pageable : Serializable {
                 withFiles = withFiles,
                 userId = userId
             )
+        }
+
+        override fun setOnlyMedia(isOnlyMedia: Boolean): UserTimeline {
+            return copy(
+                withFiles = isOnlyMedia.takeIf {
+                    it
+                }
+            )
+        }
+
+        override fun getOnlyMedia(): Boolean {
+            return withFiles ?: false
         }
     }
 
@@ -283,34 +369,64 @@ sealed class Pageable : Serializable {
     sealed class Mastodon : Pageable() {
         data class PublicTimeline(
             val isOnlyMedia: Boolean? = null
-        ) : Mastodon() {
+        ) : Mastodon(), CanOnlyMedia<PublicTimeline> {
             override fun toParams(): PageParams {
                 return PageParams(
                     type = PageType.MASTODON_PUBLIC_TIMELINE,
                     withFiles = isOnlyMedia
                 )
             }
+
+            override fun setOnlyMedia(isOnlyMedia: Boolean): PublicTimeline {
+                return copy(
+                    isOnlyMedia = isOnlyMedia
+                )
+            }
+
+            override fun getOnlyMedia(): Boolean {
+                return isOnlyMedia ?: false
+            }
         }
 
         data class LocalTimeline(
             val isOnlyMedia: Boolean? = null
-        ) : Mastodon() {
+        ) : Mastodon(), CanOnlyMedia<LocalTimeline> {
             override fun toParams(): PageParams {
                 return PageParams(
                     type = PageType.MASTODON_LOCAL_TIMELINE,
                     withFiles = isOnlyMedia,
                 )
             }
+
+            override fun setOnlyMedia(isOnlyMedia: Boolean): LocalTimeline {
+                return copy(
+                    isOnlyMedia = isOnlyMedia
+                )
+            }
+
+            override fun getOnlyMedia(): Boolean {
+                return isOnlyMedia ?: false
+            }
         }
 
         data class HashTagTimeline(val hashtag: String, val isOnlyMedia: Boolean? = null) :
-            Mastodon() {
+            Mastodon(), CanOnlyMedia<HashTagTimeline> {
             override fun toParams(): PageParams {
                 return PageParams(
                     type = PageType.MASTODON_HASHTAG_TIMELINE,
                     tag = hashtag,
                     withFiles = isOnlyMedia
                 )
+            }
+
+            override fun setOnlyMedia(isOnlyMedia: Boolean): HashTagTimeline {
+                return copy(
+                    isOnlyMedia = isOnlyMedia
+                )
+            }
+
+            override fun getOnlyMedia(): Boolean {
+                return isOnlyMedia ?: false
             }
         }
 
@@ -336,7 +452,7 @@ sealed class Pageable : Serializable {
             val isOnlyMedia: Boolean? = null,
             val excludeReplies: Boolean? = null,
             val excludeReblogs: Boolean? = null,
-        ) : Mastodon() {
+        ) : Mastodon(), CanOnlyMedia<UserTimeline> {
             override fun toParams(): PageParams {
                 return PageParams(
                     type = PageType.MASTODON_USER_TIMELINE,
@@ -345,6 +461,14 @@ sealed class Pageable : Serializable {
                     includeMyRenotes = excludeReblogs?.not(),
                     userId = userId
                 )
+            }
+
+            override fun setOnlyMedia(isOnlyMedia: Boolean): UserTimeline {
+                return copy(isOnlyMedia = isOnlyMedia)
+            }
+
+            override fun getOnlyMedia(): Boolean {
+                return isOnlyMedia ?: false
             }
         }
 
@@ -362,4 +486,16 @@ sealed class Pageable : Serializable {
     abstract fun toParams(): PageParams
 
 
+}
+
+/**
+ * リクエスト時にwithFiles(Misskey)の指定が可能なタイムライン種別であることを表すためのインターフェース
+ * これを継承したPageableはメディアのみ、あるいはメディアを除外したリクエストを送信することができる。
+ * 注意点がありMisskeyの場合デフォルトがundefined(null)になるがMastodonではfalseがデフォルトになる。
+ * またMisskeyの場合trueを指定するとファイルが添付されたノートのみになり、
+ * falseを指定するとファイルが添付されていないノートのみになる。
+ */
+interface CanOnlyMedia<T> {
+    fun setOnlyMedia(isOnlyMedia: Boolean): T
+    fun getOnlyMedia(): Boolean
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageableTemplate.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageableTemplate.kt
@@ -9,13 +9,13 @@ class PageableTemplate(val account: Account?) {
     fun globalTimeline(title: String): Page {
         return Page(account?.accountId?: - 1, title, 0, Pageable.GlobalTimeline())
     }
-    fun hybridTimeline(title: String) =
-        Page(account?.accountId?: - 1, title, 0, Pageable.HybridTimeline())
+    fun hybridTimeline(title: String, withFiles: Boolean? = null) =
+        Page(account?.accountId?: - 1, title, 0, Pageable.HybridTimeline(withFiles = withFiles))
 
     fun localTimeline(title: String) =
         Page(account?.accountId?: - 1, title, 0, Pageable.LocalTimeline())
 
-    fun homeTimeline(title: String) = Page(account?.accountId?: - 1, title, 0, Pageable.HomeTimeline())
+    fun homeTimeline(title: String, withFiles: Boolean? = null) = Page(account?.accountId?: - 1, title, 0, Pageable.HomeTimeline(withFiles = withFiles))
 
     fun userListTimeline(listId: String) = Pageable.UserListTimeline(listId = listId)
 


### PR DESCRIPTION
## やったこと
ファイルが添付されたノートのみを表示するメディアタイムラインの実装を行いました。
タブが一つも設定されていない時に自動的に設定されるタブの項目にメディアタイムラインを追加するようにしました。
LTLに対応しているMisskeyインスタンスの場合はSocial + only mediaとして
LTLに対応していないMisskeyインスタンスの場合はHome + only mediaとして追加するようにしました。
またタブ設定画面からMisskeyならwithFiles, Mastodonならonly_mediaに対応しているタイムライン種別の場合は
Switchでメディアのみの指定の切り替えを行えるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1404 


