### PR TITLE
UserRepository周りの実装のリファクタリング

### DIFF
--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
@@ -7,9 +7,11 @@ import dagger.hilt.components.SingletonComponent
 import net.pantasystem.milktea.app_store.user.FollowFollowerPagingStore
 import net.pantasystem.milktea.app_store.user.UserReactionPagingStore
 import net.pantasystem.milktea.data.infrastructure.user.*
+import net.pantasystem.milktea.data.infrastructure.user.block.MuteRepositoryImpl
 import net.pantasystem.milktea.model.user.FollowRequestRepository
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.model.user.UserRepository
+import net.pantasystem.milktea.model.user.mute.MuteRepository
 import javax.inject.Singleton
 
 @Module
@@ -43,4 +45,8 @@ abstract class UserModule {
     abstract fun bindFollowRequestRepository(
         impl: FollowRequestRepositoryImpl
     ): FollowRequestRepository
+
+    @Binds
+    @Singleton
+    internal abstract fun bindMuteRepository(impl: MuteRepositoryImpl): MuteRepository
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
@@ -7,6 +7,8 @@ import dagger.hilt.components.SingletonComponent
 import net.pantasystem.milktea.app_store.user.FollowFollowerPagingStore
 import net.pantasystem.milktea.app_store.user.UserReactionPagingStore
 import net.pantasystem.milktea.data.infrastructure.user.*
+import net.pantasystem.milktea.data.infrastructure.user.block.BlockApiAdapter
+import net.pantasystem.milktea.data.infrastructure.user.block.BlockApiAdapterImpl
 import net.pantasystem.milktea.data.infrastructure.user.block.BlockRepositoryImpl
 import net.pantasystem.milktea.data.infrastructure.user.mute.MuteApiAdapter
 import net.pantasystem.milktea.data.infrastructure.user.mute.MuteApiAdapterImpl
@@ -61,5 +63,9 @@ abstract class UserModule {
     @Binds
     @Singleton
     internal abstract fun bindBlockRepository(impl: BlockRepositoryImpl): BlockRepository
+
+    @Binds
+    @Singleton
+    internal abstract fun bindBlockApiAdapter(impl: BlockApiAdapterImpl): BlockApiAdapter
 
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
@@ -7,10 +7,12 @@ import dagger.hilt.components.SingletonComponent
 import net.pantasystem.milktea.app_store.user.FollowFollowerPagingStore
 import net.pantasystem.milktea.app_store.user.UserReactionPagingStore
 import net.pantasystem.milktea.data.infrastructure.user.*
+import net.pantasystem.milktea.data.infrastructure.user.block.BlockRepositoryImpl
 import net.pantasystem.milktea.data.infrastructure.user.mute.MuteRepositoryImpl
 import net.pantasystem.milktea.model.user.FollowRequestRepository
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.model.user.UserRepository
+import net.pantasystem.milktea.model.user.block.BlockRepository
 import net.pantasystem.milktea.model.user.mute.MuteRepository
 import javax.inject.Singleton
 
@@ -49,4 +51,8 @@ abstract class UserModule {
     @Binds
     @Singleton
     internal abstract fun bindMuteRepository(impl: MuteRepositoryImpl): MuteRepository
+
+    @Binds
+    @Singleton
+    internal abstract fun bindBlockRepository(impl: BlockRepositoryImpl): BlockRepository
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
@@ -7,7 +7,7 @@ import dagger.hilt.components.SingletonComponent
 import net.pantasystem.milktea.app_store.user.FollowFollowerPagingStore
 import net.pantasystem.milktea.app_store.user.UserReactionPagingStore
 import net.pantasystem.milktea.data.infrastructure.user.*
-import net.pantasystem.milktea.data.infrastructure.user.block.MuteRepositoryImpl
+import net.pantasystem.milktea.data.infrastructure.user.mute.MuteRepositoryImpl
 import net.pantasystem.milktea.model.user.FollowRequestRepository
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.model.user.UserRepository

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
@@ -30,7 +30,7 @@ abstract class UserModule {
 
     @Binds
     @Singleton
-    abstract fun userRepository(
+    internal abstract fun userRepository(
         impl: UserRepositoryImpl
     ): UserRepository
 
@@ -67,5 +67,9 @@ abstract class UserModule {
     @Binds
     @Singleton
     internal abstract fun bindBlockApiAdapter(impl: BlockApiAdapterImpl): BlockApiAdapter
+
+    @Binds
+    @Singleton
+    internal abstract fun bindUserApiAdapter(impl: UserApiAdapterImpl): UserApiAdapter
 
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
@@ -8,6 +8,8 @@ import net.pantasystem.milktea.app_store.user.FollowFollowerPagingStore
 import net.pantasystem.milktea.app_store.user.UserReactionPagingStore
 import net.pantasystem.milktea.data.infrastructure.user.*
 import net.pantasystem.milktea.data.infrastructure.user.block.BlockRepositoryImpl
+import net.pantasystem.milktea.data.infrastructure.user.mute.MuteApiAdapter
+import net.pantasystem.milktea.data.infrastructure.user.mute.MuteApiAdapterImpl
 import net.pantasystem.milktea.data.infrastructure.user.mute.MuteRepositoryImpl
 import net.pantasystem.milktea.model.user.FollowRequestRepository
 import net.pantasystem.milktea.model.user.UserDataSource
@@ -54,5 +56,10 @@ abstract class UserModule {
 
     @Binds
     @Singleton
+    internal abstract fun bindMuteApiAdapter(impl: MuteApiAdapterImpl): MuteApiAdapter
+
+    @Binds
+    @Singleton
     internal abstract fun bindBlockRepository(impl: BlockRepositoryImpl): BlockRepository
+
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
@@ -72,4 +72,7 @@ abstract class UserModule {
     @Singleton
     internal abstract fun bindUserApiAdapter(impl: UserApiAdapterImpl): UserApiAdapter
 
+    @Binds
+    @Singleton
+    internal abstract fun bindUserCacheUpdater(impl: UserCacheUpdaterFromUserActionResultImpl): UserCacheUpdaterFromUserActionResult
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserActionResult.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserActionResult.kt
@@ -1,0 +1,46 @@
+package net.pantasystem.milktea.data.infrastructure.user
+
+import net.pantasystem.milktea.api.mastodon.accounts.MastodonAccountRelationshipDTO
+import net.pantasystem.milktea.data.infrastructure.toUserRelated
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.UserDataSource
+import net.pantasystem.milktea.model.user.UserRepository
+import javax.inject.Inject
+
+
+sealed interface UserActionResult {
+    object Misskey : UserActionResult
+    data class Mastodon(val relationship: MastodonAccountRelationshipDTO) : UserActionResult
+}
+
+internal interface UserCacheUpdaterFromUserActionResult {
+    suspend operator fun invoke(
+        userId: User.Id,
+        result: UserActionResult,
+        reducer: suspend (User.Detail) -> User.Detail,
+    )
+}
+
+internal class UserCacheUpdaterFromUserActionResultImpl @Inject constructor(
+    private val userRepository: UserRepository,
+    private val userDataSource: UserDataSource,
+) : UserCacheUpdaterFromUserActionResult {
+    override suspend fun invoke(
+        userId: User.Id,
+        result: UserActionResult,
+        reducer: suspend (User.Detail) -> User.Detail,
+    ) {
+        val user = userRepository.find(userId, true) as User.Detail
+        val updated = when (result) {
+            is UserActionResult.Mastodon -> {
+                user.copy(
+                    related = result.relationship.toUserRelated()
+                )
+            }
+            UserActionResult.Misskey -> {
+                reducer(user)
+            }
+        }
+        userDataSource.add(updated)
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
@@ -1,7 +1,6 @@
 package net.pantasystem.milktea.data.infrastructure.user
 
 import net.pantasystem.milktea.api.mastodon.accounts.MastodonAccountDTO
-import net.pantasystem.milktea.api.mastodon.accounts.MastodonAccountRelationshipDTO
 import net.pantasystem.milktea.api.misskey.users.RequestUser
 import net.pantasystem.milktea.api.misskey.users.SearchByUserAndHost
 import net.pantasystem.milktea.api.misskey.users.UserDTO
@@ -15,6 +14,7 @@ import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.user.User
 import javax.inject.Inject
 import javax.inject.Singleton
+
 internal interface UserApiAdapter {
 
     suspend fun show(userId: User.Id, detail: Boolean): User
@@ -132,10 +132,6 @@ internal class UserApiAdapterImpl @Inject constructor(
     }
 }
 
-sealed interface UserActionResult {
-    object Misskey : UserActionResult
-    data class Mastodon(val relationship: MastodonAccountRelationshipDTO) : UserActionResult
-}
 
 sealed interface SearchResult {
     data class Misskey(val users: List<UserDTO>) : SearchResult

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
@@ -15,16 +15,30 @@ import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.user.User
 import javax.inject.Inject
 import javax.inject.Singleton
+internal interface UserApiAdapter {
 
+    suspend fun show(userId: User.Id, detail: Boolean): User
+
+    suspend fun follow(userId: User.Id): Boolean
+
+    suspend fun unfollow(userId: User.Id): Boolean
+
+    suspend fun search(
+        accountId: Long,
+        userName: String,
+        host: String?
+    ): SearchResult
+
+}
 @Singleton
-class UserApiAdapter @Inject constructor(
+internal class UserApiAdapterImpl @Inject constructor(
     private val accountRepository: AccountRepository,
     private val misskeyAPIProvider: MisskeyAPIProvider,
     private val mastodonAPIProvider: MastodonAPIProvider,
     private val userDTOEntityConverter: UserDTOEntityConverter,
-) {
+) : UserApiAdapter {
 
-    suspend fun show(userId: User.Id, detail: Boolean): User {
+    override suspend fun show(userId: User.Id, detail: Boolean): User {
         val account = accountRepository.get(userId.accountId).getOrThrow()
         return when (account.instanceType) {
             Account.InstanceType.MISSKEY -> {
@@ -59,7 +73,7 @@ class UserApiAdapter @Inject constructor(
         }
     }
 
-    suspend fun follow(userId: User.Id): Boolean {
+    override suspend fun follow(userId: User.Id): Boolean {
         val account = accountRepository.get(userId.accountId).getOrThrow()
         return when (account.instanceType) {
             Account.InstanceType.MISSKEY -> {
@@ -73,7 +87,7 @@ class UserApiAdapter @Inject constructor(
         }.throwIfHasError().isSuccessful
     }
 
-    suspend fun unfollow(userId: User.Id): Boolean {
+    override suspend fun unfollow(userId: User.Id): Boolean {
         val account = accountRepository.get(userId.accountId).getOrThrow()
         return when (account.instanceType) {
             Account.InstanceType.MISSKEY -> misskeyAPIProvider.get(account)
@@ -86,7 +100,7 @@ class UserApiAdapter @Inject constructor(
         }
     }
 
-    suspend fun search(
+    override suspend fun search(
         accountId: Long,
         userName: String,
         host: String?

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
@@ -86,51 +86,6 @@ class UserApiAdapter @Inject constructor(
         }
     }
 
-
-    suspend fun blockUser(userId: User.Id): BlockUserResult {
-        val account = accountRepository.get(userId.accountId).getOrThrow()
-        return when (account.instanceType) {
-            Account.InstanceType.MISSKEY -> {
-                misskeyAPIProvider.get(account).blockUser(
-                    RequestUser(
-                        i = account.token,
-                        userId = userId.id,
-                    )
-                )
-                    .throwIfHasError()
-                UserActionResult.Misskey
-            }
-            Account.InstanceType.MASTODON -> {
-                val body = mastodonAPIProvider.get(account).blockAccount(userId.id)
-                    .throwIfHasError()
-                    .body()
-                UserActionResult.Mastodon(requireNotNull(body))
-            }
-        }
-    }
-
-    suspend fun unblockUser(userId: User.Id): UnBlockUserResult {
-        val account = accountRepository.get(userId.accountId).getOrThrow()
-        return when (account.instanceType) {
-            Account.InstanceType.MISSKEY -> {
-                misskeyAPIProvider.get(account).unblockUser(
-                    RequestUser(
-                        i = account.token,
-                        userId = userId.id,
-                    )
-                )
-                    .throwIfHasError()
-                UserActionResult.Misskey
-            }
-            Account.InstanceType.MASTODON -> {
-                val body = mastodonAPIProvider.get(account).unblockAccount(userId.id)
-                    .throwIfHasError()
-                    .body()
-                UserActionResult.Mastodon(requireNotNull(body))
-            }
-        }
-    }
-
     suspend fun search(
         accountId: Long,
         userName: String,
@@ -173,8 +128,3 @@ sealed interface SearchResult {
     data class Mastodon(val users: List<MastodonAccountDTO>) : SearchResult
 }
 
-
-
-typealias BlockUserResult = UserActionResult
-
-typealias UnBlockUserResult = UserActionResult

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserRepositoryImpl.kt
@@ -23,7 +23,7 @@ import net.pantasystem.milktea.model.user.report.Report
 import javax.inject.Inject
 
 @Suppress("BlockingMethodInNonBlockingContext")
-class UserRepositoryImpl @Inject constructor(
+internal class UserRepositoryImpl @Inject constructor(
     val userDataSource: UserDataSource,
     val filePropertyDataSource: FilePropertyDataSource,
     val accountRepository: AccountRepository,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserRepositoryImpl.kt
@@ -12,14 +12,12 @@ import net.pantasystem.milktea.common.throwIfHasError
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
 import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
-import net.pantasystem.milktea.data.infrastructure.toUserRelated
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.drive.FilePropertyDataSource
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.model.user.UserNotFoundException
 import net.pantasystem.milktea.model.user.UserRepository
-import net.pantasystem.milktea.model.user.mute.CreateMute
 import net.pantasystem.milktea.model.user.query.FindUsersQuery
 import net.pantasystem.milktea.model.user.report.Report
 import javax.inject.Inject
@@ -148,60 +146,6 @@ class UserRepositoryImpl @Inject constructor(
             .getOrThrow()
     }
 
-    override suspend fun mute(createMute: CreateMute): Boolean = withContext(ioDispatcher) {
-        runCancellableCatching {
-            updateCacheFrom(createMute.userId, userApiAdapter.muteUser(createMute)) {
-                it.copy(
-                    related = it.related?.copy(
-                        isMuting = true
-                    )
-                )
-            }
-        }.onFailure {
-            logger.error("ユーザーのミュートに失敗", it)
-        }.isSuccess
-    }
-
-    override suspend fun unmute(userId: User.Id): Boolean = withContext(ioDispatcher) {
-        runCancellableCatching {
-            updateCacheFrom(userId, userApiAdapter.unmuteUser(userId)) {
-                it.copy(
-                    related = it.related?.copy(
-                        isMuting = false
-                    )
-                )
-            }
-        }.onFailure {
-            logger.error("unmute failed", it)
-        }.isSuccess
-
-    }
-
-    override suspend fun block(userId: User.Id): Boolean = withContext(ioDispatcher) {
-        runCancellableCatching {
-            updateCacheFrom(userId, userApiAdapter.blockUser(userId)) { user ->
-                user.copy(
-                    related = user.related?.copy(
-                        isBlocking = true
-                    )
-                )
-            }
-        }.onFailure {
-            logger.error("block failed", it)
-        }.isSuccess
-    }
-
-    override suspend fun unblock(userId: User.Id): Boolean = withContext(ioDispatcher) {
-        runCancellableCatching {
-            updateCacheFrom(userId, userApiAdapter.unblockUser(userId)) { user ->
-                user.copy(
-                    related = user.related?.copy(isBlocking = false)
-                )
-            }
-        }.onFailure {
-            logger.error("unblock failed", it)
-        }.isSuccess
-    }
 
     override suspend fun follow(userId: User.Id): Boolean = withContext(ioDispatcher) {
         val user = find(userId, true) as User.Detail
@@ -247,22 +191,6 @@ class UserRepositoryImpl @Inject constructor(
         isSuccessful
     }
 
-
-
-    private suspend fun updateCacheFrom(userId: User.Id, result: UserActionResult, reducer: suspend (User.Detail) -> User.Detail) {
-        val user = find(userId, true) as User.Detail
-        val updated = when(result) {
-            is UserActionResult.Mastodon -> {
-                user.copy(
-                    related = result.relationship.toUserRelated()
-                )
-            }
-            UserActionResult.Misskey -> {
-                reducer(user)
-            }
-        }
-        userDataSource.add(updated)
-    }
 
     override suspend fun report(report: Report): Boolean {
         return withContext(ioDispatcher) {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/block/BlockApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/block/BlockApiAdapter.kt
@@ -1,0 +1,71 @@
+package net.pantasystem.milktea.data.infrastructure.user.block
+
+import net.pantasystem.milktea.api.misskey.users.RequestUser
+import net.pantasystem.milktea.common.throwIfHasError
+import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
+import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.data.infrastructure.user.UserActionResult
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.user.User
+import javax.inject.Inject
+
+internal interface BlockApiAdapter {
+
+    suspend fun blockUser(userId: User.Id): BlockUserResult
+    suspend fun unblockUser(userId: User.Id): UnBlockUserResult
+}
+
+class BlockApiAdapterImpl @Inject constructor(
+    private val accountRepository: AccountRepository,
+    private val misskeyAPIProvider: MisskeyAPIProvider,
+    private val mastodonAPIProvider: MastodonAPIProvider
+) : BlockApiAdapter {
+    override suspend fun blockUser(userId: User.Id): BlockUserResult {
+        val account = accountRepository.get(userId.accountId).getOrThrow()
+        return when (account.instanceType) {
+            Account.InstanceType.MISSKEY -> {
+                misskeyAPIProvider.get(account).blockUser(
+                    RequestUser(
+                        i = account.token,
+                        userId = userId.id,
+                    )
+                )
+                    .throwIfHasError()
+                UserActionResult.Misskey
+            }
+            Account.InstanceType.MASTODON -> {
+                val body = mastodonAPIProvider.get(account).blockAccount(userId.id)
+                    .throwIfHasError()
+                    .body()
+                UserActionResult.Mastodon(requireNotNull(body))
+            }
+        }
+    }
+
+    override suspend fun unblockUser(userId: User.Id): UnBlockUserResult {
+        val account = accountRepository.get(userId.accountId).getOrThrow()
+        return when (account.instanceType) {
+            Account.InstanceType.MISSKEY -> {
+                misskeyAPIProvider.get(account).unblockUser(
+                    RequestUser(
+                        i = account.token,
+                        userId = userId.id,
+                    )
+                )
+                    .throwIfHasError()
+                UserActionResult.Misskey
+            }
+            Account.InstanceType.MASTODON -> {
+                val body = mastodonAPIProvider.get(account).unblockAccount(userId.id)
+                    .throwIfHasError()
+                    .body()
+                UserActionResult.Mastodon(requireNotNull(body))
+            }
+        }
+    }
+
+}
+typealias BlockUserResult = UserActionResult
+
+typealias UnBlockUserResult = UserActionResult

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/block/BlockRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/block/BlockRepositoryImpl.kt
@@ -7,7 +7,6 @@ import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
 import net.pantasystem.milktea.data.infrastructure.toUserRelated
 import net.pantasystem.milktea.data.infrastructure.user.UserActionResult
-import net.pantasystem.milktea.data.infrastructure.user.UserApiAdapter
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.model.user.UserRepository
@@ -16,7 +15,7 @@ import javax.inject.Inject
 
 internal class BlockRepositoryImpl @Inject constructor(
     private val userRepository: UserRepository,
-    private val userApiAdapter: UserApiAdapter,
+    private val blockApiAdapter: BlockApiAdapter,
     private val userDataSource: UserDataSource,
     @IODispatcher private val coroutineDispatcher: CoroutineDispatcher,
     loggerFactory: Logger.Factory
@@ -29,7 +28,7 @@ internal class BlockRepositoryImpl @Inject constructor(
     override suspend fun create(userId: User.Id): Result<Unit> {
         return runCancellableCatching {
             withContext(coroutineDispatcher) {
-                updateCacheFrom(userId, userApiAdapter.blockUser(userId)) { user ->
+                updateCacheFrom(userId, blockApiAdapter.blockUser(userId)) { user ->
                     user.copy(
                         related = user.related?.copy(
                             isBlocking = true
@@ -45,7 +44,7 @@ internal class BlockRepositoryImpl @Inject constructor(
     override suspend fun delete(userId: User.Id): Result<Unit> {
         return runCancellableCatching {
             withContext(coroutineDispatcher) {
-                updateCacheFrom(userId, userApiAdapter.unblockUser(userId)) { user ->
+                updateCacheFrom(userId, blockApiAdapter.unblockUser(userId)) { user ->
                     user.copy(
                         related = user.related?.copy(isBlocking = false)
                     )

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/block/BlockRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/block/BlockRepositoryImpl.kt
@@ -1,0 +1,73 @@
+package net.pantasystem.milktea.data.infrastructure.user.block
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import net.pantasystem.milktea.common.Logger
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.common_android.hilt.IODispatcher
+import net.pantasystem.milktea.data.infrastructure.toUserRelated
+import net.pantasystem.milktea.data.infrastructure.user.UserActionResult
+import net.pantasystem.milktea.data.infrastructure.user.UserApiAdapter
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.UserDataSource
+import net.pantasystem.milktea.model.user.UserRepository
+import net.pantasystem.milktea.model.user.block.BlockRepository
+import javax.inject.Inject
+
+internal class BlockRepositoryImpl @Inject constructor(
+    private val userRepository: UserRepository,
+    private val userApiAdapter: UserApiAdapter,
+    private val userDataSource: UserDataSource,
+    @IODispatcher private val coroutineDispatcher: CoroutineDispatcher,
+    loggerFactory: Logger.Factory
+) : BlockRepository {
+
+    private val logger by lazy {
+        loggerFactory.create("BlockRepositoryImpl")
+    }
+
+    override suspend fun create(userId: User.Id): Result<Unit> {
+        return runCancellableCatching {
+            withContext(coroutineDispatcher) {
+                updateCacheFrom(userId, userApiAdapter.blockUser(userId)) { user ->
+                    user.copy(
+                        related = user.related?.copy(
+                            isBlocking = true
+                        )
+                    )
+                }
+            }
+        }.onFailure {
+            logger.error("block failed", it)
+        }
+    }
+
+    override suspend fun delete(userId: User.Id): Result<Unit> {
+        return runCancellableCatching {
+            withContext(coroutineDispatcher) {
+                updateCacheFrom(userId, userApiAdapter.unblockUser(userId)) { user ->
+                    user.copy(
+                        related = user.related?.copy(isBlocking = false)
+                    )
+                }
+            }
+        }.onFailure {
+            logger.error("unblock failed", it)
+        }
+    }
+
+    private suspend fun updateCacheFrom(userId: User.Id, result: UserActionResult, reducer: suspend (User.Detail) -> User.Detail) {
+        val user = userRepository.find(userId, true) as User.Detail
+        val updated = when(result) {
+            is UserActionResult.Mastodon -> {
+                user.copy(
+                    related = result.relationship.toUserRelated()
+                )
+            }
+            UserActionResult.Misskey -> {
+                reducer(user)
+            }
+        }
+        userDataSource.add(updated)
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/block/BlockRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/block/BlockRepositoryImpl.kt
@@ -5,18 +5,14 @@ import kotlinx.coroutines.withContext
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
-import net.pantasystem.milktea.data.infrastructure.toUserRelated
-import net.pantasystem.milktea.data.infrastructure.user.UserActionResult
+import net.pantasystem.milktea.data.infrastructure.user.UserCacheUpdaterFromUserActionResult
 import net.pantasystem.milktea.model.user.User
-import net.pantasystem.milktea.model.user.UserDataSource
-import net.pantasystem.milktea.model.user.UserRepository
 import net.pantasystem.milktea.model.user.block.BlockRepository
 import javax.inject.Inject
 
 internal class BlockRepositoryImpl @Inject constructor(
-    private val userRepository: UserRepository,
     private val blockApiAdapter: BlockApiAdapter,
-    private val userDataSource: UserDataSource,
+    private val updateCacheFrom: UserCacheUpdaterFromUserActionResult,
     @IODispatcher private val coroutineDispatcher: CoroutineDispatcher,
     loggerFactory: Logger.Factory
 ) : BlockRepository {
@@ -55,18 +51,4 @@ internal class BlockRepositoryImpl @Inject constructor(
         }
     }
 
-    private suspend fun updateCacheFrom(userId: User.Id, result: UserActionResult, reducer: suspend (User.Detail) -> User.Detail) {
-        val user = userRepository.find(userId, true) as User.Detail
-        val updated = when(result) {
-            is UserActionResult.Mastodon -> {
-                user.copy(
-                    related = result.relationship.toUserRelated()
-                )
-            }
-            UserActionResult.Misskey -> {
-                reducer(user)
-            }
-        }
-        userDataSource.add(updated)
-    }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/block/MuteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/block/MuteRepositoryImpl.kt
@@ -1,0 +1,76 @@
+package net.pantasystem.milktea.data.infrastructure.user.block
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import net.pantasystem.milktea.common.Logger
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.common_android.hilt.IODispatcher
+import net.pantasystem.milktea.data.infrastructure.toUserRelated
+import net.pantasystem.milktea.data.infrastructure.user.UserActionResult
+import net.pantasystem.milktea.data.infrastructure.user.UserApiAdapter
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.UserDataSource
+import net.pantasystem.milktea.model.user.UserRepository
+import net.pantasystem.milktea.model.user.mute.CreateMute
+import net.pantasystem.milktea.model.user.mute.MuteRepository
+import javax.inject.Inject
+
+internal class MuteRepositoryImpl @Inject constructor(
+    private val userApiAdapter: UserApiAdapter,
+    private val userDataSource: UserDataSource,
+    private val userRepository: UserRepository,
+    @IODispatcher private val coroutineDispatcher: CoroutineDispatcher,
+    loggerFactory: Logger.Factory,
+) : MuteRepository {
+
+    private val logger by lazy {
+        loggerFactory.create("MuteRepositoryImpl")
+    }
+
+    override suspend fun create(createMute: CreateMute): Result<Unit> {
+        return runCancellableCatching {
+            withContext(coroutineDispatcher) {
+                updateCacheFrom(createMute.userId, userApiAdapter.muteUser(createMute)) {
+                    it.copy(
+                        related = it.related?.copy(
+                            isMuting = true
+                        )
+                    )
+                }
+            }
+        }.onFailure {
+            logger.error("ユーザーのミュートに失敗", it)
+        }
+    }
+
+    override suspend fun delete(userId: User.Id): Result<Unit> {
+        return runCancellableCatching {
+            withContext(coroutineDispatcher) {
+                updateCacheFrom(userId, userApiAdapter.unmuteUser(userId)) {
+                    it.copy(
+                        related = it.related?.copy(
+                            isMuting = false
+                        )
+                    )
+                }
+            }
+        }.onFailure {
+            logger.error("unmute failed", it)
+        }
+    }
+
+    private suspend fun updateCacheFrom(userId: User.Id, result: UserActionResult, reducer: suspend (User.Detail) -> User.Detail) {
+        val user = userRepository.find(userId, true) as User.Detail
+        val updated = when(result) {
+            is UserActionResult.Mastodon -> {
+                user.copy(
+                    related = result.relationship.toUserRelated()
+                )
+            }
+            UserActionResult.Misskey -> {
+                reducer(user)
+            }
+        }
+        userDataSource.add(updated)
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/mute/MuteApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/mute/MuteApiAdapter.kt
@@ -1,0 +1,81 @@
+package net.pantasystem.milktea.data.infrastructure.user.mute
+
+import kotlinx.datetime.Clock
+import net.pantasystem.milktea.api.mastodon.accounts.MuteAccountRequest
+import net.pantasystem.milktea.api.misskey.users.CreateMuteUserRequest
+import net.pantasystem.milktea.api.misskey.users.RequestUser
+import net.pantasystem.milktea.common.throwIfHasError
+import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
+import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.data.infrastructure.user.UserActionResult
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.mute.CreateMute
+import javax.inject.Inject
+
+internal interface MuteApiAdapter {
+    suspend fun muteUser(createMute: CreateMute): UserActionResult
+    suspend fun unmuteUser(userId: User.Id): UnMuteResult
+}
+
+internal class MuteApiAdapterImpl @Inject constructor(
+    private val accountRepository: AccountRepository,
+    private val misskeyAPIProvider: MisskeyAPIProvider,
+    private val mastodonAPIProvider: MastodonAPIProvider,
+) : MuteApiAdapter {
+
+    override suspend fun muteUser(createMute: CreateMute): UserActionResult {
+        val account = accountRepository.get(createMute.userId.accountId).getOrThrow()
+        return when (account.instanceType) {
+            Account.InstanceType.MISSKEY -> {
+                require(createMute.notifications == null) {
+                    "Misskey does not support notifications mute account parameter"
+                }
+                misskeyAPIProvider.get(account).muteUser(
+                    CreateMuteUserRequest(
+                        i = account.token,
+                        userId = createMute.userId.id,
+                        expiresAt = createMute.expiresAt?.toEpochMilliseconds()
+                    )
+                ).throwIfHasError()
+                UserActionResult.Misskey
+            }
+            Account.InstanceType.MASTODON -> {
+                val body = mastodonAPIProvider.get(account).muteAccount(
+                    createMute.userId.id,
+                    MuteAccountRequest(
+                        duration = createMute.expiresAt?.let {
+                            Clock.System.now().epochSeconds - it.epochSeconds
+                        } ?: 0,
+                        notifications = createMute.notifications ?: true
+                    )
+                ).throwIfHasError().body()
+                UserActionResult.Mastodon(requireNotNull(body))
+            }
+        }
+    }
+
+    override suspend fun unmuteUser(userId: User.Id): UnMuteResult {
+        val account = accountRepository.get(userId.accountId).getOrThrow()
+        return when (account.instanceType) {
+            Account.InstanceType.MISSKEY -> {
+                misskeyAPIProvider.get(account).unmuteUser(
+                    RequestUser(
+                        i = account.token,
+                        userId = userId.id,
+                    )
+                ).throwIfHasError()
+                UserActionResult.Misskey
+            }
+            Account.InstanceType.MASTODON -> {
+                val body = mastodonAPIProvider.get(account).unmuteAccount(userId.id)
+                    .throwIfHasError()
+                    .body()
+                UserActionResult.Mastodon(requireNotNull(body))
+            }
+        }
+    }
+}
+
+typealias UnMuteResult = UserActionResult

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/mute/MuteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/mute/MuteRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package net.pantasystem.milktea.data.infrastructure.user.block
+package net.pantasystem.milktea.data.infrastructure.user.mute
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/mute/MuteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/mute/MuteRepositoryImpl.kt
@@ -5,19 +5,15 @@ import kotlinx.coroutines.withContext
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
-import net.pantasystem.milktea.data.infrastructure.toUserRelated
-import net.pantasystem.milktea.data.infrastructure.user.UserActionResult
+import net.pantasystem.milktea.data.infrastructure.user.UserCacheUpdaterFromUserActionResult
 import net.pantasystem.milktea.model.user.User
-import net.pantasystem.milktea.model.user.UserDataSource
-import net.pantasystem.milktea.model.user.UserRepository
 import net.pantasystem.milktea.model.user.mute.CreateMute
 import net.pantasystem.milktea.model.user.mute.MuteRepository
 import javax.inject.Inject
 
 internal class MuteRepositoryImpl @Inject constructor(
     private val muteApiAdapter: MuteApiAdapter,
-    private val userDataSource: UserDataSource,
-    private val userRepository: UserRepository,
+    private val updateCacheFrom: UserCacheUpdaterFromUserActionResult,
     @IODispatcher private val coroutineDispatcher: CoroutineDispatcher,
     loggerFactory: Logger.Factory,
 ) : MuteRepository {
@@ -58,18 +54,5 @@ internal class MuteRepositoryImpl @Inject constructor(
         }
     }
 
-    private suspend fun updateCacheFrom(userId: User.Id, result: UserActionResult, reducer: suspend (User.Detail) -> User.Detail) {
-        val user = userRepository.find(userId, true) as User.Detail
-        val updated = when(result) {
-            is UserActionResult.Mastodon -> {
-                user.copy(
-                    related = result.relationship.toUserRelated()
-                )
-            }
-            UserActionResult.Misskey -> {
-                reducer(user)
-            }
-        }
-        userDataSource.add(updated)
-    }
+
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/mute/MuteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/mute/MuteRepositoryImpl.kt
@@ -7,7 +7,6 @@ import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
 import net.pantasystem.milktea.data.infrastructure.toUserRelated
 import net.pantasystem.milktea.data.infrastructure.user.UserActionResult
-import net.pantasystem.milktea.data.infrastructure.user.UserApiAdapter
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.model.user.UserRepository
@@ -16,7 +15,7 @@ import net.pantasystem.milktea.model.user.mute.MuteRepository
 import javax.inject.Inject
 
 internal class MuteRepositoryImpl @Inject constructor(
-    private val userApiAdapter: UserApiAdapter,
+    private val muteApiAdapter: MuteApiAdapter,
     private val userDataSource: UserDataSource,
     private val userRepository: UserRepository,
     @IODispatcher private val coroutineDispatcher: CoroutineDispatcher,
@@ -30,7 +29,7 @@ internal class MuteRepositoryImpl @Inject constructor(
     override suspend fun create(createMute: CreateMute): Result<Unit> {
         return runCancellableCatching {
             withContext(coroutineDispatcher) {
-                updateCacheFrom(createMute.userId, userApiAdapter.muteUser(createMute)) {
+                updateCacheFrom(createMute.userId, muteApiAdapter.muteUser(createMute)) {
                     it.copy(
                         related = it.related?.copy(
                             isMuting = true
@@ -46,7 +45,7 @@ internal class MuteRepositoryImpl @Inject constructor(
     override suspend fun delete(userId: User.Id): Result<Unit> {
         return runCancellableCatching {
             withContext(coroutineDispatcher) {
-                updateCacheFrom(userId, userApiAdapter.unmuteUser(userId)) {
+                updateCacheFrom(userId, muteApiAdapter.unmuteUser(userId)) {
                     it.copy(
                         related = it.related?.copy(
                             isMuting = false

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
@@ -32,7 +32,9 @@ import net.pantasystem.milktea.model.user.Acct
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.model.user.UserRepository
+import net.pantasystem.milktea.model.user.block.BlockRepository
 import net.pantasystem.milktea.model.user.mute.CreateMute
+import net.pantasystem.milktea.model.user.mute.MuteRepository
 import net.pantasystem.milktea.model.user.nickname.DeleteNicknameUseCase
 import net.pantasystem.milktea.model.user.nickname.UpdateNicknameUseCase
 import net.pantasystem.milktea.model.user.renote.mute.RenoteMuteRepository
@@ -45,6 +47,8 @@ class UserDetailViewModel @AssistedInject constructor(
     private val accountRepository: AccountRepository,
     private val settingStore: SettingStore,
     private val renoteMuteRepository: RenoteMuteRepository,
+    private val blockRepository: BlockRepository,
+    private val muteRepository: MuteRepository,
     userDataSource: UserDataSource,
     loggerFactory: Logger.Factory,
     private val userRepository: UserRepository,
@@ -209,7 +213,7 @@ class UserDetailViewModel @AssistedInject constructor(
         viewModelScope.launch {
             userState.value?.let {
                 runCancellableCatching {
-                    userRepository.mute(CreateMute(it.id, expiredAt))
+                    muteRepository.create(CreateMute(it.id, expiredAt))
                     userRepository.sync(it.id).getOrThrow()
                 }.onFailure {
                     logger.error("unmute", e = it)
@@ -223,7 +227,7 @@ class UserDetailViewModel @AssistedInject constructor(
         viewModelScope.launch {
             userState.value?.let {
                 runCancellableCatching {
-                    userRepository.unmute(it.id)
+                    muteRepository.delete(it.id)
                     userRepository.sync(it.id).getOrThrow()
                 }.onFailure {
                     logger.error("unmute", e = it)
@@ -237,7 +241,7 @@ class UserDetailViewModel @AssistedInject constructor(
         viewModelScope.launch {
             userState.value?.let {
                 runCancellableCatching {
-                    userRepository.block(it.id)
+                    blockRepository.create(it.id)
                     userRepository.sync(it.id)
                 }.onFailure {
                     logger.error("block failed", it)
@@ -251,7 +255,7 @@ class UserDetailViewModel @AssistedInject constructor(
         viewModelScope.launch {
             userState.value?.let {
                 runCancellableCatching {
-                    userRepository.unblock(it.id)
+                    blockRepository.delete(it.id)
                     userRepository.sync(it.id).getOrThrow()
                 }.onFailure {
                     logger.info("unblock failed", e = it)

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
@@ -211,10 +211,9 @@ class UserDetailViewModel @AssistedInject constructor(
 
     fun mute(expiredAt: Instant?) {
         viewModelScope.launch {
-            userState.value?.let {
-                runCancellableCatching {
-                    muteRepository.create(CreateMute(it.id, expiredAt))
-                    userRepository.sync(it.id).getOrThrow()
+            userState.value?.let { user ->
+                muteRepository.create(CreateMute(user.id, expiredAt)).mapCancellableCatching {
+                    userRepository.sync(user.id).getOrThrow()
                 }.onFailure {
                     logger.error("unmute", e = it)
                     _errors.tryEmit(it)
@@ -225,10 +224,9 @@ class UserDetailViewModel @AssistedInject constructor(
 
     fun unmute() {
         viewModelScope.launch {
-            userState.value?.let {
-                runCancellableCatching {
-                    muteRepository.delete(it.id)
-                    userRepository.sync(it.id).getOrThrow()
+            userState.value?.let { user ->
+                muteRepository.delete(user.id).mapCancellableCatching{
+                    userRepository.sync(user.id).getOrThrow()
                 }.onFailure {
                     logger.error("unmute", e = it)
                     _errors.tryEmit(it)
@@ -239,10 +237,9 @@ class UserDetailViewModel @AssistedInject constructor(
 
     fun block() {
         viewModelScope.launch {
-            userState.value?.let {
-                runCancellableCatching {
-                    blockRepository.create(it.id)
-                    userRepository.sync(it.id)
+            userState.value?.let { user ->
+                blockRepository.create(user.id).mapCancellableCatching {
+                    userRepository.sync(user.id)
                 }.onFailure {
                     logger.error("block failed", it)
                     _errors.tryEmit(it)
@@ -253,10 +250,9 @@ class UserDetailViewModel @AssistedInject constructor(
 
     fun unblock() {
         viewModelScope.launch {
-            userState.value?.let {
-                runCancellableCatching {
-                    blockRepository.delete(it.id)
-                    userRepository.sync(it.id).getOrThrow()
+            userState.value?.let { user ->
+                blockRepository.delete(user.id).mapCancellableCatching {
+                    userRepository.sync(user.id).getOrThrow()
                 }.onFailure {
                     logger.info("unblock failed", e = it)
                     _errors.tryEmit(it)

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/UserRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/UserRepository.kt
@@ -1,6 +1,5 @@
 package net.pantasystem.milktea.model.user
 
-import net.pantasystem.milktea.model.user.mute.CreateMute
 import net.pantasystem.milktea.model.user.query.FindUsersQuery
 import net.pantasystem.milktea.model.user.report.Report
 
@@ -17,14 +16,6 @@ interface UserRepository {
     suspend fun follow(userId: User.Id): Boolean
 
     suspend fun unfollow(userId: User.Id): Boolean
-
-    suspend fun mute(createMute: CreateMute): Boolean
-
-    suspend fun unmute(userId: User.Id): Boolean
-
-    suspend fun block(userId: User.Id): Boolean
-
-    suspend fun unblock(userId: User.Id): Boolean
 
     suspend fun report(report: Report) : Boolean
 

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/block/BlockRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/block/BlockRepository.kt
@@ -1,0 +1,11 @@
+package net.pantasystem.milktea.model.user.block
+
+import net.pantasystem.milktea.model.user.User
+
+interface BlockRepository {
+
+    suspend fun create(userId: User.Id): Result<Unit>
+
+    suspend fun delete(userId: User.Id): Result<Unit>
+
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/mute/MuteRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/mute/MuteRepository.kt
@@ -1,0 +1,11 @@
+package net.pantasystem.milktea.model.user.mute
+
+import net.pantasystem.milktea.model.user.User
+
+interface MuteRepository {
+
+    suspend fun create(createMute: CreateMute): Result<Unit>
+
+    suspend fun delete(userId: User.Id): Result<Unit>
+
+}


### PR DESCRIPTION
## やったこと
UserRepositoryからブロック機能とミュート機能を
別のMuteRepositoryとBlockRepositoryに切り出しました。
またAPIの実装をAdapterするUserApiAdapterもそれぞれMuteApiAdapterとBlockApiAdapterに分離しました。
またテストをしやすくするためにUser, Mute, BlockそれぞれのApiAdapterを
抽象化しその実装と分離するようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



