### PR TITLE
Reaction acceptanceの実装を行なった

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteDTO.kt
@@ -73,7 +73,6 @@ data class NoteDTO(
     val app: App? = null,
     val channel: ChannelInfo? = null,
 
-    @kotlinx.serialization.Transient
     val reactionAcceptance: ReactionAcceptanceType? = null,
 ) : Serializable {
 

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/NoteDTO.kt
@@ -72,6 +72,9 @@ data class NoteDTO(
 
     val app: App? = null,
     val channel: ChannelInfo? = null,
+
+    @kotlinx.serialization.Transient
+    val reactionAcceptance: ReactionAcceptanceType? = null,
 ) : Serializable {
 
     @kotlinx.serialization.Serializable
@@ -105,3 +108,9 @@ enum class NoteVisibilityType {
 }
 
 object NoteVisibilityTypeSerializer : EnumIgnoreUnknownSerializer<NoteVisibilityType>(NoteVisibilityType.values(), NoteVisibilityType.Public)
+
+@kotlinx.serialization.Serializable
+enum class ReactionAcceptanceType {
+    @SerialName("likeOnly") LikeOnly,
+    @SerialName("likeOnlyForRemote") LikeOnly4Remote,
+}

--- a/modules/common_resource/src/main/res/drawable/ic_baseline_favorite_border_24.xml
+++ b/modules/common_resource/src/main/res/drawable/ic_baseline_favorite_border_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M16.5,3c-1.74,0 -3.41,0.81 -4.5,2.09C10.91,3.81 9.24,3 7.5,3 4.42,3 2,5.42 2,8.5c0,3.78 3.4,6.86 8.55,11.54L12,21.35l1.45,-1.32C18.6,15.36 22,12.28 22,8.5 22,5.42 19.58,3 16.5,3zM12.1,18.55l-0.1,0.1 -0.1,-0.1C7.14,14.24 4,11.39 4,8.5 4,6.5 5.5,5 7.5,5c1.54,0 3.04,0.99 3.57,2.36h1.87C13.46,5.99 14.96,5 16.5,5c2,0 3.5,1.5 3.5,3.5 0,2.89 -3.14,5.74 -7.9,10.05z"/>
+</vector>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverter.kt
@@ -3,6 +3,7 @@ package net.pantasystem.milktea.data.converters
 import net.pantasystem.milktea.api.misskey.notes.NoteDTO
 import net.pantasystem.milktea.api.misskey.notes.NoteVisibilityType
 import net.pantasystem.milktea.api.misskey.notes.PollDTO
+import net.pantasystem.milktea.api.misskey.notes.ReactionAcceptanceType
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.channel.Channel
 import net.pantasystem.milktea.model.drive.FileProperty
@@ -61,6 +62,11 @@ class NoteDTOEntityConverter @Inject constructor() {
                         id = Channel.Id(account.accountId, it.id),
                         name = it.name
                     )
+                },
+                reactionAcceptance = when(noteDTO.reactionAcceptance) {
+                    ReactionAcceptanceType.LikeOnly -> Note.Type.Misskey.ReactionAcceptanceType.LikeOnly
+                    ReactionAcceptanceType.LikeOnly4Remote -> Note.Type.Misskey.ReactionAcceptanceType.LikeOnlyForRemote
+                    null -> Note.Type.Misskey.ReactionAcceptanceType.All
                 }
             ),
             nodeInfo = nodeInfo,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/NoteDTOEntityConverter.kt
@@ -63,11 +63,11 @@ class NoteDTOEntityConverter @Inject constructor() {
                         name = it.name
                     )
                 },
-                reactionAcceptance = when(noteDTO.reactionAcceptance) {
-                    ReactionAcceptanceType.LikeOnly -> Note.Type.Misskey.ReactionAcceptanceType.LikeOnly
-                    ReactionAcceptanceType.LikeOnly4Remote -> Note.Type.Misskey.ReactionAcceptanceType.LikeOnlyForRemote
-                    null -> Note.Type.Misskey.ReactionAcceptanceType.All
-                }
+                isAcceptingOnlyLikeReaction = when(noteDTO.reactionAcceptance){
+                    ReactionAcceptanceType.LikeOnly4Remote -> noteDTO.uri != null
+                    ReactionAcceptanceType.LikeOnly -> true
+                    null -> false
+                },
             ),
             nodeInfo = nodeInfo,
         )

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/ReactionButtonHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/ReactionButtonHelper.kt
@@ -7,12 +7,17 @@ import net.pantasystem.milktea.note.R
 object ReactionButtonHelper {
 
     @JvmStatic
-    @BindingAdapter("isReacted")
-    fun ImageButton.setIsReacted(isReacted: Boolean?){
+    @BindingAdapter("isReacted", "isAcceptingOnlyFavoriteReaction")
+    fun ImageButton.setIsReacted(isReacted: Boolean?, isAcceptingOnlyFavoriteReaction: Boolean?){
         if(isReacted == true){
             this.setImageResource(R.drawable.ic_remove_black_24dp)
         }else{
-            this.setImageResource(R.drawable.ic_add_black_24dp)
+            if (isAcceptingOnlyFavoriteReaction == true) {
+                this.setImageResource(R.drawable.ic_baseline_favorite_border_24)
+            } else {
+                this.setImageResource(R.drawable.ic_add_black_24dp)
+            }
+
         }
     }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/NoteCardActionHandler.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/NoteCardActionHandler.kt
@@ -57,6 +57,10 @@ class NoteCardActionHandler(
                     notesViewModel.toggleReaction(action.note.toShowNote.note.id, myReaction)
                     return
                 }
+                if (action.note.toShowNote.note.isAcceptingOnlyLikeReaction) {
+                    notesViewModel.toggleReaction(action.note.toShowNote.note.id, "❤️")
+                    return
+                }
                 when (settingStore.reactionPickerType) {
                     ReactionPickerType.LIST -> {
                         ReactionSelectionDialog.newInstance(action.note.toShowNote.note.id)

--- a/modules/features/note/src/main/res/layout/item_detail_note.xml
+++ b/modules/features/note/src/main/res/layout/item_detail_note.xml
@@ -473,6 +473,7 @@
                         android:padding="@dimen/note_bottom_action_icon_padding_size"
                         android:scaleType="centerCrop"
                         app:isReacted="@{note.myReaction != null}"
+                        isAcceptingOnlyFavoriteReaction="@{note.currentNote.acceptingOnlyLikeReaction}"
                         tools:srcCompat="@drawable/ic_add_circle_outline_black_24dp"
                         android:visibility="@{note.currentNote.supportEmojiReaction ? View.VISIBLE : View.GONE }"
                         app:tint="?attr/normalIconTint" />

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -540,6 +540,7 @@
                     android:layout_width="@dimen/note_bottom_action_icon_size"
                     android:layout_height="@dimen/note_bottom_action_icon_size"
                     app:isReacted="@{note.myReaction != null}"
+                    isAcceptingOnlyFavoriteReaction="@{note.currentNote.acceptingOnlyLikeReaction}"
                     tools:srcCompat="@drawable/ic_add_black_24dp"
                     style="?android:attr/borderlessButtonStyle"
                     android:padding="@dimen/note_bottom_action_icon_padding_size"

--- a/modules/features/note/src/main/res/values/dimens.xml
+++ b/modules/features/note/src/main/res/values/dimens.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="note_bottom_action_icon_size">40dp</dimen>
-    <dimen name="note_bottom_action_icon_padding_size">8dp</dimen>
+    <dimen name="note_bottom_action_icon_padding_size">10dp</dimen>
 
     <dimen name="note_horizontal_padding_size">14dp</dimen>
     <dimen name="note_top_padding_size">10dp</dimen>

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
@@ -100,6 +100,8 @@ data class Note(
 
     val isSupportEmojiReaction: Boolean = type is Type.Misskey || nodeInfo?.type is NodeInfo.SoftwareType.Mastodon.Fedibird
 
+    val isAcceptingOnlyLikeReaction: Boolean = type is Type.Misskey && type.isAcceptingOnlyLikeReaction
+
     fun getShortReactionCounts(isRenote: Boolean): List<ReactionCount> {
         return if (isRenote) {
             if (reactionCounts.size <= SHORT_RENOTE_REACTION_COUNT_MAX_SIZE) {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
@@ -58,8 +58,13 @@ data class Note(
     sealed interface Type {
         data class Misskey(
             val channel: SimpleChannelInfo? = null,
+            val reactionAcceptance: ReactionAcceptanceType
         ) : Type {
             data class SimpleChannelInfo(val id: Channel.Id, val name: String)
+
+            enum class ReactionAcceptanceType {
+                All, LikeOnly, LikeOnlyForRemote
+            }
         }
 
         data class Mastodon(
@@ -219,7 +224,9 @@ fun Note.Companion.make(
     myReaction: String? = null,
     app: AppType.Misskey? = null,
     channelId: Channel.Id? = null,
-    type: Note.Type = Note.Type.Misskey(),
+    type: Note.Type = Note.Type.Misskey(
+        reactionAcceptance = Note.Type.Misskey.ReactionAcceptanceType.All,
+    ),
     nodeInfo: NodeInfo? = null,
 ): Note {
     return Note(

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
@@ -58,13 +58,10 @@ data class Note(
     sealed interface Type {
         data class Misskey(
             val channel: SimpleChannelInfo? = null,
-            val reactionAcceptance: ReactionAcceptanceType
+            val isAcceptingOnlyLikeReaction: Boolean= false,
         ) : Type {
             data class SimpleChannelInfo(val id: Channel.Id, val name: String)
 
-            enum class ReactionAcceptanceType {
-                All, LikeOnly, LikeOnlyForRemote
-            }
         }
 
         data class Mastodon(
@@ -224,9 +221,7 @@ fun Note.Companion.make(
     myReaction: String? = null,
     app: AppType.Misskey? = null,
     channelId: Channel.Id? = null,
-    type: Note.Type = Note.Type.Misskey(
-        reactionAcceptance = Note.Type.Misskey.ReactionAcceptanceType.All,
-    ),
+    type: Note.Type = Note.Type.Misskey(),
     nodeInfo: NodeInfo? = null,
 ): Note {
     return Note(


### PR DESCRIPTION
## やったこと
「いいね」以外のリアクションを受け入れなくする
Misskey v13.10.0に実装されたReaction acceptanceに部分的に対応しました。
具体的に対応した箇所としては、ReactionAcceptanceの指定があるノートには
リアクション追加ボタンにハートのアイコンを表示するようにしました。
またそのハートのアイコンをクリックした時は直接ハートのリアクションが送信されるようにしました。
またNoteの下部Menuのアイコンのpaddingを8dpから10dpにしました。

## 動作確認


## スクリーンショット(任意)


## 備考
ノートの編集画面にReaction acceptanceの設定を行う機能は実装していません。

## Issue番号
Closed #1519 



