### PR TITLE
Fragment関連のメモリリーク問題を修正

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/tab/TabFragment.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/tab/TabFragment.kt
@@ -83,7 +83,7 @@ class TabFragment : Fragment(R.layout.fragment_tab) {
         binding.viewPager.adapter = mPagerAdapter
         binding.tabLayout.setupWithViewPager(binding.viewPager)
 
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 mTabViewModel.pages.collect { pages ->
                     mPages = pages
@@ -107,7 +107,7 @@ class TabFragment : Fragment(R.layout.fragment_tab) {
                 }
             }
         }
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 mTabViewModel.currentUser.filterNotNull().collect {
                     GlideApp.with(binding.currentAccountView)
@@ -128,7 +128,10 @@ class TabFragment : Fragment(R.layout.fragment_tab) {
                     binding.currentInstanceHostView.text = it.host
                 }
             }
-        }.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED).launchIn(lifecycleScope)
+        }.flowWithLifecycle(
+            viewLifecycleOwner.lifecycle,
+            Lifecycle.State.RESUMED
+        ).launchIn(viewLifecycleOwner.lifecycleScope)
 
     }
 
@@ -194,6 +197,7 @@ internal class TimelinePagerAdapter(
         mFragments.clear()
         oldRequestBaseSetting = requestBaseList
         requestBaseList = list
+        mFragments.clear()
         if (requestBaseList != oldRequestBaseSetting) {
             notifyDataSetChanged()
         }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
@@ -246,7 +246,10 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
 
         accountViewModel.switchAccountEvent.onEach {
             AccountSwitchingDialog().show(childFragmentManager, "tag")
-        }.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED).launchIn(lifecycleScope)
+        }.flowWithLifecycle(
+            viewLifecycleOwner.lifecycle,
+            Lifecycle.State.RESUMED
+        ).launchIn(viewLifecycleOwner.lifecycleScope)
 
         accountViewModel.showProfileEvent.onEach {
             val intent = userDetailNavigation.newIntent(
@@ -256,7 +259,10 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
             )
             intent.putActivity(Activities.ACTIVITY_IN_APP)
             startActivity(intent)
-        }.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED).launchIn(lifecycleScope)
+        }.flowWithLifecycle(
+            viewLifecycleOwner.lifecycle,
+            Lifecycle.State.RESUMED
+        ).launchIn(viewLifecycleOwner.lifecycleScope)
 
 
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
@@ -279,7 +285,7 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
                 )
             )
             binding.cw.setTokenizer(CustomEmojiTokenizer())
-        }.launchIn(lifecycleScope)
+        }.launchIn(viewLifecycleOwner.lifecycleScope)
 
         if (!text.isNullOrBlank() && savedInstanceState == null) {
             noteEditorViewModel.changeText(text)
@@ -353,7 +359,7 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
                 )
             }
         }
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 noteEditorViewModel.poll.distinctUntilChangedBy {
                     it == null
@@ -421,7 +427,7 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
         }
 
 
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 accountStore.state.collect {
                     if (it.isUnauthorized) {
@@ -444,11 +450,17 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
                     }
                 }
             }
-        }.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED).launchIn(lifecycleScope)
+        }.flowWithLifecycle(
+            viewLifecycleOwner.lifecycle,
+            Lifecycle.State.RESUMED
+        ).launchIn(viewLifecycleOwner.lifecycleScope)
 
         confirmViewModel.confirmEvent.onEach {
             ConfirmDialog.newInstance(it).show(childFragmentManager, "confirm")
-        }.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED).launchIn(lifecycleScope)
+        }.flowWithLifecycle(
+            viewLifecycleOwner.lifecycle,
+            Lifecycle.State.RESUMED
+        ).launchIn(viewLifecycleOwner.lifecycleScope)
 
 
         noteEditorViewModel.isSaveNoteAsDraft.observe(viewLifecycleOwner) {
@@ -459,11 +471,9 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
                     upTo()
                 }
             }
-
-
         }
 
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             noteEditorViewModel.textCursorPos.collect {
                 try {
                     binding.inputMain.setText(
@@ -476,7 +486,7 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
             }
         }
 
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             noteEditorViewModel.fileSizeInvalidEvent.collect {
                 whenStarted {
                     NoteEditorFileSizeWarningDialog.newInstance(

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/emojis/EmojiPickerFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/emojis/EmojiPickerFragment.kt
@@ -50,7 +50,7 @@ class EmojiPickerFragment : Fragment(R.layout.fragment_emoji_picker), ReactionSe
         binding.emojiPickerViewModel = emojiPickerViewModel
         val binder = EmojiSelectionBinder(
             context = requireContext(),
-            scope = lifecycleScope,
+            scope = viewLifecycleOwner.lifecycleScope,
             fragmentManager = childFragmentManager,
             lifecycleOwner = viewLifecycleOwner,
             searchSuggestionListView = binding.searchSuggestionsView,

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/pinned/PinnedNoteFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/pinned/PinnedNoteFragment.kt
@@ -92,7 +92,7 @@ class PinnedNoteFragment : Fragment(R.layout.fragment_pinned_notes) {
         binding.listView.adapter = adapter
         binding.listView.layoutManager = LinearLayoutManager(requireContext())
 
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 pinnedNotesViewModel.notes.collect {
                     adapter.submitList(it)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/history/ReactionHistoryListFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/history/ReactionHistoryListFragment.kt
@@ -63,7 +63,7 @@ class ReactionHistoryListFragment : Fragment(R.layout.fragment_reaction_history_
         mLinearLayoutManager = LinearLayoutManager(requireContext())
         binding.historiesView.layoutManager = mLinearLayoutManager
         binding.historiesView.addOnScrollListener(mScrollListener)
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 viewModel.uiState.collect { uiState ->
                     listAdapter.submitList(uiState.items)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
@@ -189,17 +189,26 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
 
         mViewModel.timelineListState.onEach { state ->
             adapter.submitList(state)
-        }.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED).launchIn(lifecycleScope)
+        }.flowWithLifecycle(
+            viewLifecycleOwner.lifecycle,
+            Lifecycle.State.RESUMED
+        ).launchIn(viewLifecycleOwner.lifecycleScope)
 
 
         mViewModel.errorEvent.onEach { error ->
             TimelineErrorHandler(requireContext())(error)
-        }.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED).launchIn(lifecycleScope)
+        }.flowWithLifecycle(
+            viewLifecycleOwner.lifecycle,
+            Lifecycle.State.RESUMED
+        ).launchIn(viewLifecycleOwner.lifecycleScope)
 
 
         scrollToTopViewModel.scrollToTopEvent.onEach {
                 mBinding.listView.smoothScrollToPosition(0)
-        }.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED).launchIn(lifecycleScope)
+        }.flowWithLifecycle(
+            viewLifecycleOwner.lifecycle,
+            Lifecycle.State.RESUMED
+        ).launchIn(viewLifecycleOwner.lifecycleScope)
 
 
         adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationFragment.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationFragment.kt
@@ -108,14 +108,20 @@ class NotificationFragment : Fragment(R.layout.fragment_notification) {
 
         mViewModel.errors.onEach {
             NotificationErrorHandler(requireContext())(it)
-        }.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED).launchIn(lifecycleScope)
+        }.flowWithLifecycle(
+            viewLifecycleOwner.lifecycle,
+            Lifecycle.State.RESUMED
+        ).launchIn(viewLifecycleOwner.lifecycleScope)
 
         mBinding.notificationListView.adapter = adapter
         mBinding.notificationListView.layoutManager = mLinearLayoutManager
 
         mViewModel.notifications.onEach {
             adapter.submitList(it)
-        }.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED).launchIn(lifecycleScope)
+        }.flowWithLifecycle(
+            viewLifecycleOwner.lifecycle,
+            Lifecycle.State.RESUMED
+        ).launchIn(viewLifecycleOwner.lifecycleScope)
 
 
         mViewModel.isLoading.observe(viewLifecycleOwner) {
@@ -127,7 +133,7 @@ class NotificationFragment : Fragment(R.layout.fragment_notification) {
         }
         mBinding.notificationListView.addOnScrollListener(mScrollListener)
 
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 scrollToTopViewModel.scrollToTopEvent.collect {
                     mBinding.notificationListView.smoothScrollToPosition(0)

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationMentionFragment.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationMentionFragment.kt
@@ -74,7 +74,7 @@ class NotificationMentionFragment : Fragment(R.layout.fragment_notification_ment
 
         accountStore.observeCurrentAccount.filterNotNull().onEach {
             notificationPagerAdapter.notifyDataSetChanged()
-        }.launchIn(lifecycleScope)
+        }.launchIn(viewLifecycleOwner.lifecycleScope)
 
     }
 


### PR DESCRIPTION
## やったこと
- TabFragmentで独自に保持していたFragmentの解放タイミングを変更
- FragmentのlifecycleOwnerからlifecycle, lifecycleScopeを取得していたのを、viewLifecycleOnwerから取得するように変更。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号


