### PR TITLE
aliasを用いてカスタム絵文字をフィルタすることができなかった不具合を修正

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/di/module/EmojiModule.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/di/module/EmojiModule.kt
@@ -1,6 +1,5 @@
 package jp.panta.misskeyandroidclient.di.module
 
-import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -9,10 +8,8 @@ import jp.panta.misskeyandroidclient.impl.CheckEmojiAndroidImpl
 import kotlinx.coroutines.CoroutineScope
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.data.infrastructure.DataBase
-import net.pantasystem.milktea.data.infrastructure.emoji.CustomEmojiRepositoryImpl
 import net.pantasystem.milktea.data.infrastructure.emoji.Utf8EmojiRepositoryImpl
 import net.pantasystem.milktea.data.infrastructure.emoji.Utf8EmojisDAO
-import net.pantasystem.milktea.model.emoji.CustomEmojiRepository
 import net.pantasystem.milktea.model.emoji.UtfEmojiRepository
 import net.pantasystem.milktea.model.notes.reaction.CheckEmoji
 import javax.inject.Singleton
@@ -48,12 +45,4 @@ object EmojiModule {
     fun provideUtf8EmojiDao(database: DataBase): Utf8EmojisDAO {
         return database.utf8EmojiDAO()
     }
-}
-
-@InstallIn(SingletonComponent::class)
-@Module
-abstract class EmojiBindsModule {
-    @Singleton
-    @Binds
-    abstract fun bindCustomEmojiRepository(impl: CustomEmojiRepositoryImpl): CustomEmojiRepository
 }

--- a/modules/data/src/androidTest/java/net/pantasystem/milktea/data/infrastructure/emoji/delegate/CustomEmojiUpInsertDelegateTest.kt
+++ b/modules/data/src/androidTest/java/net/pantasystem/milktea/data/infrastructure/emoji/delegate/CustomEmojiUpInsertDelegateTest.kt
@@ -1,0 +1,130 @@
+package net.pantasystem.milktea.data.infrastructure.emoji.delegate
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import net.pantasystem.milktea.data.infrastructure.DataBase
+import net.pantasystem.milktea.data.infrastructure.emoji.db.CustomEmojiAliasRecord
+import net.pantasystem.milktea.data.infrastructure.emoji.db.CustomEmojiDAO
+import net.pantasystem.milktea.data.infrastructure.emoji.db.toRecord
+import net.pantasystem.milktea.model.emoji.Emoji
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class CustomEmojiUpInsertDelegateTest {
+
+    private lateinit var dao: CustomEmojiDAO
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(context, DataBase::class.java).build()
+        dao = database.customEmojiDao()
+    }
+
+    @Test
+    fun giveNotExistsData() = runBlocking {
+        val emojis = listOf(
+            Emoji(
+                name = "test1",
+                aliases = listOf("a", "b", "c")
+            ),
+            Emoji(
+                name = "test2",
+                aliases = listOf("a2`", "b2", "c2")
+            ),
+            Emoji(
+                name = "test3",
+                aliases = listOf("a3", "b3", "c3", "d4")
+            ),
+            Emoji(
+                name = "test4",
+                aliases = listOf("")
+            )
+        )
+
+        val delegate = CustomEmojiUpInsertDelegate(dao)
+        delegate("misskey.pantasystem.com", emojis)
+
+        val actual = dao.findBy("misskey.pantasystem.com").map {
+            it.toModel()
+        }
+
+        val expect = emojis.map { emoji ->
+            emoji.copy(
+                aliases = emoji.aliases?.filterNot {
+                    it.isBlank()
+                }
+            )
+        }
+        Assert.assertEquals(
+            expect,
+            actual
+        )
+    }
+
+    @Test
+    fun giveExistsData() = runBlocking {
+        val existsData = listOf(
+            Emoji(
+                name = "test1",
+                aliases = listOf("a", "b", "c")
+            ),
+            Emoji(
+                name = "test2",
+                aliases = listOf("a2`", "b2", "c2")
+            ),
+        )
+
+        val emojis = listOf(
+            Emoji(
+                name = "test1",
+                aliases = listOf("a", "b", "c")
+            ),
+            Emoji(
+                name = "test2",
+                aliases = listOf("a2`", "b2", "c2", "updated-alias")
+            ),
+            Emoji(
+                name = "test3",
+                aliases = listOf("a3", "b3", "c3", "d4")
+            ),
+            Emoji(
+                name = "test4",
+                aliases = listOf("")
+            )
+        )
+
+        val ids = dao.insertAll(existsData.map { it.toRecord("misskey.pantasystem.com") })
+        ids.mapIndexed { index, l ->
+            existsData[index].aliases?.map {
+                CustomEmojiAliasRecord(l, it)
+            }?.let {
+                dao.insertAliases(it)
+            }
+
+        }
+
+        val delegate = CustomEmojiUpInsertDelegate(dao)
+        delegate("misskey.pantasystem.com", emojis)
+
+        val actual = dao.findBy("misskey.pantasystem.com").map {
+            it.toModel()
+        }
+
+        val expect = emojis.map { emoji ->
+            emoji.copy(
+                aliases = emoji.aliases?.filterNot {
+                    it.isBlank()
+                }
+            )
+        }
+        Assert.assertEquals(
+            expect,
+            actual
+        )
+    }
+
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/CustomEmojiModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/CustomEmojiModule.kt
@@ -1,0 +1,23 @@
+package net.pantasystem.milktea.data.di.module
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import net.pantasystem.milktea.data.infrastructure.emoji.CustomEmojiApiAdapter
+import net.pantasystem.milktea.data.infrastructure.emoji.CustomEmojiApiAdapterImpl
+import net.pantasystem.milktea.data.infrastructure.emoji.CustomEmojiRepositoryImpl
+import net.pantasystem.milktea.model.emoji.CustomEmojiRepository
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+abstract class CustomEmojiModule {
+
+    @Binds
+    internal abstract fun customEmojiApiAdapter(impl: CustomEmojiApiAdapterImpl): CustomEmojiApiAdapter
+
+    @Singleton
+    @Binds
+    internal abstract fun bindCustomEmojiRepository(impl: CustomEmojiRepositoryImpl): CustomEmojiRepository
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiApiAdapter.kt
@@ -1,0 +1,61 @@
+package net.pantasystem.milktea.data.infrastructure.emoji
+
+import net.pantasystem.milktea.api.misskey.EmptyRequest
+import net.pantasystem.milktea.common.throwIfHasError
+import net.pantasystem.milktea.common_android.emoji.V13EmojiUrlResolver
+import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
+import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.model.emoji.Emoji
+import net.pantasystem.milktea.model.instance.RequestMeta
+import net.pantasystem.milktea.model.instance.Version
+import net.pantasystem.milktea.model.nodeinfo.NodeInfo
+import net.pantasystem.milktea.model.nodeinfo.getVersion
+import javax.inject.Inject
+
+
+internal interface CustomEmojiApiAdapter {
+    suspend fun fetch(nodeInfo: NodeInfo): List<Emoji>
+}
+
+internal class CustomEmojiApiAdapterImpl @Inject constructor(
+    val mastodonAPIProvider: MastodonAPIProvider,
+    val misskeyAPIProvider: MisskeyAPIProvider
+) : CustomEmojiApiAdapter {
+
+    override suspend fun fetch(nodeInfo: NodeInfo): List<Emoji> {
+        return when (nodeInfo.type) {
+            is NodeInfo.SoftwareType.Mastodon -> {
+                val emojis = mastodonAPIProvider.get("https://${nodeInfo.host}").getCustomEmojis()
+                    .throwIfHasError()
+                    .body()
+                emojis?.map {
+                    it.toEmoji()
+                }
+            }
+            is NodeInfo.SoftwareType.Misskey -> {
+                if (
+                    nodeInfo.type.getVersion() >= Version("13")
+                    && nodeInfo.type !is NodeInfo.SoftwareType.Misskey.Calckey
+                ) {
+                    val emojis =
+                        misskeyAPIProvider.get("https://${nodeInfo.host}").getEmojis(EmptyRequest)
+                            .throwIfHasError()
+                            .body()
+                    emojis?.emojis?.map {
+                        it.copy(
+                            url = if (it.url == null) V13EmojiUrlResolver.resolve(it, "https://${nodeInfo.host}") else it.url,
+                            uri = if (it.uri == null) V13EmojiUrlResolver.resolve(it, "https://${nodeInfo.host}") else it.uri,
+                        )
+                    }
+                } else {
+                    misskeyAPIProvider.get("https://${nodeInfo.host}")
+                        .getMeta(RequestMeta(detail = true))
+                        .throwIfHasError()
+                        .body()
+                        ?.emojis
+                }
+            }
+            is NodeInfo.SoftwareType.Other -> throw IllegalStateException()
+        } ?: throw IllegalArgumentException()
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiRepositoryImpl.kt
@@ -161,6 +161,16 @@ class CustomEmojiRepositoryImpl @Inject constructor(
                     record.emoji.id
                 }
             } else {
+                emojis[index].aliases?.filterNot {
+                    it.isBlank()
+                }?.map {
+                    CustomEmojiAliasRecord(
+                        emojiId = id,
+                        it
+                    )
+                }?.let {
+                    customEmojiDAO.insertAliases(it)
+                }
                 id
             }
         }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiRepositoryImpl.kt
@@ -5,30 +5,21 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.withContext
-import net.pantasystem.milktea.api.misskey.EmptyRequest
 import net.pantasystem.milktea.common.runCancellableCatching
-import net.pantasystem.milktea.common.throwIfHasError
-import net.pantasystem.milktea.common_android.emoji.V13EmojiUrlResolver
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
-import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
-import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
 import net.pantasystem.milktea.data.infrastructure.emoji.db.CustomEmojiAliasRecord
 import net.pantasystem.milktea.data.infrastructure.emoji.db.CustomEmojiDAO
 import net.pantasystem.milktea.data.infrastructure.emoji.db.toRecord
 import net.pantasystem.milktea.model.emoji.CustomEmojiRepository
 import net.pantasystem.milktea.model.emoji.Emoji
-import net.pantasystem.milktea.model.instance.RequestMeta
-import net.pantasystem.milktea.model.instance.Version
 import net.pantasystem.milktea.model.nodeinfo.NodeInfo
 import net.pantasystem.milktea.model.nodeinfo.NodeInfoRepository
-import net.pantasystem.milktea.model.nodeinfo.getVersion
 import javax.inject.Inject
 
-class CustomEmojiRepositoryImpl @Inject constructor(
+internal class CustomEmojiRepositoryImpl @Inject constructor(
     private val nodeInfoRepository: NodeInfoRepository,
     private val customEmojiDAO: CustomEmojiDAO,
-    private val mastodonAPIProvider: MastodonAPIProvider,
-    private val misskeyAPIProvider: MisskeyAPIProvider,
+    private val customEmojiApiAdapter: CustomEmojiApiAdapter,
     private val customEmojiCache: CustomEmojiCache,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : CustomEmojiRepository {
@@ -79,40 +70,7 @@ class CustomEmojiRepositoryImpl @Inject constructor(
     }
 
     private suspend fun fetch(nodeInfo: NodeInfo): Result<List<Emoji>> = runCancellableCatching {
-        when (nodeInfo.type) {
-            is NodeInfo.SoftwareType.Mastodon -> {
-                val emojis = mastodonAPIProvider.get("https://${nodeInfo.host}").getCustomEmojis()
-                    .throwIfHasError()
-                    .body()
-                emojis?.map {
-                    it.toEmoji()
-                }
-            }
-            is NodeInfo.SoftwareType.Misskey -> {
-                if (
-                    nodeInfo.type.getVersion() >= Version("13")
-                    && nodeInfo.type !is NodeInfo.SoftwareType.Misskey.Calckey
-                ) {
-                    val emojis =
-                        misskeyAPIProvider.get("https://${nodeInfo.host}").getEmojis(EmptyRequest)
-                            .throwIfHasError()
-                            .body()
-                    emojis?.emojis?.map {
-                        it.copy(
-                            url = if (it.url == null) V13EmojiUrlResolver.resolve(it, "https://${nodeInfo.host}") else it.url,
-                            uri = if (it.uri == null) V13EmojiUrlResolver.resolve(it, "https://${nodeInfo.host}") else it.uri,
-                        )
-                    }
-                } else {
-                    misskeyAPIProvider.get("https://${nodeInfo.host}")
-                        .getMeta(RequestMeta(detail = true))
-                        .throwIfHasError()
-                        .body()
-                        ?.emojis
-                }
-            }
-            is NodeInfo.SoftwareType.Other -> throw IllegalStateException()
-        } ?: throw IllegalArgumentException()
+        customEmojiApiAdapter.fetch(nodeInfo)
     }
 
     override fun get(host: String): List<Emoji>? {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiRepositoryImpl.kt
@@ -21,6 +21,7 @@ internal class CustomEmojiRepositoryImpl @Inject constructor(
     private val customEmojiDAO: CustomEmojiDAO,
     private val customEmojiApiAdapter: CustomEmojiApiAdapter,
     private val customEmojiCache: CustomEmojiCache,
+    private val upInsert: CustomEmojiUpInsertDelegate,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : CustomEmojiRepository {
 
@@ -97,7 +98,12 @@ internal class CustomEmojiRepositoryImpl @Inject constructor(
         return customEmojiCache.getMap(host)
     }
 
-    private suspend fun upInsert(host: String, emojis: List<Emoji>) {
+}
+
+internal class CustomEmojiUpInsertDelegate @Inject constructor(
+    private val customEmojiDAO: CustomEmojiDAO,
+) {
+    suspend operator fun invoke(host: String, emojis: List<Emoji>) {
         val record = emojis.map {
             it.toRecord(host)
         }
@@ -133,5 +139,4 @@ internal class CustomEmojiRepositoryImpl @Inject constructor(
             }
         }
     }
-
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiRepositoryImpl.kt
@@ -7,9 +7,8 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.withContext
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
-import net.pantasystem.milktea.data.infrastructure.emoji.db.CustomEmojiAliasRecord
 import net.pantasystem.milktea.data.infrastructure.emoji.db.CustomEmojiDAO
-import net.pantasystem.milktea.data.infrastructure.emoji.db.toRecord
+import net.pantasystem.milktea.data.infrastructure.emoji.delegate.CustomEmojiUpInsertDelegate
 import net.pantasystem.milktea.model.emoji.CustomEmojiRepository
 import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.nodeinfo.NodeInfo
@@ -100,43 +99,3 @@ internal class CustomEmojiRepositoryImpl @Inject constructor(
 
 }
 
-internal class CustomEmojiUpInsertDelegate @Inject constructor(
-    private val customEmojiDAO: CustomEmojiDAO,
-) {
-    suspend operator fun invoke(host: String, emojis: List<Emoji>) {
-        val record = emojis.map {
-            it.toRecord(host)
-        }
-        val ids = customEmojiDAO.insertAll(record)
-
-        ids.mapIndexed { index, id ->
-            if (id == -1L) {
-                customEmojiDAO.findBy(host, emojis[index].name)?.let { record ->
-                    customEmojiDAO.update(emojis[index].toRecord(host, record.emoji.id))
-                    customEmojiDAO.deleteAliasByEmojiId(record.emoji.id)
-                    emojis[index].aliases?.map {
-                        CustomEmojiAliasRecord(
-                            emojiId = record.emoji.id,
-                            it
-                        )
-                    }?.let {
-                        customEmojiDAO.insertAliases(it)
-                    }
-                    record.emoji.id
-                }
-            } else {
-                emojis[index].aliases?.filterNot {
-                    it.isBlank()
-                }?.map {
-                    CustomEmojiAliasRecord(
-                        emojiId = id,
-                        it
-                    )
-                }?.let {
-                    customEmojiDAO.insertAliases(it)
-                }
-                id
-            }
-        }
-    }
-}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/delegate/CustomEmojiUpInsertDelegate.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/delegate/CustomEmojiUpInsertDelegate.kt
@@ -1,0 +1,48 @@
+package net.pantasystem.milktea.data.infrastructure.emoji.delegate
+
+import net.pantasystem.milktea.data.infrastructure.emoji.db.CustomEmojiAliasRecord
+import net.pantasystem.milktea.data.infrastructure.emoji.db.CustomEmojiDAO
+import net.pantasystem.milktea.data.infrastructure.emoji.db.toRecord
+import net.pantasystem.milktea.model.emoji.Emoji
+import javax.inject.Inject
+
+internal class CustomEmojiUpInsertDelegate @Inject constructor(
+    private val customEmojiDAO: CustomEmojiDAO,
+) {
+    suspend operator fun invoke(host: String, emojis: List<Emoji>) {
+        val record = emojis.map {
+            it.toRecord(host)
+        }
+        val ids = customEmojiDAO.insertAll(record)
+
+        ids.mapIndexed { index, id ->
+            if (id == -1L) {
+                customEmojiDAO.findBy(host, emojis[index].name)?.let { record ->
+                    customEmojiDAO.update(emojis[index].toRecord(host, record.emoji.id))
+                    customEmojiDAO.deleteAliasByEmojiId(record.emoji.id)
+                    emojis[index].aliases?.map {
+                        CustomEmojiAliasRecord(
+                            emojiId = record.emoji.id,
+                            it
+                        )
+                    }?.let {
+                        customEmojiDAO.insertAliases(it)
+                    }
+                    record.emoji.id
+                }
+            } else {
+                emojis[index].aliases?.filterNot {
+                    it.isBlank()
+                }?.map {
+                    CustomEmojiAliasRecord(
+                        emojiId = id,
+                        it
+                    )
+                }?.let {
+                    customEmojiDAO.insertAliases(it)
+                }
+                id
+            }
+        }
+    }
+}


### PR DESCRIPTION
## やったこと
DBにaliasの登録が行われていないため
aliasを用いて検索することができないという問題が発生していました。
そこでaliasが正常にDBに登録されるように修正しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1385 



