### PR TITLE
リアクションの判定にFedibirdのハードコーディングで判定するのをやめた

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/instance/Instance.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/instance/Instance.kt
@@ -12,6 +12,7 @@ data class Instance(
     val version: String,
     val urls: Urls,
     val configuration: Configuration? = null,
+    @SerialName("fedibird_capabilities") val fedibirdCapabilities: List<String>? = null,
 ) {
     @Serializable
     data class Configuration(

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/TootStatusDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/TootStatusDTO.kt
@@ -7,6 +7,7 @@ import net.pantasystem.milktea.api.mastodon.emojis.TootEmojiDTO
 import net.pantasystem.milktea.api.mastodon.filter.FilterResultDTO
 import net.pantasystem.milktea.api.mastodon.media.TootMediaAttachment
 import net.pantasystem.milktea.api.mastodon.poll.TootPollDTO
+import net.pantasystem.milktea.common.serializations.EnumIgnoreUnknownSerializer
 import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.notes.Note
 
@@ -124,7 +125,9 @@ data class TootStatusDTO(
     }
 }
 
-@kotlinx.serialization.Serializable
+object TootStatusVisibilityTypeSerializer : EnumIgnoreUnknownSerializer<StatusVisibilityType>(StatusVisibilityType.values(), StatusVisibilityType.Public)
+
+@kotlinx.serialization.Serializable(with = TootStatusVisibilityTypeSerializer::class)
 enum class StatusVisibilityType {
     @SerialName("private") Private,
     @SerialName("unlisted") Unlisted,

--- a/modules/data/schemas/net.pantasystem.milktea.data.infrastructure.DataBase/42.json
+++ b/modules/data/schemas/net.pantasystem.milktea.data.infrastructure.DataBase/42.json
@@ -1,0 +1,3793 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 42,
+    "identityHash": "81d289dc1714f5ef5d109132333e0879",
+    "entities": [
+      {
+        "tableName": "connection_information",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` TEXT NOT NULL, `instanceBaseUrl` TEXT NOT NULL, `encryptedI` TEXT NOT NULL, `viaName` TEXT, `createdAt` TEXT NOT NULL, `isDirect` INTEGER NOT NULL, `updatedAt` TEXT NOT NULL, PRIMARY KEY(`accountId`, `encryptedI`, `instanceBaseUrl`), FOREIGN KEY(`accountId`) REFERENCES `Account`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceBaseUrl",
+            "columnName": "instanceBaseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "encryptedI",
+            "columnName": "encryptedI",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viaName",
+            "columnName": "viaName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDirect",
+            "columnName": "isDirect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId",
+            "encryptedI",
+            "instanceBaseUrl"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Account",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "reaction_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`reaction` TEXT NOT NULL, `instance_domain` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT)",
+        "fields": [
+          {
+            "fieldPath": "reaction",
+            "columnName": "reaction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instance_domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Account",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "reaction_user_setting",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`reaction` TEXT NOT NULL, `instance_domain` TEXT NOT NULL, `weight` INTEGER NOT NULL, PRIMARY KEY(`reaction`, `instance_domain`))",
+        "fields": [
+          {
+            "fieldPath": "reaction",
+            "columnName": "reaction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instance_domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "reaction",
+            "instance_domain"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "page",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` TEXT, `title` TEXT NOT NULL, `pageNumber` INTEGER, `id` INTEGER PRIMARY KEY AUTOINCREMENT, `global_timeline_with_files` INTEGER, `global_timeline_type` TEXT, `local_timeline_with_files` INTEGER, `local_timeline_exclude_nsfw` INTEGER, `local_timeline_type` TEXT, `hybrid_timeline_withFiles` INTEGER, `hybrid_timeline_includeLocalRenotes` INTEGER, `hybrid_timeline_includeMyRenotes` INTEGER, `hybrid_timeline_includeRenotedMyRenotes` INTEGER, `hybrid_timeline_type` TEXT, `home_timeline_withFiles` INTEGER, `home_timeline_includeLocalRenotes` INTEGER, `home_timeline_includeMyRenotes` INTEGER, `home_timeline_includeRenotedMyRenotes` INTEGER, `home_timeline_type` TEXT, `user_list_timeline_listId` TEXT, `user_list_timeline_withFiles` INTEGER, `user_list_timeline_includeLocalRenotes` INTEGER, `user_list_timeline_includeMyRenotes` INTEGER, `user_list_timeline_includeRenotedMyRenotes` INTEGER, `user_list_timeline_type` TEXT, `mention_following` INTEGER, `mention_visibility` TEXT, `mention_type` TEXT, `show_noteId` TEXT, `show_type` TEXT, `tag_tag` TEXT, `tag_reply` INTEGER, `tag_renote` INTEGER, `tag_withFiles` INTEGER, `tag_poll` INTEGER, `tag_type` TEXT, `featured_offset` INTEGER, `featured_type` TEXT, `notification_following` INTEGER, `notification_markAsRead` INTEGER, `notification_type` TEXT, `user_userId` TEXT, `user_includeReplies` INTEGER, `user_includeMyRenotes` INTEGER, `user_withFiles` INTEGER, `user_type` TEXT, `search_query` TEXT, `search_host` TEXT, `search_userId` TEXT, `search_type` TEXT, `favorite_type` TEXT, `antenna_antennaId` TEXT, `antenna_type` TEXT, FOREIGN KEY(`accountId`) REFERENCES `Account`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageNumber",
+            "columnName": "pageNumber",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "globalTimeline.withFiles",
+            "columnName": "global_timeline_with_files",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "globalTimeline.type",
+            "columnName": "global_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localTimeline.withFiles",
+            "columnName": "local_timeline_with_files",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localTimeline.excludeNsfw",
+            "columnName": "local_timeline_exclude_nsfw",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localTimeline.type",
+            "columnName": "local_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.withFiles",
+            "columnName": "hybrid_timeline_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.includeLocalRenotes",
+            "columnName": "hybrid_timeline_includeLocalRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.includeMyRenotes",
+            "columnName": "hybrid_timeline_includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.includeRenotedMyRenotes",
+            "columnName": "hybrid_timeline_includeRenotedMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hybridTimeline.type",
+            "columnName": "hybrid_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.withFiles",
+            "columnName": "home_timeline_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.includeLocalRenotes",
+            "columnName": "home_timeline_includeLocalRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.includeMyRenotes",
+            "columnName": "home_timeline_includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.includeRenotedMyRenotes",
+            "columnName": "home_timeline_includeRenotedMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "homeTimeline.type",
+            "columnName": "home_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.listId",
+            "columnName": "user_list_timeline_listId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.withFiles",
+            "columnName": "user_list_timeline_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.includeLocalRenotes",
+            "columnName": "user_list_timeline_includeLocalRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.includeMyRenotes",
+            "columnName": "user_list_timeline_includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.includeRenotedMyRenotes",
+            "columnName": "user_list_timeline_includeRenotedMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userListTimeline.type",
+            "columnName": "user_list_timeline_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mention.following",
+            "columnName": "mention_following",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mention.visibility",
+            "columnName": "mention_visibility",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mention.type",
+            "columnName": "mention_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "show.noteId",
+            "columnName": "show_noteId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "show.type",
+            "columnName": "show_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.tag",
+            "columnName": "tag_tag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.reply",
+            "columnName": "tag_reply",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.renote",
+            "columnName": "tag_renote",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.withFiles",
+            "columnName": "tag_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.poll",
+            "columnName": "tag_poll",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "searchByTag.type",
+            "columnName": "tag_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "featured.offset",
+            "columnName": "featured_offset",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "featured.type",
+            "columnName": "featured_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notification.following",
+            "columnName": "notification_following",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notification.markAsRead",
+            "columnName": "notification_markAsRead",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notification.type",
+            "columnName": "notification_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.userId",
+            "columnName": "user_userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.includeReplies",
+            "columnName": "user_includeReplies",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.includeMyRenotes",
+            "columnName": "user_includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.withFiles",
+            "columnName": "user_withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userTimeline.type",
+            "columnName": "user_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "search.query",
+            "columnName": "search_query",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "search.host",
+            "columnName": "search_host",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "search.userId",
+            "columnName": "search_userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "search.type",
+            "columnName": "search_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "favorite.type",
+            "columnName": "favorite_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "antenna.antennaId",
+            "columnName": "antenna_antennaId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "antenna.type",
+            "columnName": "antenna_type",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_page_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Account",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "poll_choice_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`choice` TEXT NOT NULL, `draft_note_id` INTEGER NOT NULL, `weight` INTEGER NOT NULL, PRIMARY KEY(`choice`, `weight`, `draft_note_id`), FOREIGN KEY(`draft_note_id`) REFERENCES `draft_note_table`(`draft_note_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "choice",
+            "columnName": "choice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draft_note_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "choice",
+            "weight",
+            "draft_note_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_poll_choice_table_draft_note_id_choice",
+            "unique": false,
+            "columnNames": [
+              "draft_note_id",
+              "choice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_poll_choice_table_draft_note_id_choice` ON `${TABLE_NAME}` (`draft_note_id`, `choice`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "draft_note_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "draft_note_id"
+            ],
+            "referencedColumns": [
+              "draft_note_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_id",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `draft_note_id` INTEGER NOT NULL, PRIMARY KEY(`userId`, `draft_note_id`), FOREIGN KEY(`draft_note_id`) REFERENCES `draft_note_table`(`draft_note_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draft_note_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "draft_note_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_id_draft_note_id",
+            "unique": false,
+            "columnNames": [
+              "draft_note_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_id_draft_note_id` ON `${TABLE_NAME}` (`draft_note_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "draft_note_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "draft_note_id"
+            ],
+            "referencedColumns": [
+              "draft_note_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "draft_file_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL DEFAULT 'name none', `remote_file_id` TEXT, `file_path` TEXT, `is_sensitive` INTEGER, `type` TEXT, `thumbnailUrl` TEXT, `draft_note_id` INTEGER NOT NULL, `folder_id` TEXT, `file_id` INTEGER PRIMARY KEY AUTOINCREMENT, FOREIGN KEY(`draft_note_id`) REFERENCES `draft_note_table`(`draft_note_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'name none'"
+          },
+          {
+            "fieldPath": "remoteFileId",
+            "columnName": "remote_file_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isSensitive",
+            "columnName": "is_sensitive",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draft_note_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folder_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fileId",
+            "columnName": "file_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "file_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_draft_file_table_draft_note_id",
+            "unique": false,
+            "columnNames": [
+              "draft_note_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_file_table_draft_note_id` ON `${TABLE_NAME}` (`draft_note_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "draft_note_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "draft_note_id"
+            ],
+            "referencedColumns": [
+              "draft_note_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "draft_note_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `visibility` TEXT NOT NULL, `text` TEXT, `cw` TEXT, `viaMobile` INTEGER, `localOnly` INTEGER, `noExtractMentions` INTEGER, `noExtractHashtags` INTEGER, `noExtractEmojis` INTEGER, `replyId` TEXT, `renoteId` TEXT, `channelId` TEXT, `scheduleWillPostAt` TEXT, `draft_note_id` INTEGER PRIMARY KEY AUTOINCREMENT, `isSensitive` INTEGER, `multiple` INTEGER, `expiresAt` INTEGER, FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cw",
+            "columnName": "cw",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "viaMobile",
+            "columnName": "viaMobile",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localOnly",
+            "columnName": "localOnly",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noExtractMentions",
+            "columnName": "noExtractMentions",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noExtractHashtags",
+            "columnName": "noExtractHashtags",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noExtractEmojis",
+            "columnName": "noExtractEmojis",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "replyId",
+            "columnName": "replyId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "renoteId",
+            "columnName": "renoteId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "scheduleWillPostAt",
+            "columnName": "scheduleWillPostAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draft_note_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isSensitive",
+            "columnName": "isSensitive",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "poll.multiple",
+            "columnName": "multiple",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "poll.expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "draft_note_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_draft_note_table_accountId_text",
+            "unique": false,
+            "columnNames": [
+              "accountId",
+              "text"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_note_table_accountId_text` ON `${TABLE_NAME}` (`accountId`, `text`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "url_preview",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`url` TEXT NOT NULL, `title` TEXT NOT NULL, `icon` TEXT, `description` TEXT, `thumbnail` TEXT, `siteName` TEXT, PRIMARY KEY(`url`))",
+        "fields": [
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnail",
+            "columnName": "thumbnail",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "siteName",
+            "columnName": "siteName",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "url"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "account_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`remoteId` TEXT NOT NULL, `instanceDomain` TEXT NOT NULL, `userName` TEXT NOT NULL, `encryptedToken` TEXT NOT NULL, `instanceType` TEXT NOT NULL DEFAULT 'misskey', `accountId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instanceDomain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "userName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "encryptedToken",
+            "columnName": "encryptedToken",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceType",
+            "columnName": "instanceType",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'misskey'"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "accountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_account_table_remoteId",
+            "unique": false,
+            "columnNames": [
+              "remoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_table_remoteId` ON `${TABLE_NAME}` (`remoteId`)"
+          },
+          {
+            "name": "index_account_table_instanceDomain",
+            "unique": false,
+            "columnNames": [
+              "instanceDomain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_table_instanceDomain` ON `${TABLE_NAME}` (`instanceDomain`)"
+          },
+          {
+            "name": "index_account_table_userName",
+            "unique": false,
+            "columnNames": [
+              "userName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_account_table_userName` ON `${TABLE_NAME}` (`userName`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "page_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `title` TEXT NOT NULL, `weight` INTEGER NOT NULL, `pageId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `withFiles` INTEGER, `excludeNsfw` INTEGER, `includeLocalRenotes` INTEGER, `includeMyRenotes` INTEGER, `includeRenotedMyRenotes` INTEGER, `listId` TEXT, `following` INTEGER, `visibility` TEXT, `noteId` TEXT, `tag` TEXT, `reply` INTEGER, `renote` INTEGER, `poll` INTEGER, `offset` INTEGER, `markAsRead` INTEGER, `userId` TEXT, `includeReplies` INTEGER, `query` TEXT, `host` TEXT, `antennaId` TEXT, `channelId` TEXT, `clipId` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageId",
+            "columnName": "pageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageParams.type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageParams.withFiles",
+            "columnName": "withFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.excludeNsfw",
+            "columnName": "excludeNsfw",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.includeLocalRenotes",
+            "columnName": "includeLocalRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.includeMyRenotes",
+            "columnName": "includeMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.includeRenotedMyRenotes",
+            "columnName": "includeRenotedMyRenotes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.listId",
+            "columnName": "listId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.following",
+            "columnName": "following",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.visibility",
+            "columnName": "visibility",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.reply",
+            "columnName": "reply",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.renote",
+            "columnName": "renote",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.poll",
+            "columnName": "poll",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.offset",
+            "columnName": "offset",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.markAsRead",
+            "columnName": "markAsRead",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.includeReplies",
+            "columnName": "includeReplies",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.antennaId",
+            "columnName": "antennaId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pageParams.clipId",
+            "columnName": "clipId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "pageId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_page_table_weight",
+            "unique": false,
+            "columnNames": [
+              "weight"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_table_weight` ON `${TABLE_NAME}` (`weight`)"
+          },
+          {
+            "name": "index_page_table_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_page_table_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "meta_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uri` TEXT NOT NULL, `bannerUrl` TEXT, `cacheRemoteFiles` INTEGER, `description` TEXT, `disableGlobalTimeline` INTEGER, `disableLocalTimeline` INTEGER, `disableRegistration` INTEGER, `driveCapacityPerLocalUserMb` INTEGER, `driveCapacityPerRemoteUserMb` INTEGER, `enableDiscordIntegration` INTEGER, `enableEmail` INTEGER, `enableEmojiReaction` INTEGER, `enableGithubIntegration` INTEGER, `enableRecaptcha` INTEGER, `enableServiceWorker` INTEGER, `enableTwitterIntegration` INTEGER, `errorImageUrl` TEXT, `feedbackUrl` TEXT, `iconUrl` TEXT, `maintainerEmail` TEXT, `maintainerName` TEXT, `mascotImageUrl` TEXT, `maxNoteTextLength` INTEGER, `name` TEXT, `recaptchaSiteKey` TEXT, `secure` INTEGER, `swPublicKey` TEXT, `toSUrl` TEXT, `version` TEXT NOT NULL, PRIMARY KEY(`uri`))",
+        "fields": [
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bannerUrl",
+            "columnName": "bannerUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cacheRemoteFiles",
+            "columnName": "cacheRemoteFiles",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "disableGlobalTimeline",
+            "columnName": "disableGlobalTimeline",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "disableLocalTimeline",
+            "columnName": "disableLocalTimeline",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "disableRegistration",
+            "columnName": "disableRegistration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "driveCapacityPerLocalUserMb",
+            "columnName": "driveCapacityPerLocalUserMb",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "driveCapacityPerRemoteUserMb",
+            "columnName": "driveCapacityPerRemoteUserMb",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableDiscordIntegration",
+            "columnName": "enableDiscordIntegration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableEmail",
+            "columnName": "enableEmail",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableEmojiReaction",
+            "columnName": "enableEmojiReaction",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableGithubIntegration",
+            "columnName": "enableGithubIntegration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableRecaptcha",
+            "columnName": "enableRecaptcha",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableServiceWorker",
+            "columnName": "enableServiceWorker",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "enableTwitterIntegration",
+            "columnName": "enableTwitterIntegration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "errorImageUrl",
+            "columnName": "errorImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "feedbackUrl",
+            "columnName": "feedbackUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "iconUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maintainerEmail",
+            "columnName": "maintainerEmail",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maintainerName",
+            "columnName": "maintainerName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mascotImageUrl",
+            "columnName": "mascotImageUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxNoteTextLength",
+            "columnName": "maxNoteTextLength",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recaptchaSiteKey",
+            "columnName": "recaptchaSiteKey",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "secure",
+            "columnName": "secure",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "swPublicKey",
+            "columnName": "swPublicKey",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "toSUrl",
+            "columnName": "toSUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uri"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "emoji_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `instanceDomain` TEXT NOT NULL, `host` TEXT, `url` TEXT, `uri` TEXT, `type` TEXT, `category` TEXT, `id` TEXT, PRIMARY KEY(`name`, `instanceDomain`), FOREIGN KEY(`instanceDomain`) REFERENCES `meta_table`(`uri`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instanceDomain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name",
+            "instanceDomain"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_emoji_table_instanceDomain",
+            "unique": false,
+            "columnNames": [
+              "instanceDomain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_emoji_table_instanceDomain` ON `${TABLE_NAME}` (`instanceDomain`)"
+          },
+          {
+            "name": "index_emoji_table_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_emoji_table_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "meta_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "instanceDomain"
+            ],
+            "referencedColumns": [
+              "uri"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "emoji_alias_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`alias` TEXT NOT NULL, `name` TEXT NOT NULL, `instanceDomain` TEXT NOT NULL, PRIMARY KEY(`alias`, `name`, `instanceDomain`), FOREIGN KEY(`name`, `instanceDomain`) REFERENCES `emoji_table`(`name`, `instanceDomain`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "alias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instanceDomain",
+            "columnName": "instanceDomain",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "alias",
+            "name",
+            "instanceDomain"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_emoji_alias_table_name_instanceDomain",
+            "unique": false,
+            "columnNames": [
+              "name",
+              "instanceDomain"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_emoji_alias_table_name_instanceDomain` ON `${TABLE_NAME}` (`name`, `instanceDomain`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "emoji_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "name",
+              "instanceDomain"
+            ],
+            "referencedColumns": [
+              "name",
+              "instanceDomain"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "unread_notifications_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `notificationId` TEXT NOT NULL, PRIMARY KEY(`accountId`, `notificationId`), FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationId",
+            "columnName": "notificationId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId",
+            "notificationId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "nicknames",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`nickname` TEXT NOT NULL, `username` TEXT NOT NULL, `host` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_nicknames_username_host",
+            "unique": true,
+            "columnNames": [
+              "username",
+              "host"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_nicknames_username_host` ON `${TABLE_NAME}` (`username`, `host`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "utf8_emojis_by_amio",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`codes` TEXT NOT NULL, `name` TEXT NOT NULL, `char` TEXT NOT NULL, PRIMARY KEY(`codes`))",
+        "fields": [
+          {
+            "fieldPath": "codes",
+            "columnName": "codes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "charCode",
+            "columnName": "char",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "codes"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "drive_file_v1",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `relatedAccountId` INTEGER NOT NULL, `createdAt` TEXT, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `md5` TEXT, `size` INTEGER, `url` TEXT NOT NULL, `isSensitive` INTEGER NOT NULL, `thumbnailUrl` TEXT, `folderId` TEXT, `userId` TEXT, `comment` TEXT, `blurhash` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`relatedAccountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatedAccountId",
+            "columnName": "relatedAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "md5",
+            "columnName": "md5",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSensitive",
+            "columnName": "isSensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folderId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "blurhash",
+            "columnName": "blurhash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_drive_file_v1_serverId_relatedAccountId",
+            "unique": true,
+            "columnNames": [
+              "serverId",
+              "relatedAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_drive_file_v1_serverId_relatedAccountId` ON `${TABLE_NAME}` (`serverId`, `relatedAccountId`)"
+          },
+          {
+            "name": "index_drive_file_v1_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drive_file_v1_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_drive_file_v1_relatedAccountId",
+            "unique": false,
+            "columnNames": [
+              "relatedAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drive_file_v1_relatedAccountId` ON `${TABLE_NAME}` (`relatedAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "relatedAccountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "draft_file_v2_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`draftNoteId` INTEGER NOT NULL, `filePropertyId` INTEGER, `localFileId` INTEGER, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`filePropertyId`) REFERENCES `drive_file_v1`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`localFileId`) REFERENCES `draft_local_file_v2_table`(`localFileId`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "draftNoteId",
+            "columnName": "draftNoteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePropertyId",
+            "columnName": "filePropertyId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localFileId",
+            "columnName": "localFileId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_draft_file_v2_table_draftNoteId_filePropertyId_localFileId",
+            "unique": true,
+            "columnNames": [
+              "draftNoteId",
+              "filePropertyId",
+              "localFileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_draft_file_v2_table_draftNoteId_filePropertyId_localFileId` ON `${TABLE_NAME}` (`draftNoteId`, `filePropertyId`, `localFileId`)"
+          },
+          {
+            "name": "index_draft_file_v2_table_draftNoteId",
+            "unique": false,
+            "columnNames": [
+              "draftNoteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_file_v2_table_draftNoteId` ON `${TABLE_NAME}` (`draftNoteId`)"
+          },
+          {
+            "name": "index_draft_file_v2_table_localFileId",
+            "unique": false,
+            "columnNames": [
+              "localFileId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_file_v2_table_localFileId` ON `${TABLE_NAME}` (`localFileId`)"
+          },
+          {
+            "name": "index_draft_file_v2_table_filePropertyId",
+            "unique": false,
+            "columnNames": [
+              "filePropertyId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_draft_file_v2_table_filePropertyId` ON `${TABLE_NAME}` (`filePropertyId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "drive_file_v1",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "filePropertyId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "draft_local_file_v2_table",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "localFileId"
+            ],
+            "referencedColumns": [
+              "localFileId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "draft_local_file_v2_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `file_path` TEXT NOT NULL, `is_sensitive` INTEGER, `type` TEXT NOT NULL, `thumbnailUrl` TEXT, `folder_id` TEXT, `file_size` INTEGER, `comment` TEXT, `localFileId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSensitive",
+            "columnName": "is_sensitive",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folder_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localFileId",
+            "columnName": "localFileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "localFileId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "group_v1",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `name` TEXT NOT NULL, `ownerId` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ownerId",
+            "columnName": "ownerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_v1_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_v1_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_group_v1_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_v1_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_group_v1_accountId_serverId",
+            "unique": true,
+            "columnNames": [
+              "accountId",
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_group_v1_accountId_serverId` ON `${TABLE_NAME}` (`accountId`, `serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "group_member_v1",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`groupId` INTEGER NOT NULL, `userId` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`groupId`) REFERENCES `group_v1`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_member_v1_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_member_v1_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_group_member_v1_groupId_userId",
+            "unique": true,
+            "columnNames": [
+              "groupId",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_group_member_v1_groupId_userId` ON `${TABLE_NAME}` (`groupId`, `userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "group_v1",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `userName` TEXT NOT NULL, `name` TEXT, `avatarUrl` TEXT, `isCat` INTEGER, `isBot` INTEGER, `host` TEXT NOT NULL, `isSameHost` INTEGER NOT NULL, `avatarBlurhash` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userName",
+            "columnName": "userName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isCat",
+            "columnName": "isCat",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isBot",
+            "columnName": "isBot",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSameHost",
+            "columnName": "isSameHost",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarBlurhash",
+            "columnName": "avatarBlurhash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_serverId_accountId",
+            "unique": true,
+            "columnNames": [
+              "serverId",
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_serverId_accountId` ON `${TABLE_NAME}` (`serverId`, `accountId`)"
+          },
+          {
+            "name": "index_user_userName",
+            "unique": false,
+            "columnNames": [
+              "userName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_userName` ON `${TABLE_NAME}` (`userName`)"
+          },
+          {
+            "name": "index_user_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_user_host",
+            "unique": false,
+            "columnNames": [
+              "host"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_host` ON `${TABLE_NAME}` (`host`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_detailed_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`description` TEXT, `followersCount` INTEGER, `followingCount` INTEGER, `hostLower` TEXT, `notesCount` INTEGER, `bannerUrl` TEXT, `url` TEXT, `isFollowing` INTEGER NOT NULL, `isFollower` INTEGER NOT NULL, `isBlocking` INTEGER NOT NULL, `isMuting` INTEGER NOT NULL, `hasPendingFollowRequestFromYou` INTEGER NOT NULL, `hasPendingFollowRequestToYou` INTEGER NOT NULL, `isLocked` INTEGER NOT NULL, `birthday` TEXT, `createdAt` TEXT, `updatedAt` TEXT, `publicReactions` INTEGER, `userId` INTEGER NOT NULL, PRIMARY KEY(`userId`), FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followersCount",
+            "columnName": "followersCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followingCount",
+            "columnName": "followingCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hostLower",
+            "columnName": "hostLower",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesCount",
+            "columnName": "notesCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bannerUrl",
+            "columnName": "bannerUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isFollowing",
+            "columnName": "isFollowing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFollower",
+            "columnName": "isFollower",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBlocking",
+            "columnName": "isBlocking",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMuting",
+            "columnName": "isMuting",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasPendingFollowRequestFromYou",
+            "columnName": "hasPendingFollowRequestFromYou",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasPendingFollowRequestToYou",
+            "columnName": "hasPendingFollowRequestToYou",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLocked",
+            "columnName": "isLocked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "birthday",
+            "columnName": "birthday",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "publicReactions",
+            "columnName": "publicReactions",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_detailed_state_userId",
+            "unique": true,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_detailed_state_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_emoji",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `url` TEXT, `uri` TEXT, `userId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_emoji_name_userId",
+            "unique": true,
+            "columnNames": [
+              "name",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_emoji_name_userId` ON `${TABLE_NAME}` (`name`, `userId`)"
+          },
+          {
+            "name": "index_user_emoji_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_emoji_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pinned_note_id",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`noteId` TEXT NOT NULL, `userId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pinned_note_id_noteId_userId",
+            "unique": true,
+            "columnNames": [
+              "noteId",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_pinned_note_id_noteId_userId` ON `${TABLE_NAME}` (`noteId`, `userId`)"
+          },
+          {
+            "name": "index_pinned_note_id_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pinned_note_id_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_instance_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`faviconUrl` TEXT, `iconUrl` TEXT, `name` TEXT, `softwareName` TEXT, `softwareVersion` TEXT, `themeColor` TEXT, `userId` INTEGER NOT NULL, PRIMARY KEY(`userId`), FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "faviconUrl",
+            "columnName": "faviconUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "iconUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "softwareName",
+            "columnName": "softwareName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "softwareVersion",
+            "columnName": "softwareVersion",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_instance_info_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_instance_info_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_profile_field",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `value` TEXT NOT NULL, `userId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_profile_field_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_profile_field_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "word_filter_condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "word_filter_regex_condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pattern` TEXT NOT NULL, `parentId` INTEGER NOT NULL, PRIMARY KEY(`parentId`), FOREIGN KEY(`parentId`) REFERENCES `word_filter_condition`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "pattern",
+            "columnName": "pattern",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "parentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_word_filter_regex_condition_parentId",
+            "unique": false,
+            "columnNames": [
+              "parentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_word_filter_regex_condition_parentId` ON `${TABLE_NAME}` (`parentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "word_filter_condition",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "parentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "word_filter_word_condition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`word` TEXT NOT NULL, `parentId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`parentId`) REFERENCES `word_filter_condition`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "word",
+            "columnName": "word",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_word_filter_word_condition_parentId",
+            "unique": false,
+            "columnNames": [
+              "parentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_word_filter_word_condition_parentId` ON `${TABLE_NAME}` (`parentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "word_filter_condition",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "parentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `name` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_list_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_list_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_user_list_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_list_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_user_list_accountId_serverId",
+            "unique": true,
+            "columnNames": [
+              "accountId",
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_list_accountId_serverId` ON `${TABLE_NAME}` (`accountId`, `serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_list_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userListId` INTEGER NOT NULL, `userId` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`userListId`) REFERENCES `user_list`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userListId",
+            "columnName": "userListId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_list_member_userListId",
+            "unique": false,
+            "columnNames": [
+              "userListId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_list_member_userListId` ON `${TABLE_NAME}` (`userListId`)"
+          },
+          {
+            "name": "index_user_list_member_userListId_userId",
+            "unique": true,
+            "columnNames": [
+              "userListId",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_list_member_userListId_userId` ON `${TABLE_NAME}` (`userListId`, `userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user_list",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userListId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "instance_info_v1_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `host` TEXT NOT NULL, `name` TEXT, `description` TEXT, `clientMaxBodyByteSize` INTEGER, `iconUrl` TEXT, `themeColor` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "clientMaxBodyByteSize",
+            "columnName": "clientMaxBodyByteSize",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "iconUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_instance_info_v1_table_host",
+            "unique": true,
+            "columnNames": [
+              "host"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_instance_info_v1_table_host` ON `${TABLE_NAME}` (`host`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "search_histories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `keyword` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`accountId`) REFERENCES `account_table`(`accountId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keyword",
+            "columnName": "keyword",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_histories_keyword_accountId",
+            "unique": true,
+            "columnNames": [
+              "keyword",
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_histories_keyword_accountId` ON `${TABLE_NAME}` (`keyword`, `accountId`)"
+          },
+          {
+            "name": "index_search_histories_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_histories_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "accountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_info_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`description` TEXT, `followersCount` INTEGER, `followingCount` INTEGER, `hostLower` TEXT, `notesCount` INTEGER, `bannerUrl` TEXT, `url` TEXT, `isLocked` INTEGER NOT NULL, `birthday` TEXT, `createdAt` TEXT, `updatedAt` TEXT, `publicReactions` INTEGER, `userId` INTEGER NOT NULL, PRIMARY KEY(`userId`), FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followersCount",
+            "columnName": "followersCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "followingCount",
+            "columnName": "followingCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hostLower",
+            "columnName": "hostLower",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notesCount",
+            "columnName": "notesCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "bannerUrl",
+            "columnName": "bannerUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isLocked",
+            "columnName": "isLocked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "birthday",
+            "columnName": "birthday",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "publicReactions",
+            "columnName": "publicReactions",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_info_state_userId",
+            "unique": true,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_info_state_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user_related_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`isFollowing` INTEGER NOT NULL, `isFollower` INTEGER NOT NULL, `isBlocking` INTEGER NOT NULL, `isMuting` INTEGER NOT NULL, `hasPendingFollowRequestFromYou` INTEGER NOT NULL, `hasPendingFollowRequestToYou` INTEGER NOT NULL, `userId` INTEGER NOT NULL, PRIMARY KEY(`userId`), FOREIGN KEY(`userId`) REFERENCES `user`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "isFollowing",
+            "columnName": "isFollowing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFollower",
+            "columnName": "isFollower",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBlocking",
+            "columnName": "isBlocking",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMuting",
+            "columnName": "isMuting",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasPendingFollowRequestFromYou",
+            "columnName": "hasPendingFollowRequestFromYou",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasPendingFollowRequestToYou",
+            "columnName": "hasPendingFollowRequestToYou",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_user_related_state_userId",
+            "unique": true,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_user_related_state_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "user",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "nodeinfo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`host` TEXT NOT NULL, `nodeInfoVersion` TEXT NOT NULL, `name` TEXT NOT NULL, `version` TEXT NOT NULL, PRIMARY KEY(`host`))",
+        "fields": [
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nodeInfoVersion",
+            "columnName": "nodeInfoVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "host"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "mastodon_instance_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uri` TEXT NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `email` TEXT NOT NULL, `version` TEXT NOT NULL, `urls_streamingApi` TEXT, `configuration_statuses_maxCharacters` INTEGER, `configuration_statuses_maxMediaAttachments` INTEGER, `configuration_polls_maxOptions` INTEGER, `configuration_polls_maxCharactersPerOption` INTEGER, `configuration_polls_minExpiration` INTEGER, `configuration_polls_maxExpiration` INTEGER, PRIMARY KEY(`uri`))",
+        "fields": [
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "urls.streamingApi",
+            "columnName": "urls_streamingApi",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "configuration.statuses.maxCharacters",
+            "columnName": "configuration_statuses_maxCharacters",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "configuration.statuses.maxMediaAttachments",
+            "columnName": "configuration_statuses_maxMediaAttachments",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "configuration.polls.maxOptions",
+            "columnName": "configuration_polls_maxOptions",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "configuration.polls.maxCharactersPerOption",
+            "columnName": "configuration_polls_maxCharactersPerOption",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "configuration.polls.minExpiration",
+            "columnName": "configuration_polls_minExpiration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "configuration.polls.maxExpiration",
+            "columnName": "configuration_polls_maxExpiration",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uri"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "custom_emojis",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT, `name` TEXT NOT NULL, `emojiHost` TEXT NOT NULL, `url` TEXT, `uri` TEXT, `type` TEXT, `category` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emojiHost",
+            "columnName": "emojiHost",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_custom_emojis_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_custom_emojis_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_custom_emojis_emojiHost",
+            "unique": false,
+            "columnNames": [
+              "emojiHost"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_custom_emojis_emojiHost` ON `${TABLE_NAME}` (`emojiHost`)"
+          },
+          {
+            "name": "index_custom_emojis_category",
+            "unique": false,
+            "columnNames": [
+              "category"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_custom_emojis_category` ON `${TABLE_NAME}` (`category`)"
+          },
+          {
+            "name": "index_custom_emojis_emojiHost_name",
+            "unique": true,
+            "columnNames": [
+              "emojiHost",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_custom_emojis_emojiHost_name` ON `${TABLE_NAME}` (`emojiHost`, `name`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "custom_emoji_aliases",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`emojiId` INTEGER NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`emojiId`, `value`), FOREIGN KEY(`emojiId`) REFERENCES `custom_emojis`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "emojiId",
+            "columnName": "emojiId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "emojiId",
+            "value"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_custom_emoji_aliases_emojiId_value",
+            "unique": false,
+            "columnNames": [
+              "emojiId",
+              "value"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_custom_emoji_aliases_emojiId_value` ON `${TABLE_NAME}` (`emojiId`, `value`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "custom_emojis",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "emojiId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "notification_json_cache_v1",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `notificationId` TEXT NOT NULL, `json` TEXT NOT NULL, `key` TEXT, `weight` INTEGER NOT NULL, PRIMARY KEY(`accountId`, `notificationId`))",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationId",
+            "columnName": "notificationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "weight",
+            "columnName": "weight",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId",
+            "notificationId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_notification_json_cache_v1_key",
+            "unique": false,
+            "columnNames": [
+              "key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_notification_json_cache_v1_key` ON `${TABLE_NAME}` (`key`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "mastodon_word_filters_v1",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `filterId` TEXT NOT NULL, `phrase` TEXT NOT NULL, `wholeWord` INTEGER NOT NULL, `expiresAt` TEXT, `irreversible` INTEGER NOT NULL, `isContextHome` INTEGER NOT NULL, `isContextNotifications` INTEGER NOT NULL, `isContextPublic` INTEGER NOT NULL, `isContextThread` INTEGER NOT NULL, `isContextAccount` INTEGER NOT NULL, PRIMARY KEY(`accountId`, `filterId`))",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filterId",
+            "columnName": "filterId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phrase",
+            "columnName": "phrase",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wholeWord",
+            "columnName": "wholeWord",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "irreversible",
+            "columnName": "irreversible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isContextHome",
+            "columnName": "isContextHome",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isContextNotifications",
+            "columnName": "isContextNotifications",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isContextPublic",
+            "columnName": "isContextPublic",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isContextThread",
+            "columnName": "isContextThread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isContextAccount",
+            "columnName": "isContextAccount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountId",
+            "filterId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "renote_mute_users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `userId` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `postedAt` TEXT, PRIMARY KEY(`userId`, `accountId`))",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "postedAt",
+            "columnName": "postedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "accountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_renote_mute_users_postedAt",
+            "unique": false,
+            "columnNames": [
+              "postedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_renote_mute_users_postedAt` ON `${TABLE_NAME}` (`postedAt`)"
+          },
+          {
+            "name": "index_renote_mute_users_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_renote_mute_users_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "mastodon_instance_fedibird_capabilities",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`type` TEXT NOT NULL, `uri` TEXT NOT NULL, PRIMARY KEY(`uri`, `type`), FOREIGN KEY(`uri`) REFERENCES `mastodon_instance_info`(`uri`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uri",
+            "type"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_mastodon_instance_fedibird_capabilities_uri",
+            "unique": false,
+            "columnNames": [
+              "uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_mastodon_instance_fedibird_capabilities_uri` ON `${TABLE_NAME}` (`uri`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "mastodon_instance_info",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "uri"
+            ],
+            "referencedColumns": [
+              "uri"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [
+      {
+        "viewName": "user_view",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS select user.*, nicknames.nickname from user left join nicknames on user.userName = nicknames.username and user.host = nicknames.host"
+      },
+      {
+        "viewName": "group_member_view",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS select m.groupId, u.id as userId, u.avatarUrl, u.serverId from group_member_v1 as m \n            inner join group_v1 as g\n            inner join user as u\n            on m.groupId = g.id\n                and m.userId = u.serverId\n                and g.accountId = u.accountId"
+      },
+      {
+        "viewName": "user_list_member_view",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS select m.userListId, u.id as userId, u.avatarUrl, u.serverId from user_list_member as m \n            inner join user_list as ul\n            inner join user as u\n            on m.userListId = ul.id\n                and m.userId = u.serverId\n                and ul.accountId = u.accountId"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '81d289dc1714f5ef5d109132333e0879')"
+    ]
+  }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/TootDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/TootDTOEntityConverter.kt
@@ -1,0 +1,91 @@
+package net.pantasystem.milktea.data.converters
+
+import net.pantasystem.milktea.api.mastodon.status.TootStatusDTO
+import net.pantasystem.milktea.data.infrastructure.toPoll
+import net.pantasystem.milktea.model.account.Account
+import net.pantasystem.milktea.model.drive.FileProperty
+import net.pantasystem.milktea.model.instance.MastodonInstanceInfoRepository
+import net.pantasystem.milktea.model.nodeinfo.NodeInfo
+import net.pantasystem.milktea.model.notes.Note
+import net.pantasystem.milktea.model.notes.reaction.ReactionCount
+import net.pantasystem.milktea.model.user.User
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TootDTOEntityConverter @Inject constructor(
+    private val instanceInfoRepository: MastodonInstanceInfoRepository
+) {
+
+    suspend fun convert(statusDTO: TootStatusDTO, account: Account, nodeInfo: NodeInfo?): Note {
+        val isReactionAvailable = (instanceInfoRepository.find(account.normalizedInstanceDomain)
+            .getOrNull()?.isReactionAvailable
+            ?: false) || nodeInfo?.type is NodeInfo.SoftwareType.Mastodon.Fedibird
+        return with(statusDTO) {
+            Note(
+                id = Note.Id(account.accountId, id),
+                text = this.content,
+                cw = this.spoilerText.takeIf {
+                    it.isNotBlank()
+                },
+                userId = User.Id(account.accountId, this.account.id),
+                replyId = this.inReplyToId?.let { Note.Id(account.accountId, this.inReplyToId!!) },
+                renoteId = this.quote?.id?.let { Note.Id(account.accountId, it) }
+                    ?: this.reblog?.id?.let { Note.Id(account.accountId, this.reblog?.id!!) },
+                viaMobile = null,
+                visibility = net.pantasystem.milktea.data.infrastructure.Visibility(
+                    visibility,
+                    circleId,
+                    visibilityEx
+                ),
+                localOnly = null,
+                emojis = emojis.map {
+                    it.toEmoji()
+                } + (emojiReactions?.mapNotNull {
+                    it.getEmoji()
+                } ?: emptyList()),
+                app = null,
+                reactionCounts = emojiReactions?.map {
+                    ReactionCount(
+                        reaction = it.reaction,
+                        count = it.count
+                    )
+                } ?: emptyList(),
+                repliesCount = repliesCount,
+                renoteCount = reblogsCount,
+                uri = this.uri,
+                url = this.url,
+                visibleUserIds = emptyList(),
+                myReaction = emojiReactions?.firstOrNull {
+                    it.myReaction() != null
+                }?.myReaction(),
+                channelId = null,
+                createdAt = createdAt,
+                fileIds = mediaAttachments.map {
+                    FileProperty.Id(account.accountId, it.id)
+                },
+                poll = poll.toPoll(),
+                type = Note.Type.Mastodon(
+                    favorited = favourited,
+                    reblogged = reblogged,
+                    bookmarked = bookmarked,
+                    muted = muted,
+                    favoriteCount = favouritesCount,
+                    tags = tags?.map {
+                        it.toModel()
+                    } ?: emptyList(),
+                    mentions = mentions?.map {
+                        it.toModel()
+                    } ?: emptyList(),
+                    isFedibirdQuote = quote != null,
+                    pollId = poll?.id,
+                    isSensitive = sensitive,
+                    pureText = text,
+                    isReactionAvailable = isReactionAvailable
+                ),
+                nodeInfo = nodeInfo,
+            )
+        }
+
+    }
+}

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/DataBase.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/DataBase.kt
@@ -112,8 +112,10 @@ import net.pantasystem.milktea.data.infrastructure.user.renote.mute.db.RenoteMut
         MastodonWordFilterRecord::class,
 
         RenoteMuteRecord::class,
+
+        FedibirdCapabilitiesRecord::class,
     ],
-    version = 41,
+    version = 42,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 11, to = 12),
@@ -146,6 +148,7 @@ import net.pantasystem.milktea.data.infrastructure.user.renote.mute.db.RenoteMut
         AutoMigration(from = 38, to = 39),
         AutoMigration(from = 39, to = 40),
         AutoMigration(from = 40, to = 41),
+        AutoMigration(from = 41, to = 42),
     ],
     views = [UserView::class, GroupMemberView::class, UserListMemberView::class]
 )

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
@@ -7,6 +7,7 @@ import net.pantasystem.milktea.api.mastodon.notification.MstNotificationDTO
 import net.pantasystem.milktea.api.mastodon.poll.TootPollDTO
 import net.pantasystem.milktea.api.mastodon.status.StatusVisibilityType
 import net.pantasystem.milktea.api.mastodon.status.TootStatusDTO
+import net.pantasystem.milktea.data.converters.TootDTOEntityConverter
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.drive.FileProperty
 import net.pantasystem.milktea.model.instance.MastodonInstanceInfo
@@ -14,7 +15,6 @@ import net.pantasystem.milktea.model.nodeinfo.NodeInfo
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.Visibility
 import net.pantasystem.milktea.model.notes.poll.Poll
-import net.pantasystem.milktea.model.notes.reaction.ReactionCount
 import net.pantasystem.milktea.model.notification.*
 import net.pantasystem.milktea.model.user.User
 
@@ -54,88 +54,31 @@ fun TootMediaAttachment.toFileProperty(account: Account, isSensitive: Boolean): 
     )
 }
 
-fun TootStatusDTO.toNote(account: Account, nodeInfo: NodeInfo?): Note {
-    return Note(
-        id = Note.Id(account.accountId, id),
-        text = this.content,
-        cw = this.spoilerText.takeIf {
-            it.isNotBlank()
-        },
-        userId = User.Id(account.accountId, this.account.id),
-        replyId = this.inReplyToId?.let { Note.Id(account.accountId, this.inReplyToId!!) },
-        renoteId = this.quote?.id?.let { Note.Id(account.accountId, it) }
-            ?: this.reblog?.id?.let { Note.Id(account.accountId, this.reblog?.id!!) },
-        viaMobile = null,
-        visibility = Visibility(visibility, circleId, visibilityEx),
-        localOnly = null,
-        emojis = emojis.map {
-            it.toEmoji()
-        } + (emojiReactions?.mapNotNull {
-            it.getEmoji()
-        } ?: emptyList()),
-        app = null,
-        reactionCounts = emojiReactions?.map {
-            ReactionCount(
-                reaction = it.reaction,
-                count = it.count
-            )
-        } ?: emptyList(),
-        repliesCount = repliesCount,
-        renoteCount = reblogsCount,
-        uri = this.uri,
-        url = this.url,
-        visibleUserIds = emptyList(),
-        myReaction = emojiReactions?.firstOrNull {
-            it.myReaction() != null
-        }?.myReaction(),
-        channelId = null,
-        createdAt = createdAt,
-        fileIds = mediaAttachments.map {
-            FileProperty.Id(account.accountId, it.id)
-        },
-        poll = poll.toPoll(),
-        type = Note.Type.Mastodon(
-            favorited = favourited,
-            reblogged = reblogged,
-            bookmarked = bookmarked,
-            muted = muted,
-            favoriteCount = favouritesCount,
-            tags = tags?.map {
-                it.toModel()
-            } ?: emptyList(),
-            mentions = mentions?.map {
-                it.toModel()
-            } ?: emptyList(),
-            isFedibirdQuote = quote != null,
-            pollId = poll?.id,
-            isSensitive = sensitive,
-            pureText = text
-        ),
-        nodeInfo = nodeInfo,
-    )
-}
 
-fun TootStatusDTO.toEntities(account: Account, nodeInfo: NodeInfo?): NoteRelationEntities {
+suspend fun TootStatusDTO.toEntities(
+    converter: TootDTOEntityConverter,
+    account: Account, nodeInfo: NodeInfo?): NoteRelationEntities {
     val users = mutableListOf<User>()
     val notes = mutableListOf<Note>()
     val files = mutableListOf<FileProperty>()
-    pickEntities(account, notes, users, files, nodeInfo)
+    pickEntities(converter, account, notes, users, files, nodeInfo)
     return NoteRelationEntities(
-        note = toNote(account, nodeInfo),
+        note = converter.convert(this, account, nodeInfo),
         files = files,
         users = users,
         notes = notes,
     )
 }
 
-fun TootStatusDTO.pickEntities(
+suspend fun TootStatusDTO.pickEntities(
+    converter: TootDTOEntityConverter,
     account: Account,
     notes: MutableList<Note>,
     users: MutableList<User>,
     files: MutableList<FileProperty>,
     nodeInfo: NodeInfo?
 ) {
-    val (note, user) = toNote(account, nodeInfo) to this.account.toModel(account)
+    val (note, user) = converter.convert(this, account, nodeInfo) to this.account.toModel(account)
     notes.add(note)
     users.add(user)
     files.addAll(
@@ -143,8 +86,8 @@ fun TootStatusDTO.pickEntities(
             it.toFileProperty(account, sensitive)
         }
     )
-    this.reblog?.pickEntities(account, notes, users, files, nodeInfo)
-    this.quote?.pickEntities(account, notes, users, files, nodeInfo)
+    this.reblog?.pickEntities(converter, account, notes, users, files, nodeInfo)
+    this.quote?.pickEntities(converter, account, notes, users, files, nodeInfo)
 }
 
 fun MastodonAccountRelationshipDTO.toUserRelated(): User.Related {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/TootEntityConverters.kt
@@ -289,6 +289,7 @@ fun Instance.toModel(): MastodonInstanceInfo {
                     )
                 }
             )
-        }
+        },
+        fedibirdCapabilities = fedibirdCapabilities,
     )
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/MastodonInstanceInfoRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/MastodonInstanceInfoRepositoryImpl.kt
@@ -9,10 +9,7 @@ import kotlinx.coroutines.withContext
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common_android.hilt.IODispatcher
 import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
-import net.pantasystem.milktea.data.infrastructure.instance.db.MastodonInstanceInfoDAO
-import net.pantasystem.milktea.data.infrastructure.instance.db.MastodonInstanceInfoRecord
-import net.pantasystem.milktea.data.infrastructure.instance.db.from
-import net.pantasystem.milktea.data.infrastructure.instance.db.toModel
+import net.pantasystem.milktea.data.infrastructure.instance.db.*
 import net.pantasystem.milktea.data.infrastructure.toModel
 import net.pantasystem.milktea.model.instance.MastodonInstanceInfo
 import net.pantasystem.milktea.model.instance.MastodonInstanceInfoRepository
@@ -77,8 +74,23 @@ class MastodonInstanceInfoRepositoryImpl @Inject constructor(
         val exists = mastodonInstanceInfoDAO.findBy(instanceInfo.uri)
         if (exists == null) {
             mastodonInstanceInfoDAO.insert(MastodonInstanceInfoRecord.from(instanceInfo))
+            instanceInfo.fedibirdCapabilities?.let { capabilities ->
+                mastodonInstanceInfoDAO.insertFedibirdCapabilities(
+                    capabilities.map {
+                        FedibirdCapabilitiesRecord(it, instanceInfo.uri)
+                    }
+                )
+            }
         } else {
             mastodonInstanceInfoDAO.update(MastodonInstanceInfoRecord.from(instanceInfo))
+            mastodonInstanceInfoDAO.clearFedibirdCapabilities(instanceInfo.uri)
+            instanceInfo.fedibirdCapabilities?.let { capabilities ->
+                mastodonInstanceInfoDAO.insertFedibirdCapabilities(
+                    capabilities.map {
+                        FedibirdCapabilitiesRecord(it, instanceInfo.uri)
+                    }
+                )
+            }
         }
     }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/db/MastodonInstanceInfoDAO.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/instance/db/MastodonInstanceInfoDAO.kt
@@ -18,11 +18,21 @@ abstract class MastodonInstanceInfoDAO {
     @Query("""
         select * from mastodon_instance_info where uri = :uri
     """)
-    abstract suspend fun findBy(uri: String): MastodonInstanceInfoRecord?
+    @Transaction
+    abstract suspend fun findBy(uri: String): MastodonInstanceInfoRelated?
 
     @Query("""
         select * from mastodon_instance_info where uri = :uri
     """)
-    abstract fun observeBy(uri: String): Flow<MastodonInstanceInfoRecord?>
+    @Transaction
+    abstract fun observeBy(uri: String): Flow<MastodonInstanceInfoRelated?>
+
+    @Query("""
+        delete from mastodon_instance_fedibird_capabilities where uri = :uri
+    """)
+    abstract fun clearFedibirdCapabilities(uri: String)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    abstract fun insertFedibirdCapabilities(list: List<FedibirdCapabilitiesRecord>): List<Long>
 
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteDataSourceAdder.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteDataSourceAdder.kt
@@ -4,6 +4,7 @@ import net.pantasystem.milktea.api.mastodon.status.TootStatusDTO
 import net.pantasystem.milktea.api.misskey.notes.NoteDTO
 import net.pantasystem.milktea.data.converters.FilePropertyDTOEntityConverter
 import net.pantasystem.milktea.data.converters.NoteDTOEntityConverter
+import net.pantasystem.milktea.data.converters.TootDTOEntityConverter
 import net.pantasystem.milktea.data.converters.UserDTOEntityConverter
 import net.pantasystem.milktea.data.infrastructure.NoteRelationEntities
 import net.pantasystem.milktea.data.infrastructure.toEntities
@@ -29,6 +30,7 @@ class NoteDataSourceAdder @Inject constructor(
     private val userDTOEntityConverter: UserDTOEntityConverter,
     private val noteDTOEntityConverter: NoteDTOEntityConverter,
     private val filePropertyDTOEntityConverter: FilePropertyDTOEntityConverter,
+    private val tootDTOEntityConverter: TootDTOEntityConverter,
 ) {
 
 
@@ -72,7 +74,7 @@ class NoteDataSourceAdder @Inject constructor(
 
     suspend fun addTootStatusDtoIntoDataSource(account: Account, status: TootStatusDTO, skipExists: Boolean = false): Note {
         val nodeInfo = nodeInfoRepository.find(account.getHost()).getOrNull()
-        val entities = status.toEntities(account, nodeInfo)
+        val entities = status.toEntities(tootDTOEntityConverter, account, nodeInfo)
         if (skipExists) {
             userDataSource.addAll(
                 entities.users.filterNot {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/ReactionRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/ReactionRepositoryImpl.kt
@@ -58,7 +58,9 @@ class ReactionRepositoryImpl @Inject constructor(
                             if (nodeInfoRepository.find(account.getHost())
                                     .getOrThrow().type !is NodeInfo.SoftwareType.Mastodon.Fedibird
                             ) {
-                                throw IllegalArgumentException("Mastodon is not support reaction, host:${account.getHost()}, username:${account.userName}")
+                                if (!note.isSupportEmojiReaction) {
+                                    throw IllegalArgumentException("Mastodon is not support reaction, host:${account.getHost()}, username:${account.userName}")
+                                }
                             }
                             val body = mastodonAPIProvider.get(account).reaction(
                                 createReaction.noteId.noteId,
@@ -98,7 +100,9 @@ class ReactionRepositoryImpl @Inject constructor(
                     if (nodeInfoRepository.find(account.getHost())
                             .getOrThrow().type !is NodeInfo.SoftwareType.Mastodon.Fedibird
                     ) {
-                        return@withContext false
+                        if (!note.isSupportEmojiReaction) {
+                            return@withContext false
+                        }
                     }
                     val res = mastodonAPIProvider.get(account)
                         .unreaction(noteId.noteId)

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/instance/MastodonInstanceInfo.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/instance/MastodonInstanceInfo.kt
@@ -9,6 +9,7 @@ data class MastodonInstanceInfo(
     val version: String,
     val urls: Urls,
     val configuration: Configuration?,
+    val fedibirdCapabilities: List<String>?,
 ) {
     companion object;
 
@@ -34,4 +35,9 @@ data class MastodonInstanceInfo(
     data class Urls(
         val streamingApi: String?
     )
+
+
+    // リアクションを使用可能か？
+    val isReactionAvailable: Boolean
+        get() = fedibirdCapabilities?.contains("emoji_reactions") ?: false
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/instance/MastodonInstanceInfo.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/instance/MastodonInstanceInfo.kt
@@ -39,5 +39,5 @@ data class MastodonInstanceInfo(
 
     // リアクションを使用可能か？
     val isReactionAvailable: Boolean
-        get() = fedibirdCapabilities?.contains("emoji_reactions") ?: false
+        get() = fedibirdCapabilities?.contains("emoji_reaction") ?: false
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
@@ -76,6 +76,7 @@ data class Note(
             val pollId: String?,
             val isSensitive: Boolean?,
             val pureText: String?,
+            val isReactionAvailable: Boolean
             ) : Type {
             data class Tag(
                 val name: String,
@@ -98,7 +99,7 @@ data class Note(
     val isMastodon: Boolean = type is Type.Mastodon
     val isMisskey: Boolean = type is Type.Misskey
 
-    val isSupportEmojiReaction: Boolean = type is Type.Misskey || nodeInfo?.type is NodeInfo.SoftwareType.Mastodon.Fedibird
+    val isSupportEmojiReaction: Boolean = type is Type.Misskey || (type is Type.Mastodon && type.isReactionAvailable)
 
     val isAcceptingOnlyLikeReaction: Boolean = type is Type.Misskey && type.isAcceptingOnlyLikeReaction
 

--- a/modules/model/src/test/java/net/pantasystem/milktea/model/notes/NoteTest.kt
+++ b/modules/model/src/test/java/net/pantasystem/milktea/model/notes/NoteTest.kt
@@ -140,7 +140,8 @@ class NoteTest {
                 isFedibirdQuote = true,
                 pollId = null,
                 isSensitive = null,
-                pureText = null
+                pureText = null,
+                isReactionAvailable = true,
             )
         )
         assertTrue(note.isQuote())
@@ -161,7 +162,8 @@ class NoteTest {
                 isFedibirdQuote = false,
                 pollId = null,
                 isSensitive = null,
-                pureText = null
+                pureText = null,
+                isReactionAvailable = true,
             )
         )
         assertFalse(note.isQuote())
@@ -182,7 +184,8 @@ class NoteTest {
                 isFedibirdQuote = false,
                 pollId = null,
                 isSensitive = null,
-                pureText = null
+                pureText = null,
+                isReactionAvailable = true,
             ),
             renoteId = Note.Id(0L, "id")
         )
@@ -206,6 +209,7 @@ class NoteTest {
                 pollId = null,
                 isSensitive = null,
                 pureText = null,
+                isReactionAvailable = true,
             )
         )
         assertFalse(note.hasContent())


### PR DESCRIPTION
## やったこと
Mastodon時のリアクションの可否の判定にsoftware.name=fedibirdの判定を行うのではなく
fedibird_capabilitiesを使用して判定を行うようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1546 

