### PR TITLE
13.10.0以降でリノートのミュートの状態が同期されるようにした

### DIFF
--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/renote/mute/IsSupportRenoteMuteInstance.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/renote/mute/IsSupportRenoteMuteInstance.kt
@@ -1,13 +1,37 @@
 package net.pantasystem.milktea.data.infrastructure.user.renote.mute
 
+import net.pantasystem.milktea.common.Logger
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.model.account.GetAccount
+import net.pantasystem.milktea.model.instance.Version
+import net.pantasystem.milktea.model.nodeinfo.NodeInfo
+import net.pantasystem.milktea.model.nodeinfo.NodeInfoRepository
+import net.pantasystem.milktea.model.nodeinfo.getVersion
 import javax.inject.Inject
 
 interface IsSupportRenoteMuteInstance {
     suspend operator fun invoke(accountId: Long): Boolean
 }
 
-class IsSupportRenoteMuteInstanceImpl @Inject constructor(): IsSupportRenoteMuteInstance {
+class IsSupportRenoteMuteInstanceImpl @Inject constructor(
+    private val getAccount: GetAccount,
+    private val nodeInfoRepository: NodeInfoRepository,
+    private val loggerFactory: Logger.Factory,
+): IsSupportRenoteMuteInstance {
+
+    private val logger by lazy {
+        loggerFactory.create("IsSupportRenoteMuteInstance")
+    }
     override suspend fun invoke(accountId: Long): Boolean {
-        return false
+        return runCancellableCatching {
+            val account = getAccount.get(accountId)
+            val nodeInfo = nodeInfoRepository.find(account.getHost()).getOrThrow()
+            nodeInfo.type is NodeInfo.SoftwareType.Misskey.Normal
+                    && nodeInfo.type.getVersion() >= Version("13.10.0")
+        }.onFailure {
+            logger.error("Failed to check support renote mute instance", it)
+        }.getOrElse {
+            false
+        }
     }
 }


### PR DESCRIPTION
## やったこと
リノートのミュートが追加されるバージョンが判明したため
リノートのミュートの状態がサーバと同期されるようにした。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



