### PR TITLE
リノートのミュートの設定画面を追加しました

### DIFF
--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -460,6 +460,7 @@
 
     <string name="user_detail_mute_renotes">リノートを表示しない</string>
     <string name="user_detail_unmute_renotes">リノートを表示する</string>
+    <string name="settings_renote_mute_title">リノート非表示ユーザ</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -456,6 +456,7 @@
     <string name="content_not_exists_message">无内容</string>
     <string name="user_detail_mute_renotes">Mute Renotes</string>
     <string name="user_detail_unmute_renotes">Unmute renotes</string>
+    <string name="settings_renote_mute_title">远程静音</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -450,5 +450,6 @@
     <string name="content_not_exists_message">No content</string>
     <string name="user_detail_mute_renotes">Mute Renotes</string>
     <string name="user_detail_unmute_renotes">Unmute renotes</string>
+    <string name="settings_renote_mute_title">Renote mutes</string>
 
 </resources>

--- a/modules/features/setting/src/main/AndroidManifest.xml
+++ b/modules/features/setting/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <application>
         <activity
-            android:name=".ReactionMuteSettingActivity"
+            android:name=".activities.RenoteMuteSettingActivity"
             android:exported="false" />
         <activity
             android:name=".activities.AccountSettingActivity"

--- a/modules/features/setting/src/main/AndroidManifest.xml
+++ b/modules/features/setting/src/main/AndroidManifest.xml
@@ -1,27 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-        package="net.pantasystem.milktea.setting">
+    package="net.pantasystem.milktea.setting">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application>
         <activity
-                android:name=".activities.AccountSettingActivity"
-                android:exported="false">
+            android:name=".ReactionMuteSettingActivity"
+            android:exported="false" />
+        <activity
+            android:name=".activities.AccountSettingActivity"
+            android:exported="false">
             <meta-data
-                    android:name="android.app.lib_name"
-                    android:value="" />
+                android:name="android.app.lib_name"
+                android:value="" />
         </activity>
         <activity
-                android:name=".activities.ImportReactionFromWebViewActivity"
-                android:exported="false">
+            android:name=".activities.ImportReactionFromWebViewActivity"
+            android:exported="false">
             <meta-data
-                    android:name="android.app.lib_name"
-                    android:value="" />
+                android:name="android.app.lib_name"
+                android:value="" />
         </activity>
         <activity
-                android:name=".activities.ClientWordFilterSettingActivity"
-                android:exported="false" />
+            android:name=".activities.ClientWordFilterSettingActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/RenoteMuteSettingActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/RenoteMuteSettingActivity.kt
@@ -1,0 +1,11 @@
+package net.pantasystem.milktea.setting.activities
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class RenoteMuteSettingActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+    }
+}

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/RenoteMuteSettingActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/RenoteMuteSettingActivity.kt
@@ -1,11 +1,60 @@
 package net.pantasystem.milktea.setting.activities
 
 import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import com.google.android.material.composethemeadapter.MdcTheme
+import dagger.hilt.android.AndroidEntryPoint
+import net.pantasystem.milktea.common.ui.ApplyTheme
+import net.pantasystem.milktea.common_navigation.UserDetailNavigation
+import net.pantasystem.milktea.common_navigation.UserDetailNavigationArgs
+import net.pantasystem.milktea.setting.compose.renote.mute.RenoteMuteSettingScreen
+import net.pantasystem.milktea.setting.viewmodel.RenoteMuteSettingViewModel
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class RenoteMuteSettingActivity : AppCompatActivity() {
+
+    @Inject
+    internal lateinit var applyTheme: ApplyTheme
+
+    @Inject
+    internal lateinit var userDetailNavigation: UserDetailNavigation
+
+    private val viewModel: RenoteMuteSettingViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        applyTheme()
 
+        setContent {
+            MdcTheme {
+                val uiState by viewModel.uiState.collectAsState()
+
+                RenoteMuteSettingScreen(
+                    uiState = uiState,
+                    onRemoveRenoteMuteButtonClicked = viewModel::onRemoveRenoteMute,
+                    onUserClicked = {
+                        startActivity(
+                            userDetailNavigation.newIntent(UserDetailNavigationArgs.UserId(it.id))
+                        )
+                    },
+                    onRefresh = {
+                        when(val account = uiState.currentAccount) {
+                            null -> Unit
+                            else -> {
+                                viewModel.onRefresh(account)
+                            }
+                        }
+                    },
+                    onNavigateUp = {
+                        finish()
+                    }
+                )
+            }
+        }
     }
 }

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingsActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingsActivity.kt
@@ -132,6 +132,20 @@ class SettingsActivity : AppCompatActivity() {
                                 startActivity(
                                     Intent(
                                         this@SettingsActivity,
+                                        RenoteMuteSettingActivity::class.java,
+                                    )
+                                )
+                            }
+                        ) {
+                            Text(stringResource(id = R.string.settings_renote_mute_title))
+                        }
+
+                        SettingListTileLayout(
+                            verticalPadding = 12.dp,
+                            onClick = {
+                                startActivity(
+                                    Intent(
+                                        this@SettingsActivity,
                                         ReactionSettingActivity::class.java,
                                     )
                                 )

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/compose/renote/mute/RenoteMuteSettingScreen.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/compose/renote/mute/RenoteMuteSettingScreen.kt
@@ -1,0 +1,141 @@
+package net.pantasystem.milktea.setting.compose.renote.mute
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
+import net.pantasystem.milktea.common.ResultState
+import net.pantasystem.milktea.common_compose.CustomEmojiText
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.renote.mute.RenoteMute
+import net.pantasystem.milktea.setting.R
+import net.pantasystem.milktea.setting.viewmodel.RenoteMuteSettingUiState
+
+@Composable
+fun RenoteMuteSettingScreen(
+    uiState: RenoteMuteSettingUiState,
+    onRemoveRenoteMuteButtonClicked: (RenoteMute) -> Unit,
+    onUserClicked: (User) -> Unit,
+    onRefresh: () -> Unit,
+    onNavigateUp: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(text = stringResource(id = R.string.settings_renote_mute_title))
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "navigate up")
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        SwipeRefresh(
+            state = rememberSwipeRefreshState(isRefreshing = uiState.syncState is ResultState.Loading),
+            onRefresh = onRefresh,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                items(uiState.renoteMutes.size) {
+                    val item = uiState.renoteMutes[it]
+                    RemovableSimpleUserCard(
+                        user = item.user,
+                        accountHost = uiState.currentAccount?.getHost(),
+                        onClick = {
+                            when (val user = item.user) {
+                                null -> Unit
+                                else -> {
+                                    onUserClicked(user)
+                                }
+                            }
+                        },
+                        onDeleteButtonClicked = {
+                            onRemoveRenoteMuteButtonClicked(item.renoteMute)
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun RemovableSimpleUserCard(
+    user: User?,
+    accountHost: String?,
+    onClick: () -> Unit,
+    onDeleteButtonClicked: () -> Unit,
+) {
+
+    Card(
+        onClick = onClick,
+        shape = RoundedCornerShape(0.dp),
+        modifier = Modifier.padding(0.5.dp),
+        backgroundColor = MaterialTheme.colors.surface
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier
+                .fillMaxWidth()
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)
+                    .weight(1f),
+            ) {
+                Image(
+                    painter = rememberAsyncImagePainter(user?.avatarUrl),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Column {
+                    CustomEmojiText(
+                        text = user?.displayName ?: "",
+                        emojis = user?.emojis ?: emptyList(),
+                        sourceHost = user?.host,
+                        accountHost = accountHost,
+                        parsedResult = user?.parsedResult,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(text = user?.displayUserName ?: "")
+                }
+            }
+            IconButton(onClick = onDeleteButtonClicked) {
+                Icon(Icons.Default.Delete, contentDescription = null)
+            }
+        }
+
+    }
+}

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/RenoteMuteSettingViewModel.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/RenoteMuteSettingViewModel.kt
@@ -1,0 +1,101 @@
+package net.pantasystem.milktea.setting.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import net.pantasystem.milktea.app_store.account.AccountStore
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.UserDataSource
+import net.pantasystem.milktea.model.user.renote.mute.RenoteMute
+import net.pantasystem.milktea.model.user.renote.mute.RenoteMuteRepository
+import javax.inject.Inject
+
+@HiltViewModel
+class RenoteMuteSettingViewModel @Inject constructor(
+    accountStore: AccountStore,
+    private val renoteMuteRepository: RenoteMuteRepository,
+    private val userDataSource: UserDataSource,
+) : ViewModel() {
+
+    private val currentAccount = accountStore.observeCurrentAccount
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val renoteMutes = currentAccount.filterNotNull().flatMapLatest {
+        renoteMuteRepository.observeBy(it.accountId)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val relatedUsers =
+        combine(currentAccount.filterNotNull(), renoteMutes) { account, mutes ->
+            AccountWithMutes(
+                account,
+                mutes,
+            )
+        }.flatMapLatest {
+            userDataSource.observeIn(it.account.accountId, it.userIds)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val uiState = combine(
+        currentAccount,
+        renoteMutes,
+        relatedUsers
+    ) { account, renoteMutes, users ->
+        RenoteMuteSettingUiState(
+            currentAccount = account,
+            renoteMutes = renoteMutes.map { renoteMute ->
+                RenoteMuteWithUser(
+                    renoteMute = renoteMute,
+                    user = users.firstOrNull {
+                        it.id == renoteMute.userId
+                    }
+                )
+            }
+
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        RenoteMuteSettingUiState(null, emptyList())
+    )
+
+    private val _errors = MutableSharedFlow<Throwable>(
+        extraBufferCapacity = 100,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    val errors = _errors.asSharedFlow()
+
+    fun onRemoveRenoteMute(renoteMute: RenoteMute) {
+        viewModelScope.launch {
+            renoteMuteRepository.delete(renoteMute.userId).onFailure {
+                _errors.tryEmit(it)
+            }
+        }
+    }
+}
+
+
+data class RenoteMuteSettingUiState(
+    val currentAccount: Account?,
+    val renoteMutes: List<RenoteMuteWithUser>,
+)
+
+data class RenoteMuteWithUser(
+    val renoteMute: RenoteMute,
+    val user: User?,
+)
+
+private data class AccountWithMutes(
+    val account: Account,
+    val mutes: List<RenoteMute>,
+) {
+    val userIds = mutes.map {
+        it.userId.id
+    }
+}


### PR DESCRIPTION
## やったこと
リノートをミュートしているユーザを一覧表示し
かつリノートのミュートを解除するための設定画面を作成し
一覧画面のリンクに設定画面へのリンクを追加しました。
また設定の状態をUIに表示するためのUIStateとそれを構築するためのViewModelを作成実装しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1522 
Closed #1516 


