### PR TITLE
アカウント切り替え時にフォローリクエスト一覧の内容が切り替わらない問題を修正

### DIFF
--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsFragment.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsFragment.kt
@@ -55,14 +55,14 @@ class FollowRequestsFragment : Fragment() {
                                 rememberNestedScrollInteropConnection()
                             ),
                         uiState = uiState,
-                        onAccept = viewModel::accept,
-                        onReject = viewModel::reject,
+                        onAccept = viewModel::onAccept,
+                        onReject = viewModel::onReject,
                         onAvatarClicked = {
                             startActivity(
                                 userDetailNavigation.newIntent(UserDetailNavigationArgs.UserId(it))
                             )
                         },
-                        onRefresh = viewModel::refresh
+                        onRefresh = viewModel::onRefresh
                     )
                 }
             }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsViewModel.kt
@@ -45,6 +45,8 @@ class FollowRequestsViewModel @Inject constructor(
     }.flatMapLatest { ids ->
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest { account ->
             userDataSource.observeIn(account.accountId, ids.map { it.id })
+        }.onStart {
+            emit(emptyList())
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/follow_requests/FollowRequestsViewModel.kt
@@ -79,11 +79,11 @@ class FollowRequestsViewModel @Inject constructor(
 
     init {
         accountStore.observeCurrentAccount.distinctUntilChanged().onEach {
-            refresh()
+            onRefresh()
         }.launchIn(viewModelScope)
     }
 
-    fun refresh() {
+    fun onRefresh() {
         viewModelScope.launch {
             pagingStore.clear()
             pagingStore.loadPrevious().onFailure {
@@ -92,26 +92,26 @@ class FollowRequestsViewModel @Inject constructor(
         }
     }
 
-    fun accept(userId: User.Id) {
+    fun onAccept(userId: User.Id) {
         viewModelScope.launch {
             runCancellableCatching {
                 followRequestRepository.accept(userId)
             }.onFailure {
                 _errors.tryEmit(it)
             }.onSuccess {
-                refresh()
+                onRefresh()
             }
         }
     }
 
-    fun reject(userId: User.Id) {
+    fun onReject(userId: User.Id) {
         viewModelScope.launch {
             runCancellableCatching {
                 followRequestRepository.reject(userId)
             }.onFailure {
                 _errors.tryEmit(it)
             }.onSuccess {
-                refresh()
+                onRefresh()
             }
         }
     }


### PR DESCRIPTION
## やったこと
空の要素でキャッシュにアクセスした時に
データが返ってことないため以前の状態が参照されてしまうため
アカウントが切り替わっても前回の値が参照されてしまうことがわかった。
そこでFlow開始時に空のリストを流すようにした

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1488 


