### PR TITLE
特定のバージョン以上ではグループ機能が表示されないようにした

### DIFF
--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/FeatureEnablesImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/FeatureEnablesImpl.kt
@@ -35,15 +35,16 @@ class FeatureEnablesImpl @Inject constructor(
             val nodeInfo = nodeInfoRepository.find(URL(instanceDomain).host).getOrNull() ?: return@withContext emptySet()
             val version = meta?.getVersion() ?: nodeInfo.type.getVersion()
             val isMisskey = meta != null || nodeInfo.type is NodeInfo.SoftwareType.Misskey
+            val isCalckey = isMisskey && nodeInfo.type is NodeInfo.SoftwareType.Misskey.Calckey
             val isMastodon = nodeInfo.type is NodeInfo.SoftwareType.Mastodon
             setOfNotNull(
                 if (isMisskey && version >= Version("12.75.0")) FeatureType.Gallery else null,
                 if (isMisskey && version >= Version("12")) FeatureType.Channel else null,
-                if (isMisskey && version >= Version("11")) FeatureType.Group else null,
+                if (isMisskey && version >= Version("11") && version <= Version("13.6.1") || isCalckey) FeatureType.Group else null,
                 if (isMisskey && version >= Version("12.75.0")) FeatureType.Antenna else null,
                 if (isMisskey && version >= Version("12")) FeatureType.UserReactionHistory else null,
                 if (isMisskey && version >= Version("12")) FeatureType.Clip else null,
-                if (isMisskey && version <= Version("13.6.1")) FeatureType.Messaging else null,
+                if (isMisskey && version <= Version("13.6.1") || isCalckey) FeatureType.Messaging else null,
                 if (isMisskey) FeatureType.Drive else null,
                 if (isMastodon) FeatureType.Bookmark else null,
             )


### PR DESCRIPTION
v13.6.1以降グループ機能が削除されたので
グループを非表示にするようにしました。
ただしCalckeyではまだメッセージとグループを使うことができるので
Calckeyの場合は有効にするようにしました。

## やったこと


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1499 



