### PR TITLE
UserRepositoryからFollow周りの処理を切り出し

### DIFF
--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
@@ -11,6 +11,7 @@ import net.pantasystem.milktea.data.infrastructure.user.*
 import net.pantasystem.milktea.data.infrastructure.user.block.BlockApiAdapter
 import net.pantasystem.milktea.data.infrastructure.user.block.BlockApiAdapterImpl
 import net.pantasystem.milktea.data.infrastructure.user.block.BlockRepositoryImpl
+import net.pantasystem.milktea.data.infrastructure.user.follow.FollowRepositoryImpl
 import net.pantasystem.milktea.data.infrastructure.user.mute.MuteApiAdapter
 import net.pantasystem.milktea.data.infrastructure.user.mute.MuteApiAdapterImpl
 import net.pantasystem.milktea.data.infrastructure.user.mute.MuteRepositoryImpl
@@ -18,6 +19,7 @@ import net.pantasystem.milktea.model.user.FollowRequestRepository
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.model.user.UserRepository
 import net.pantasystem.milktea.model.user.block.BlockRepository
+import net.pantasystem.milktea.model.user.follow.FollowRepository
 import net.pantasystem.milktea.model.user.mute.MuteRepository
 import net.pantasystem.milktea.model.user.report.ReportRepository
 import javax.inject.Singleton
@@ -81,4 +83,8 @@ abstract class UserModule {
     @Binds
     @Singleton
     internal abstract fun bindReportRepository(impl: ReportRepositoryImpl): ReportRepository
+
+    @Binds
+    @Singleton
+    internal abstract fun bindFollowRepository(impl: FollowRepositoryImpl): FollowRepository
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/di/module/UserModule.kt
@@ -11,6 +11,8 @@ import net.pantasystem.milktea.data.infrastructure.user.*
 import net.pantasystem.milktea.data.infrastructure.user.block.BlockApiAdapter
 import net.pantasystem.milktea.data.infrastructure.user.block.BlockApiAdapterImpl
 import net.pantasystem.milktea.data.infrastructure.user.block.BlockRepositoryImpl
+import net.pantasystem.milktea.data.infrastructure.user.follow.FollowApiAdapter
+import net.pantasystem.milktea.data.infrastructure.user.follow.FollowApiAdapterImpl
 import net.pantasystem.milktea.data.infrastructure.user.follow.FollowRepositoryImpl
 import net.pantasystem.milktea.data.infrastructure.user.mute.MuteApiAdapter
 import net.pantasystem.milktea.data.infrastructure.user.mute.MuteApiAdapterImpl
@@ -87,4 +89,8 @@ abstract class UserModule {
     @Binds
     @Singleton
     internal abstract fun bindFollowRepository(impl: FollowRepositoryImpl): FollowRepository
+
+    @Binds
+    @Singleton
+    internal abstract fun bindFollowApiAdapter(impl: FollowApiAdapterImpl): FollowApiAdapter
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
@@ -1,7 +1,6 @@
 package net.pantasystem.milktea.data.infrastructure.user
 
 import net.pantasystem.milktea.api.mastodon.accounts.MastodonAccountDTO
-import net.pantasystem.milktea.api.misskey.users.CancelFollow
 import net.pantasystem.milktea.api.misskey.users.RequestUser
 import net.pantasystem.milktea.api.misskey.users.SearchByUserAndHost
 import net.pantasystem.milktea.api.misskey.users.UserDTO
@@ -19,12 +18,6 @@ import javax.inject.Singleton
 internal interface UserApiAdapter {
 
     suspend fun show(userId: User.Id, detail: Boolean): User
-
-    suspend fun follow(userId: User.Id): UserActionResult
-
-    suspend fun cancelFollowRequest(userId: User.Id): UserActionResult
-
-    suspend fun unfollow(userId: User.Id): UserActionResult
 
     suspend fun search(
         accountId: Long,
@@ -77,65 +70,7 @@ internal class UserApiAdapterImpl @Inject constructor(
         }
     }
 
-    override suspend fun follow(userId: User.Id): UserActionResult {
-        val account = accountRepository.get(userId.accountId).getOrThrow()
-        return when (account.instanceType) {
-            Account.InstanceType.MISSKEY -> {
-                misskeyAPIProvider.get(account).followUser(
-                    RequestUser(userId = userId.id, i = account.token)
-                ).throwIfHasError()
-                UserActionResult.Misskey
-            }
-            Account.InstanceType.MASTODON -> {
-                mastodonAPIProvider.get(account).follow(userId.id)
-                    .throwIfHasError().body().let {
-                        UserActionResult.Mastodon(requireNotNull(it))
-                    }
-            }
-        }
-    }
 
-    override suspend fun unfollow(userId: User.Id): UserActionResult {
-        val account = accountRepository.get(userId.accountId).getOrThrow()
-        return when (account.instanceType) {
-            Account.InstanceType.MISSKEY -> {
-                misskeyAPIProvider.get(account)
-                    .unFollowUser(RequestUser(userId = userId.id, i = account.token))
-                    .throwIfHasError()
-                    .body()
-                UserActionResult.Misskey
-            }
-            Account.InstanceType.MASTODON -> {
-                mastodonAPIProvider.get(account).unfollow(userId.id)
-                    .throwIfHasError()
-                    .body().let {
-                        UserActionResult.Mastodon(requireNotNull(it))
-                    }
-
-            }
-        }
-    }
-
-    override suspend fun cancelFollowRequest(userId: User.Id): UserActionResult {
-        val account = accountRepository.get(userId.accountId).getOrThrow()
-        return when (account.instanceType) {
-            Account.InstanceType.MISSKEY -> {
-                misskeyAPIProvider.get(account).cancelFollowRequest(
-                    CancelFollow(
-                        i = account.token,
-                        userId = userId.id
-                    )
-                ).throwIfHasError()
-                UserActionResult.Misskey
-            }
-            Account.InstanceType.MASTODON -> {
-                mastodonAPIProvider.get(account).unfollow(userId.id).throwIfHasError()
-                    .body().let {
-                        UserActionResult.Mastodon(requireNotNull(it))
-                    }
-            }
-        }
-    }
 
     override suspend fun search(
         accountId: Long,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/follow/FollowApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/follow/FollowApiAdapter.kt
@@ -11,7 +11,7 @@ import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.user.User
 import javax.inject.Inject
 
-interface FollowApiAdapter {
+internal interface FollowApiAdapter {
 
     suspend fun follow(userId: User.Id): UserActionResult
 
@@ -21,7 +21,7 @@ interface FollowApiAdapter {
 
 }
 
-class FollowApiAdapterImpl @Inject constructor(
+internal class FollowApiAdapterImpl @Inject constructor(
     private val accountRepository: AccountRepository,
     private val misskeyAPIProvider: MisskeyAPIProvider,
     private val mastodonAPIProvider: MastodonAPIProvider,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/follow/FollowApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/follow/FollowApiAdapter.kt
@@ -1,0 +1,88 @@
+package net.pantasystem.milktea.data.infrastructure.user.follow
+
+import net.pantasystem.milktea.api.misskey.users.CancelFollow
+import net.pantasystem.milktea.api.misskey.users.RequestUser
+import net.pantasystem.milktea.common.throwIfHasError
+import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
+import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
+import net.pantasystem.milktea.data.infrastructure.user.UserActionResult
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.account.AccountRepository
+import net.pantasystem.milktea.model.user.User
+import javax.inject.Inject
+
+interface FollowApiAdapter {
+
+    suspend fun follow(userId: User.Id): UserActionResult
+
+    suspend fun cancelFollowRequest(userId: User.Id): UserActionResult
+
+    suspend fun unfollow(userId: User.Id): UserActionResult
+
+}
+
+class FollowApiAdapterImpl @Inject constructor(
+    private val accountRepository: AccountRepository,
+    private val misskeyAPIProvider: MisskeyAPIProvider,
+    private val mastodonAPIProvider: MastodonAPIProvider,
+) : FollowApiAdapter {
+    override suspend fun follow(userId: User.Id): UserActionResult {
+        val account = accountRepository.get(userId.accountId).getOrThrow()
+        return when (account.instanceType) {
+            Account.InstanceType.MISSKEY -> {
+                misskeyAPIProvider.get(account).followUser(
+                    RequestUser(userId = userId.id, i = account.token)
+                ).throwIfHasError()
+                UserActionResult.Misskey
+            }
+            Account.InstanceType.MASTODON -> {
+                mastodonAPIProvider.get(account).follow(userId.id)
+                    .throwIfHasError().body().let {
+                        UserActionResult.Mastodon(requireNotNull(it))
+                    }
+            }
+        }
+    }
+
+    override suspend fun unfollow(userId: User.Id): UserActionResult {
+        val account = accountRepository.get(userId.accountId).getOrThrow()
+        return when (account.instanceType) {
+            Account.InstanceType.MISSKEY -> {
+                misskeyAPIProvider.get(account)
+                    .unFollowUser(RequestUser(userId = userId.id, i = account.token))
+                    .throwIfHasError()
+                    .body()
+                UserActionResult.Misskey
+            }
+            Account.InstanceType.MASTODON -> {
+                mastodonAPIProvider.get(account).unfollow(userId.id)
+                    .throwIfHasError()
+                    .body().let {
+                        UserActionResult.Mastodon(requireNotNull(it))
+                    }
+
+            }
+        }
+    }
+
+    override suspend fun cancelFollowRequest(userId: User.Id): UserActionResult {
+        val account = accountRepository.get(userId.accountId).getOrThrow()
+        return when (account.instanceType) {
+            Account.InstanceType.MISSKEY -> {
+                misskeyAPIProvider.get(account).cancelFollowRequest(
+                    CancelFollow(
+                        i = account.token,
+                        userId = userId.id
+                    )
+                ).throwIfHasError()
+                UserActionResult.Misskey
+            }
+            Account.InstanceType.MASTODON -> {
+                mastodonAPIProvider.get(account).unfollow(userId.id).throwIfHasError()
+                    .body().let {
+                        UserActionResult.Mastodon(requireNotNull(it))
+                    }
+            }
+        }
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/follow/FollowRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/follow/FollowRepositoryImpl.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
-import net.pantasystem.milktea.data.infrastructure.user.UserApiAdapter
 import net.pantasystem.milktea.data.infrastructure.user.UserCacheUpdaterFromUserActionResult
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserRepository
@@ -13,14 +12,14 @@ import javax.inject.Inject
 
 internal class FollowRepositoryImpl @Inject constructor(
     private val userRepository: UserRepository,
-    private val userApiAdapter: UserApiAdapter,
+    private val followApiAdapter: FollowApiAdapter,
     private val userCacheUpdaterFromUserActionResult: UserCacheUpdaterFromUserActionResult,
     @IODispatcher private val coroutineDispatcher: CoroutineDispatcher,
 ): FollowRepository {
     override suspend fun create(userId: User.Id): Result<Unit> = runCancellableCatching {
         withContext(coroutineDispatcher) {
             val user = userRepository.find(userId, true) as User.Detail
-            val result = userApiAdapter.follow(userId)
+            val result = followApiAdapter.follow(userId)
             userCacheUpdaterFromUserActionResult(userId, result) { u ->
                 u.copy(
                     related = (if (user.info.isLocked) user.related?.isFollowing else true)?.let {
@@ -40,9 +39,9 @@ internal class FollowRepositoryImpl @Inject constructor(
         withContext(coroutineDispatcher) {
             val user = userRepository.find(userId, true) as User.Detail
             val result = if (user.info.isLocked) {
-                userApiAdapter.cancelFollowRequest(userId)
+                followApiAdapter.cancelFollowRequest(userId)
             } else {
-                userApiAdapter.unfollow(userId)
+                followApiAdapter.unfollow(userId)
             }
             userCacheUpdaterFromUserActionResult(userId, result) { u ->
                 u.copy(

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/follow/FollowRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/follow/FollowRepositoryImpl.kt
@@ -1,0 +1,59 @@
+package net.pantasystem.milktea.data.infrastructure.user.follow
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.common_android.hilt.IODispatcher
+import net.pantasystem.milktea.data.infrastructure.user.UserApiAdapter
+import net.pantasystem.milktea.data.infrastructure.user.UserCacheUpdaterFromUserActionResult
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.UserRepository
+import net.pantasystem.milktea.model.user.follow.FollowRepository
+import javax.inject.Inject
+
+internal class FollowRepositoryImpl @Inject constructor(
+    private val userRepository: UserRepository,
+    private val userApiAdapter: UserApiAdapter,
+    private val userCacheUpdaterFromUserActionResult: UserCacheUpdaterFromUserActionResult,
+    @IODispatcher private val coroutineDispatcher: CoroutineDispatcher,
+): FollowRepository {
+    override suspend fun create(userId: User.Id): Result<Unit> = runCancellableCatching {
+        withContext(coroutineDispatcher) {
+            val user = userRepository.find(userId, true) as User.Detail
+            val result = userApiAdapter.follow(userId)
+            userCacheUpdaterFromUserActionResult(userId, result) { u ->
+                u.copy(
+                    related = (if (user.info.isLocked) user.related?.isFollowing else true)?.let {
+                        (if (user.info.isLocked) true else user.related?.hasPendingFollowRequestFromYou)?.let { it1 ->
+                            user.related?.copy(
+                                isFollowing = it,
+                                hasPendingFollowRequestFromYou = it1
+                            )
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    override suspend fun delete(userId: User.Id): Result<Unit> = runCancellableCatching {
+        withContext(coroutineDispatcher) {
+            val user = userRepository.find(userId, true) as User.Detail
+            val result = if (user.info.isLocked) {
+                userApiAdapter.cancelFollowRequest(userId)
+            } else {
+                userApiAdapter.unfollow(userId)
+            }
+            userCacheUpdaterFromUserActionResult(userId, result) { u ->
+                u.copy(
+                    related = u.related?.let{
+                        it.copy(
+                            isFollowing = if (u.info.isLocked) it.isFollowing else false,
+                            hasPendingFollowRequestFromYou = if (u.info.isLocked) false else it.hasPendingFollowRequestFromYou
+                        )
+                    }
+                )
+            }
+        }
+    }
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/ToggleFollowUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/ToggleFollowUseCase.kt
@@ -2,21 +2,23 @@ package net.pantasystem.milktea.model.user
 
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.model.UseCase
+import net.pantasystem.milktea.model.user.follow.FollowRepository
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class ToggleFollowUseCase @Inject constructor(
-    val userRepository: UserRepository,
+    private val followRepository: FollowRepository,
+    private val userRepository: UserRepository,
 ) : UseCase {
 
     suspend operator fun invoke(userId: User.Id): Result<Unit> {
         return runCancellableCatching {
             val state = userRepository.find(userId, true) as User.Detail
-            if (state.related?.isFollowing == true) {
-                userRepository.unfollow(userId)
+            if (state.related?.isFollowing == true || state.related?.hasPendingFollowRequestFromYou == true) {
+                followRepository.delete(userId)
             } else {
-                userRepository.follow(userId)
+                followRepository.create(userId)
             }
         }
     }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/UserRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/UserRepository.kt
@@ -12,7 +12,6 @@ interface UserRepository {
 
     suspend fun searchByNameOrUserName(accountId: Long, keyword: String, limit: Int = 100, nextId: String? = null, host: String? = null): List<User>
 
-
     suspend fun findUsers(accountId: Long, query: FindUsersQuery): List<User>
 
     suspend fun sync(userId: User.Id): Result<Unit>

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/UserRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/UserRepository.kt
@@ -12,9 +12,6 @@ interface UserRepository {
 
     suspend fun searchByNameOrUserName(accountId: Long, keyword: String, limit: Int = 100, nextId: String? = null, host: String? = null): List<User>
 
-    suspend fun follow(userId: User.Id): Boolean
-
-    suspend fun unfollow(userId: User.Id): Boolean
 
     suspend fun findUsers(accountId: Long, query: FindUsersQuery): List<User>
 

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/follow/FollowRepository.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/follow/FollowRepository.kt
@@ -1,0 +1,9 @@
+package net.pantasystem.milktea.model.user.follow
+
+import net.pantasystem.milktea.model.user.User
+
+interface FollowRepository {
+    suspend fun create(userId: User.Id): Result<Unit>
+
+    suspend fun delete(userId: User.Id): Result<Unit>
+}


### PR DESCRIPTION
## やったこと
UserRepositoryに実装されていたfollow, unfollowの処理を
新たに作成したFollowRepositoryに切り出しました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号

