### PR TITLE
Mastodonのブックマークを一覧表示できるようにした

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/MastodonAPI.kt
@@ -221,6 +221,13 @@ interface MastodonAPI {
         @Query("exclude_replies") excludeReplies: Boolean? = null,
     ): Response<List<TootStatusDTO>>
 
+    @GET("api/v1/bookmarks")
+    suspend fun getBookmarks(
+        @Query("max_id") maxId: String? = null,
+        @Query("min_id") minId: String? = null,
+        @Query("limit") limit: Int = 20,
+    ): Response<List<TootStatusDTO>>
+
 
     @GET("api/v1/lists")
     suspend fun getMyLists(): Response<List<ListDTO>>

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/page/PageTypeHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/page/PageTypeHelper.kt
@@ -41,6 +41,7 @@ object PageTypeHelper{
             MASTODON_USER_TIMELINE -> context.getString(R.string.user)
             CALCKEY_RECOMMENDED_TIMELINE -> context.getString(R.string.calckey_recomended_timeline)
             CLIP_NOTES -> context.getString(R.string.clip)
+            MASTODON_BOOKMARK_TIMELINE -> context.getString(R.string.bookmark)
         }
     }
 }

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -461,6 +461,7 @@
     <string name="user_detail_mute_renotes">リノートを表示しない</string>
     <string name="user_detail_unmute_renotes">リノートを表示する</string>
     <string name="settings_renote_mute_title">リノート非表示ユーザ</string>
+    <string name="bookmark">ブックマーク</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -457,6 +457,7 @@
     <string name="user_detail_mute_renotes">Mute Renotes</string>
     <string name="user_detail_unmute_renotes">Unmute renotes</string>
     <string name="settings_renote_mute_title">远程静音</string>
+    <string name="bookmark">书签</string>
 
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -451,5 +451,6 @@
     <string name="user_detail_mute_renotes">Mute Renotes</string>
     <string name="user_detail_unmute_renotes">Unmute renotes</string>
     <string name="settings_renote_mute_title">Renote mutes</string>
+    <string name="bookmark">Bookmark</string>
 
 </resources>

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageSettingViewModel.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageSettingViewModel.kt
@@ -88,6 +88,7 @@ class PageSettingViewModel @Inject constructor(
                     PageType.NOTIFICATION,
                     PageType.FAVORITE,
                     PageType.MASTODON_LIST_TIMELINE,
+                    PageType.MASTODON_BOOKMARK_TIMELINE,
 //                    PageType.MASTODON_USER_TIMELINE,
 
                 )
@@ -276,6 +277,12 @@ class PageSettingViewModel @Inject constructor(
             PageType.CALCKEY_RECOMMENDED_TIMELINE -> addPage(
                 account.value!!.newPage(
                     Pageable.CalckeyRecommendedTimeline,
+                    name,
+                )
+            )
+            PageType.MASTODON_BOOKMARK_TIMELINE -> addPage(
+                account.value!!.newPage(
+                    Pageable.Mastodon.BookmarkTimeline,
                     name,
                 )
             )

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
@@ -189,6 +189,9 @@ data class PageParams(
                         clipId = requireNotNull(clipId)
                     )
                 }
+                MASTODON_BOOKMARK_TIMELINE -> {
+                    Pageable.Mastodon.BookmarkTimeline
+                }
             }
         } catch (e: NullPointerException) {
             throw IllegalStateException("パラメーターに問題があります: $this")

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageType.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageType.kt
@@ -29,7 +29,7 @@ enum class PageType(val defaultName: String){
     MASTODON_HASHTAG_TIMELINE("MastodonHashtagTimeline"),
     MASTODON_LIST_TIMELINE("MastodonListTimeline"),
     MASTODON_USER_TIMELINE("MastodonUserTimeline"),
-
+    MASTODON_BOOKMARK_TIMELINE("MastodonBookmarkTimeline"),
     CALCKEY_RECOMMENDED_TIMELINE("CalckeyRecommendedTimeline"),
 
     CLIP_NOTES("ClipNotes"),

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
@@ -472,6 +472,14 @@ sealed class Pageable : Serializable {
             }
         }
 
+        object BookmarkTimeline : Mastodon() {
+            override fun toParams(): PageParams {
+                return PageParams(
+                    type = PageType.MASTODON_BOOKMARK_TIMELINE
+                )
+            }
+        }
+
     }
 
     object CalckeyRecommendedTimeline : Pageable(), UntilPaginate, SincePaginate {


### PR DESCRIPTION
## やったこと
Mastodonのブックマークに登録した投稿を
一覧で表示できるように実装しました。
またそのためにページネーションロジックに投稿取得のエンドポイントにリクエストを送信する処理の追加と
タブ設定画面にブックマークを追加するための処理を追加実装しました。
またページネーションのロジックに不具合があったためその修正を行いました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1528 

