### PR TITLE
AccountのインスタンスのURL取得にURLクラスを用いらないようにした

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/ChangeNavMenuVisibilityFromAPIVersion.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/ChangeNavMenuVisibilityFromAPIVersion.kt
@@ -11,7 +11,7 @@ internal class ChangeNavMenuVisibilityFromAPIVersion(
     private val featureEnables: FeatureEnables,
 ) {
     suspend operator fun invoke(currentAccount: Account) {
-        val enableFeatures = featureEnables.enableFeatures(currentAccount.normalizedInstanceDomain)
+        val enableFeatures = featureEnables.enableFeatures(currentAccount.normalizedInstanceUri)
         navView.menu.also { menu ->
             menu.findItem(R.id.nav_antenna).isVisible = enableFeatures.contains(FeatureType.Antenna)
             menu.findItem(R.id.nav_channel).isVisible = enableFeatures.contains(FeatureType.Channel)

--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/account/AccountTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/account/AccountTest.kt
@@ -246,6 +246,20 @@ class AccountTest {
     }
 
     @Test
+    fun getNormalizedInstanceDomain_GiveAcctAndIllegalHost() {
+        val account = Account(
+            instanceDomain = "https://@Panta@MisSkey.io",
+            userName = "",
+            token = "",
+            remoteId = "remoteId",
+            instanceType = Account.InstanceType.MISSKEY
+        )
+        Assertions.assertEquals("https://misskey.io", account.normalizedInstanceUri)
+    }
+
+
+
+    @Test
     fun getNormalizedInstanceDomain_GiveAcctCase2() {
         val account = Account(
             instanceDomain = "https://@artyom24@misskey.io",

--- a/app/src/test/java/jp/panta/misskeyandroidclient/model/account/AccountTest.kt
+++ b/app/src/test/java/jp/panta/misskeyandroidclient/model/account/AccountTest.kt
@@ -54,7 +54,7 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("https://example.com", account.normalizedInstanceDomain)
+        Assertions.assertEquals("https://example.com", account.normalizedInstanceUri)
     }
 
     @Test
@@ -66,7 +66,7 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("https://example.com", account.normalizedInstanceDomain)
+        Assertions.assertEquals("https://example.com", account.normalizedInstanceUri)
     }
 
     @Test
@@ -78,7 +78,7 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("https://example.com:8080", account.normalizedInstanceDomain)
+        Assertions.assertEquals("https://example.com:8080", account.normalizedInstanceUri)
     }
 
     @Test
@@ -90,7 +90,7 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("https://example.com", account.normalizedInstanceDomain)
+        Assertions.assertEquals("https://example.com", account.normalizedInstanceUri)
     }
 
     @Test
@@ -102,7 +102,7 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("https://test-example.com", account.normalizedInstanceDomain)
+        Assertions.assertEquals("https://test-example.com", account.normalizedInstanceUri)
     }
 
     @Test
@@ -114,7 +114,7 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("https://test_example.com", account.normalizedInstanceDomain)
+        Assertions.assertEquals("https://test_example.com", account.normalizedInstanceUri)
     }
 
     @Test
@@ -126,7 +126,7 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("https://test_example.com", account.normalizedInstanceDomain)
+        Assertions.assertEquals("https://test_example.com", account.normalizedInstanceUri)
     }
 
     @Test
@@ -138,8 +138,21 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("https://www.example.com", account.normalizedInstanceDomain)
+        Assertions.assertEquals("https://www.example.com", account.normalizedInstanceUri)
     }
+
+    @Test
+    fun getNormalizedInstanceDomain_GiveSchemaLess2() {
+        val account = Account(
+            instanceDomain = "//www.example.com ",
+            userName = "",
+            token = "",
+            remoteId = "remoteId",
+            instanceType = Account.InstanceType.MISSKEY
+        )
+        Assertions.assertEquals("https://www.example.com", account.normalizedInstanceUri)
+    }
+
 
     @Test
     fun getNormalizedInstanceDomain_GiveIllegalFormat() {
@@ -150,7 +163,7 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("http://", account.normalizedInstanceDomain)
+        Assertions.assertEquals("http://", account.normalizedInstanceUri)
     }
 
     @Test
@@ -162,7 +175,7 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("http://192.168.0.1", account.normalizedInstanceDomain)
+        Assertions.assertEquals("http://192.168.0.1", account.normalizedInstanceUri)
     }
 
     @Test
@@ -176,7 +189,7 @@ class AccountTest {
         )
         Assertions.assertEquals(
             "http://[2001:db8:85a3::8a2e:370:7334]",
-            account.normalizedInstanceDomain
+            account.normalizedInstanceUri
         )
     }
 
@@ -191,7 +204,7 @@ class AccountTest {
         )
         Assertions.assertEquals(
             "ftp://[2001:db8:85a3::8a2e:370:7334]",
-            account.normalizedInstanceDomain
+            account.normalizedInstanceUri
         )
 
     }
@@ -205,7 +218,7 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("https://みすきー.com:8080", account.normalizedInstanceDomain)
+        Assertions.assertEquals("https://みすきー.com:8080", account.normalizedInstanceUri)
     }
 
     @Test
@@ -217,7 +230,7 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("https://みすきー.com:8080", account.normalizedInstanceDomain)
+        Assertions.assertEquals("https://みすきー.com:8080", account.normalizedInstanceUri)
     }
 
     @Test
@@ -229,7 +242,7 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("https://misskey.io", account.normalizedInstanceDomain)
+        Assertions.assertEquals("https://misskey.io", account.normalizedInstanceUri)
     }
 
     @Test
@@ -241,7 +254,7 @@ class AccountTest {
             remoteId = "remoteId",
             instanceType = Account.InstanceType.MISSKEY
         )
-        Assertions.assertEquals("https://misskey.io", account.normalizedInstanceDomain)
+        Assertions.assertEquals("https://misskey.io", account.normalizedInstanceUri)
     }
 
     @Test

--- a/modules/app_store/src/main/java/net/pantasystem/milktea/app_store/account/AccountStore.kt
+++ b/modules/app_store/src/main/java/net/pantasystem/milktea/app_store/account/AccountStore.kt
@@ -148,7 +148,7 @@ class AccountStore @Inject constructor(
             return
         }
         try {
-            val meta = metaRepository.find(account.normalizedInstanceDomain).getOrNull()
+            val meta = metaRepository.find(account.normalizedInstanceUri).getOrNull()
             val pages = makeDefaultPagesUseCase(account, meta)
             accountRepository.add(account.copy(pages = pages), true)
         } catch (e: Exception) {

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/ReactionViewHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/ReactionViewHelper.kt
@@ -72,8 +72,8 @@ object ReactionViewHelper {
         //Log.d("ReactionViewHelper", "reaction $reaction")
         if (reaction.startsWith(":") && reaction.endsWith(":")) {
             val account = accountStore.currentAccount
-            val emojis = if (account?.normalizedInstanceDomain != null) {
-                cache.get(account.normalizedInstanceDomain)?.emojis ?: emptyList()
+            val emojis = if (account?.normalizedInstanceUri != null) {
+                cache.get(account.normalizedInstanceUri)?.emojis ?: emptyList()
             } else {
                 emptyList()
             }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/viewmodel/AccountViewModel.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/viewmodel/AccountViewModel.kt
@@ -50,7 +50,7 @@ class AccountViewModel @Inject constructor(
 
     private val metaList = accountStore.observeAccounts.flatMapLatest { accounts ->
         val flows = accounts.map {
-            instanceInfoService.observe(it.normalizedInstanceDomain).flowOn(Dispatchers.IO)
+            instanceInfoService.observe(it.normalizedInstanceUri).flowOn(Dispatchers.IO)
         }
         combine(flows) {
             it.toList()
@@ -73,7 +73,7 @@ class AccountViewModel @Inject constructor(
             AccountInfo(
                 it,
                 userMap[it.accountId],
-                metaMap[it.normalizedInstanceDomain],
+                metaMap[it.normalizedInstanceUri],
                 current?.accountId == it.accountId
             )
         }
@@ -125,7 +125,7 @@ class AccountViewModel @Inject constructor(
     fun setSwitchTargetConnectionInstance(account: Account) {
         viewModelScope.launch {
             accountStore.setCurrent(account)
-            syncMetaExecutor(account.normalizedInstanceDomain)
+            syncMetaExecutor(account.normalizedInstanceUri)
         }
     }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/api/mastodon/MastodonAPIProvider.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/api/mastodon/MastodonAPIProvider.kt
@@ -35,7 +35,7 @@ class MastodonAPIProvider @Inject constructor(
         if (account.instanceType == Account.InstanceType.MISSKEY) {
             throw IllegalArgumentException("アカウント種別Misskeyは受け入れていません")
         }
-        return get(account.normalizedInstanceDomain, account.token)
+        return get(account.normalizedInstanceUri, account.token)
 
     }
 

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/api/misskey/MisskeyAPIProvider.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/api/misskey/MisskeyAPIProvider.kt
@@ -39,7 +39,7 @@ class MisskeyAPIProvider @Inject constructor(
     }
 
     fun get(account: Account, version: Version? = null): MisskeyAPI {
-        return get(account.normalizedInstanceDomain, version)
+        return get(account.normalizedInstanceUri, version)
     }
 
     fun applyVersion(baseURL: String, version: Version) {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/FilePropertyDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/FilePropertyDTOEntityConverter.kt
@@ -22,8 +22,8 @@ class FilePropertyDTOEntityConverter @Inject constructor() {
             folderId = filePropertyDTO.folderId,
             comment = filePropertyDTO.comment,
             isSensitive = filePropertyDTO.isSensitive ?: false,
-            url = filePropertyDTO.getUrl(account.normalizedInstanceDomain),
-            thumbnailUrl = filePropertyDTO.getThumbnailUrl(account.normalizedInstanceDomain),
+            url = filePropertyDTO.getUrl(account.normalizedInstanceUri),
+            thumbnailUrl = filePropertyDTO.getThumbnailUrl(account.normalizedInstanceUri),
             blurhash = filePropertyDTO.blurhash,
             properties = filePropertyDTO.properties?.let {
                 FileProperty.Properties(it.width, it.height)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/converters/TootDTOEntityConverter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/converters/TootDTOEntityConverter.kt
@@ -24,7 +24,7 @@ class TootDTOEntityConverter @Inject constructor(
     }
 
     suspend fun convert(statusDTO: TootStatusDTO, account: Account, nodeInfo: NodeInfo?): Note {
-        val isReactionAvailable = (instanceInfoRepository.find(account.normalizedInstanceDomain)
+        val isReactionAvailable = (instanceInfoRepository.find(account.normalizedInstanceUri)
             .onFailure {
                 logger.error("Failed to find instance info", it)
             }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/DriveFileRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/DriveFileRepositoryImpl.kt
@@ -35,7 +35,7 @@ class DriveFileRepositoryImpl @Inject constructor(
                 return@withContext file
             }
             val account = getAccount.get(id.accountId)
-            val api = misskeyAPIProvider.get(account.normalizedInstanceDomain)
+            val api = misskeyAPIProvider.get(account.normalizedInstanceUri)
             val response = api.showFile(ShowFile(fileId = id.fileId, i = account.token))
                 .throwIfHasError()
             val fp = filePropertyDTOEntityConverter.convert(response.body()!!, account)
@@ -47,7 +47,7 @@ class DriveFileRepositoryImpl @Inject constructor(
     override suspend fun toggleNsfw(id: FileProperty.Id) {
         withContext(ioDispatcher) {
             val account = getAccount.get(id.accountId)
-            val api = misskeyAPIProvider.get(account.normalizedInstanceDomain)
+            val api = misskeyAPIProvider.get(account.normalizedInstanceUri)
             val fileProperty = find(id)
             val result = api.updateFile(
                 UpdateFileDTO(

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/MastodonOkHttpFileUploader.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/MastodonOkHttpFileUploader.kt
@@ -43,7 +43,7 @@ class MastodonOkHttpFileUploader(
 
     private suspend fun upload(file: UploadSource.LocalFile): FileProperty {
         val okHttpClient =
-            mastodonAPIFactory.getOkHttp(account.normalizedInstanceDomain, account.token)
+            mastodonAPIFactory.getOkHttp(account.normalizedInstanceUri, account.token)
         val builder = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
             .addFormDataPart(
@@ -52,7 +52,7 @@ class MastodonOkHttpFileUploader(
                 UriRequestBody(Uri.parse(file.file.path), context)
             )
         val request = Request.Builder()
-            .url(URL("${account.normalizedInstanceDomain}/api/v2/media"))
+            .url(URL("${account.normalizedInstanceUri}/api/v2/media"))
             .post(builder.build()).build()
         val response = okHttpClient.newCall(request).execute()
         throwErrorFromStatusCode(response.code)
@@ -78,9 +78,9 @@ class MastodonOkHttpFileUploader(
 
     private fun checkUploadStatus(fileId: String): Int {
         val okHttpClient =
-            mastodonAPIFactory.getOkHttp(account.normalizedInstanceDomain, account.token)
+            mastodonAPIFactory.getOkHttp(account.normalizedInstanceUri, account.token)
         val request = Request.Builder()
-            .url(URL("${account.normalizedInstanceDomain}/api/v1/media/${fileId}"))
+            .url(URL("${account.normalizedInstanceUri}/api/v1/media/${fileId}"))
             .get()
             .build()
         return okHttpClient.newCall(

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/MisskeyOkHttpDriveFileUploader.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/MisskeyOkHttpDriveFileUploader.kt
@@ -84,7 +84,7 @@ class MisskeyOkHttpDriveFileUploader(
 
             val request =
                 Request.Builder()
-                    .url(URL("${account.normalizedInstanceDomain}/api/drive/files/create"))
+                    .url(URL("${account.normalizedInstanceUri}/api/drive/files/create"))
                     .post(requestBody).build()
             val response = client.newCall(request).execute()
             if (response.isSuccessful) {
@@ -147,7 +147,7 @@ class MisskeyOkHttpDriveFileUploader(
 
             val request =
                 Request.Builder()
-                    .url(URL("${account.normalizedInstanceDomain}/api/drive/files/create"))
+                    .url(URL("${account.normalizedInstanceUri}/api/drive/files/create"))
                     .post(requestBody).build()
             val response = client.newCall(request).execute()
             val code = response.code

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/file_paginator.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/file_paginator.kt
@@ -132,7 +132,7 @@ class FilePropertyPagingImpl(
 
     override suspend fun loadPrevious(): Result<List<FilePropertyDTO>> {
         return runCancellableCatching {
-            misskeyAPIProvider.get(getAccount.invoke().normalizedInstanceDomain).getFiles(
+            misskeyAPIProvider.get(getAccount.invoke().normalizedInstanceUri).getFiles(
                 RequestFile(
                     folderId = getCurrentFolderId.invoke(),
                     untilId = this.getUntilId(),

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/EmojiEventHandlerImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/EmojiEventHandlerImpl.kt
@@ -42,7 +42,7 @@ class EmojiEventHandlerImpl @Inject constructor(
         return when(e) {
             is EmojiAdded -> {
                 if (currentAccount != null) {
-                    executor.invoke(requireNotNull(currentAccount).normalizedInstanceDomain)
+                    executor.invoke(requireNotNull(currentAccount).normalizedInstanceUri)
                 }
                 true
             }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/GalleryRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/GalleryRepositoryImpl.kt
@@ -163,7 +163,7 @@ class GalleryRepositoryImpl @Inject constructor(
     }
 
     private fun getMisskeyAPI(account: Account): MisskeyAPIV1275 {
-        return misskeyAPIProvider.get(account.normalizedInstanceDomain) as? MisskeyAPIV1275
+        return misskeyAPIProvider.get(account.normalizedInstanceUri) as? MisskeyAPIV1275
             ?: throw IllegalVersionException()
     }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/gallery_posts_paginators.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/gallery_posts_paginators.kt
@@ -113,7 +113,7 @@ class GalleryPostsLoader(
         untilId: String? = null
     ): suspend () -> Response<List<GalleryPostDTO>> {
         val i = getAccount.invoke().token
-        val api = apiProvider.get(getAccount.invoke().normalizedInstanceDomain) as? MisskeyAPIV1275
+        val api = apiProvider.get(getAccount.invoke().normalizedInstanceUri) as? MisskeyAPIV1275
             ?: throw IllegalVersionException()
         when (pageable) {
             is Pageable.Gallery.MyPosts -> {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/liked_gallery_posts_paginator.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/gallery/liked_gallery_posts_paginator.kt
@@ -96,7 +96,7 @@ class LikedGalleryPostsLoader(
     override suspend fun loadFuture(): Result<List<LikedGalleryPost>> {
         return runCancellableCatching {
             val api =
-                misskeyAPIProvider.get(getAccount.invoke().normalizedInstanceDomain) as? MisskeyAPIV1275
+                misskeyAPIProvider.get(getAccount.invoke().normalizedInstanceUri) as? MisskeyAPIV1275
                     ?: throw IllegalVersionException()
             api.likedGalleryPosts(
                 GetPosts(
@@ -111,7 +111,7 @@ class LikedGalleryPostsLoader(
     override suspend fun loadPrevious(): Result<List<LikedGalleryPost>> {
         return runCancellableCatching {
             val api =
-                misskeyAPIProvider.get(getAccount.invoke().normalizedInstanceDomain) as? MisskeyAPIV1275
+                misskeyAPIProvider.get(getAccount.invoke().normalizedInstanceUri) as? MisskeyAPIV1275
                     ?: throw IllegalVersionException()
             api.likedGalleryPosts(
                 GetPosts(

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/group/GroupRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/group/GroupRepositoryImpl.kt
@@ -211,7 +211,7 @@ class GroupRepositoryImpl @Inject constructor(
     }
 
     private fun getMisskeyAPI(account: Account): MisskeyAPIV11 {
-        return misskeyAPIProvider.get(account.normalizedInstanceDomain) as? MisskeyAPIV11
+        return misskeyAPIProvider.get(account.normalizedInstanceUri) as? MisskeyAPIV11
             ?: throw IllegalVersionException()
     }
 }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteTranslationStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteTranslationStoreImpl.kt
@@ -50,7 +50,7 @@ class NoteTranslationStoreImpl @Inject constructor(
         runCancellableCatching {
             withContext(Dispatchers.IO) {
                 val account = accountRepository.get(noteId.accountId).getOrThrow()
-                val api = misskeyAPIProvider.get(account.normalizedInstanceDomain)
+                val api = misskeyAPIProvider.get(account.normalizedInstanceUri)
                 val req = Translate(
                     i = account.token,
                     targetLang = Locale.getDefault().language,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/TimelinePagingStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/TimelinePagingStoreImpl.kt
@@ -112,7 +112,7 @@ internal class TimelinePagingStoreImpl(
 
     private suspend fun getStore(): (suspend (NoteRequest) -> Response<List<NoteDTO>?>)? {
         val account = getAccount.invoke()
-        val meta = metaRepository.find(account.normalizedInstanceDomain)
+        val meta = metaRepository.find(account.normalizedInstanceUri)
         val api = misskeyAPIProvider.get(account, meta.getOrNull()?.getVersion())
         return try {
             when (pageableTimeline) {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -298,7 +298,7 @@ class NoteRepositoryImpl @Inject constructor(
             val account = getAccount.get(noteId.accountId)
             when(account.instanceType) {
                 Account.InstanceType.MISSKEY -> {
-                    misskeyAPIProvider.get(account.normalizedInstanceDomain).noteState(
+                    misskeyAPIProvider.get(account.normalizedInstanceUri).noteState(
                         NoteRequest(
                             i = account.token,
                             noteId = noteId.noteId

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/ReactionHistoryPaginatorImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/ReactionHistoryPaginatorImpl.kt
@@ -56,7 +56,7 @@ class ReactionHistoryPaginatorImpl(
             lock.withLock {
 
                 val account = accountRepository.get(reactionHistoryRequest.noteId.accountId).getOrThrow()
-                val misskeyAPI = misskeyAPIProvider.get(account.normalizedInstanceDomain)
+                val misskeyAPI = misskeyAPIProvider.get(account.normalizedInstanceUri)
                 val res = misskeyAPI.reactions(
                     RequestReactionHistoryDTO(
                         i = account.token,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/renote/RenotesPagingService.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/renote/RenotesPagingService.kt
@@ -93,7 +93,7 @@ class RenotesPagingImpl(
             val account = accountRepository.get(targetNoteId.accountId).getOrThrow()
             val i = account.token
 
-            misskeyAPIProvider.get(account.normalizedInstanceDomain)
+            misskeyAPIProvider.get(account.normalizedInstanceUri)
                 .renotes(FindRenotes(i = i, noteId = targetNoteId.noteId, untilId = getUntilId()))
                 .throwIfHasError().body()!!
         }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/sw/register/SubscriptionRegistrationImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/sw/register/SubscriptionRegistrationImpl.kt
@@ -45,7 +45,7 @@ class SubscriptionRegistrationImpl(
         ).build()
         logger.debug("endpoint:${endpoint}")
 
-        val api = misskeyAPIProvider.get(account.normalizedInstanceDomain)
+        val api = misskeyAPIProvider.get(account.normalizedInstanceUri)
         val res = api.swRegister(
             Subscription(
                 i = account.token,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/url/UrlPreviewStoreFactory.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/url/UrlPreviewStoreFactory.kt
@@ -21,7 +21,7 @@ class UrlPreviewStoreFactory(
 
 
     fun create(): UrlPreviewStore {
-        val url = account?.normalizedInstanceDomain
+        val url = account?.normalizedInstanceUri
             ?: summalyUrl
         return UrlPreviewMediatorStore(urlPreviewDAO, createUrlPreviewStore(url))
     }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/url/UrlPreviewStoreProvider.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/url/UrlPreviewStoreProvider.kt
@@ -31,7 +31,7 @@ class UrlPreviewStoreProviderImpl @Inject constructor(
         account: Account,
         isReplace: Boolean
     ): UrlPreviewStore {
-        return account.normalizedInstanceDomain.let { accountUrl ->
+        return account.normalizedInstanceUri.let { accountUrl ->
 
             var store = mUrlPreviewStoreInstanceBaseUrlMap[accountUrl]
             if (store == null || isReplace) {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserRepositoryImpl.kt
@@ -78,7 +78,7 @@ internal class UserRepositoryImpl @Inject constructor(
             return@withContext local
         }
         val account = accountRepository.get(accountId).getOrThrow()
-        val misskeyAPI = misskeyAPIProvider.get(account.normalizedInstanceDomain)
+        val misskeyAPI = misskeyAPIProvider.get(account.normalizedInstanceUri)
         val res = misskeyAPI.showUser(
             RequestUser(
                 i = account.token,

--- a/modules/features/account/src/main/java/net/pantasystem/milktea/account/AccountTabViewModel.kt
+++ b/modules/features/account/src/main/java/net/pantasystem/milktea/account/AccountTabViewModel.kt
@@ -23,10 +23,10 @@ class AccountTabViewModel @Inject constructor(
 
     val tabs = accountStore.observeCurrentAccount.filterNotNull().map { account ->
         val isEnableGallery =
-            featureEnables.isEnable(account.normalizedInstanceDomain, FeatureType.Gallery)
+            featureEnables.isEnable(account.normalizedInstanceUri, FeatureType.Gallery)
         val userId = User.Id(account.accountId, account.remoteId)
         val isEnableMessaging =
-            featureEnables.isEnable(account.normalizedInstanceDomain, FeatureType.Messaging, false)
+            featureEnables.isEnable(account.normalizedInstanceUri, FeatureType.Messaging, false)
         when (account.instanceType) {
             Account.InstanceType.MISSKEY -> {
                 listOfNotNull(

--- a/modules/features/auth/src/main/java/net/pantasystem/milktea/auth/viewmodel/app/AppAuthViewModel.kt
+++ b/modules/features/auth/src/main/java/net/pantasystem/milktea/auth/viewmodel/app/AppAuthViewModel.kt
@@ -203,7 +203,7 @@ class AppAuthViewModel @Inject constructor(
         }.onFailure {
             logger.error("アカウント登録処理失敗", it)
         }.onSuccess {
-            syncMetaExecutor(it.account.normalizedInstanceDomain)
+            syncMetaExecutor(it.account.normalizedInstanceUri)
         }.getOrNull()
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/EmojiPickerUiState.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/EmojiPickerUiState.kt
@@ -39,7 +39,7 @@ class EmojiPickerUiStateService(
     @OptIn(ExperimentalCoroutinesApi::class)
     private val reactionCount =
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest { ac ->
-            reactionHistoryRepository.observeSumReactions(ac.normalizedInstanceDomain)
+            reactionHistoryRepository.observeSumReactions(ac.normalizedInstanceUri)
         }.catch {
             logger.error("リアクション履歴の取得に失敗", it)
         }.flowOn(Dispatchers.IO)
@@ -47,7 +47,7 @@ class EmojiPickerUiStateService(
     @OptIn(ExperimentalCoroutinesApi::class)
     private val userSetting =
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest { ac ->
-            userEmojiConfigRepository.observeByInstanceDomain(ac.normalizedInstanceDomain)
+            userEmojiConfigRepository.observeByInstanceDomain(ac.normalizedInstanceUri)
         }.catch {
             logger.error("ユーザーリアクション設定情報の取得に失敗", it)
         }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), emptyList())
@@ -74,7 +74,7 @@ class EmojiPickerUiStateService(
     @OptIn(ExperimentalCoroutinesApi::class)
     private val recentlyUsedReactions =
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
-            reactionHistoryRepository.observeRecentlyUsedBy(it.normalizedInstanceDomain, limit = 20)
+            reactionHistoryRepository.observeRecentlyUsedBy(it.normalizedInstanceUri, limit = 20)
         }.catch {
             logger.error("絵文字の直近使用履歴の取得に失敗", it)
         }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), emptyList())

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewData.kt
@@ -32,6 +32,6 @@ class NoteDetailViewData(
     coroutineScope
 ) {
     init {
-        super.reactionCountsExpanded.postValue(true)
+        super.reactionCountsExpanded.value = true
     }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/detail/viewmodel/NoteDetailViewModel.kt
@@ -203,7 +203,7 @@ class NoteDetailViewModel @AssistedInject constructor(
 
     suspend fun getUrl(): String {
         val account = currentAccountWatcher.getAccount()
-        return "${account.normalizedInstanceDomain}/notes/${show.noteId}"
+        return "${account.normalizedInstanceUri}/notes/${show.noteId}"
     }
 
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/NoteEditorFragment.kt
@@ -266,7 +266,7 @@ class NoteEditorFragment : Fragment(R.layout.fragment_note_editor), EmojiSelecti
 
 
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
-            metaRepository.observe(it.normalizedInstanceDomain)
+            metaRepository.observe(it.normalizedInstanceUri)
         }.mapNotNull {
             it?.emojis
         }.distinctUntilChanged().onEach { emojis ->

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/SimpleEditorFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/SimpleEditorFragment.kt
@@ -124,7 +124,7 @@ class SimpleEditorFragment : Fragment(R.layout.fragment_simple_editor), SimpleEd
         }.flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED).launchIn(lifecycleScope)
 
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
-            metaRepository.observe(it.normalizedInstanceDomain)
+            metaRepository.observe(it.normalizedInstanceUri)
         }.mapNotNull {
             it?.emojis
         }.distinctUntilChanged().onEach { emojis ->

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorSwitchAccountExecutor.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorSwitchAccountExecutor.kt
@@ -80,7 +80,7 @@ class NoteEditorSwitchAccountExecutor @Inject constructor(
     ): Result<NoteEditorSwitchAccountExecutorResult> = runCancellableCatching {
         if (noteEditingState.renoteId != null) {
             val renote = noteRepository.find(noteEditingState.renoteId).getOrThrow()
-            val url = renote.url ?: renote.uri ?: "${fromAccount?.normalizedInstanceDomain}/notes/${renote.id.noteId}"
+            val url = renote.url ?: renote.uri ?: "${fromAccount?.normalizedInstanceUri}/notes/${renote.id.noteId}"
             val toRenoteNote = resolverRepository.resolve(account.accountId, url)
                 .getOrThrow() as ApResolver.TypeNote
             noteEditingState.copy(renoteId = toRenoteNote.note.id)
@@ -96,7 +96,7 @@ class NoteEditorSwitchAccountExecutor @Inject constructor(
     ): Result<NoteEditorSwitchAccountExecutorResult> = runCancellableCatching {
         if (noteEditingState.replyId != null) {
             val reply = noteRepository.find(noteEditingState.replyId).getOrThrow()
-            val url = reply.url ?: reply.uri ?: "${fromAccount?.normalizedInstanceDomain}/notes/${reply.id.noteId}"
+            val url = reply.url ?: reply.uri ?: "${fromAccount?.normalizedInstanceUri}/notes/${reply.id.noteId}"
             val toReplyNote = resolverRepository.resolve(account.accountId, url)
                 .getOrThrow() as ApResolver.TypeNote
             noteEditingState.copy(replyId = toReplyNote.note.id)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
@@ -88,7 +88,7 @@ class NoteEditorViewModel @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val instanceInfoType = currentAccount.filterNotNull().flatMapLatest {
-        instanceInfoService.observe(it.normalizedInstanceDomain)
+        instanceInfoService.observe(it.normalizedInstanceUri)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     val isSensitiveMedia =
@@ -140,7 +140,7 @@ class NoteEditorViewModel @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     val maxTextLength =
         currentAccount.filterNotNull().flatMapLatest { account ->
-            instanceInfoService.observe(account.normalizedInstanceDomain).filterNotNull()
+            instanceInfoService.observe(account.normalizedInstanceUri).filterNotNull()
                 .map { meta ->
                     meta.maxNoteTextLength
                 }
@@ -152,11 +152,11 @@ class NoteEditorViewModel @Inject constructor(
 
 
     val enableFeatures = currentAccount.filterNotNull().map {
-        featureEnables.enableFeatures(it.normalizedInstanceDomain)
+        featureEnables.enableFeatures(it.normalizedInstanceUri)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
 
     val maxFileCount = currentAccount.filterNotNull().mapNotNull {
-        instanceInfoService.find(it.normalizedInstanceDomain).getOrNull()?.maxFileCount
+        instanceInfoService.find(it.normalizedInstanceUri).getOrNull()?.maxFileCount
     }.stateIn(viewModelScope + Dispatchers.IO, started = SharingStarted.Eagerly, initialValue = 4)
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/media/viewmodel/MediaViewData.kt
@@ -1,41 +1,40 @@
 package net.pantasystem.milktea.note.media.viewmodel
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Transformations
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.*
 import net.pantasystem.milktea.model.file.FilePreviewSource
 import net.pantasystem.milktea.model.file.isSensitive
 import net.pantasystem.milktea.model.setting.Config
 
-class MediaViewData(files: List<FilePreviewSource>, val config: Config?) {
+class MediaViewData(files: List<FilePreviewSource>, val config: Config?, coroutineScope: CoroutineScope) {
 
     // NOTE: サイズが変わることは決してない
-    private val _files = MutableLiveData(files.map{
+    private val _files = MutableStateFlow(files.map{
         PreviewAbleFile(it, if (it.isSensitive) PreviewAbleFile.VisibleType.SensitiveHide else if (config?.isHideMediaWhenMobileNetwork == true) PreviewAbleFile.VisibleType.HideWhenMobileNetwork else PreviewAbleFile.VisibleType.Visible)
     })
-    val files: LiveData<List<PreviewAbleFile>> = _files
+    val files: StateFlow<List<PreviewAbleFile>> = _files
 
-    val fileOne = Transformations.map(_files) {
+    val fileOne = _files.map {
         it.getOrNull(0)
-    }
+    }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), null)
 
-    val fileTwo = Transformations.map(_files) {
+    val fileTwo = _files.map {
         it.getOrNull(1)
-    }
+    }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), null)
 
-    val fileThree = Transformations.map(_files) {
+    val fileThree = _files.map {
         it.getOrNull(2)
-    }
+    }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), null)
 
-    val fileFour = Transformations.map(_files) {
+    val fileFour = _files.map {
         it.getOrNull(3)
-    }
+    }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), null)
 
     val isOver4Files = files.size > 4
     val isVisibleMediaPreviewArea = !(isOver4Files || files.isEmpty())
 
     fun show(index: Int) {
-        val list = (_files.value ?: emptyList()).toMutableList()
+        val list = _files.value.toMutableList()
         _files.value = list.mapIndexed { i, previewAbleFile ->
             if (i == index) {
                 previewAbleFile.copy(visibleType = PreviewAbleFile.VisibleType.Visible)
@@ -46,7 +45,7 @@ class MediaViewData(files: List<FilePreviewSource>, val config: Config?) {
     }
 
     fun toggleVisibility(index: Int) {
-        val list = (_files.value ?: emptyList()).toMutableList()
+        val list = _files.value.toMutableList()
         _files.value = list.mapIndexed { i, previewAbleFile ->
             if (i == index) {
                 previewAbleFile.copy(

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/option/NoteOptionDialog.kt
@@ -73,7 +73,7 @@ class NoteOptionDialog : BottomSheetDialogFragment() {
                             }
                         },
                         onShareButtonClicked = {
-                            val baseUrl = uiState.currentAccount?.normalizedInstanceDomain
+                            val baseUrl = uiState.currentAccount?.normalizedInstanceUri
                             val url = "$baseUrl/notes/${it?.id?.noteId}"
                             val intent = Intent().apply {
                                 action = ACTION_SEND
@@ -110,7 +110,7 @@ class NoteOptionDialog : BottomSheetDialogFragment() {
                         },
                         onReportButtonClicked ={
                             if (it != null) {
-                                val baseUrl = uiState.currentAccount?.normalizedInstanceDomain
+                                val baseUrl = uiState.currentAccount?.normalizedInstanceUri
                                 val report = it.toReport(baseUrl!!)
                                 notesViewModel.confirmReportEvent.tryEmit(report)
                             }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
@@ -61,7 +61,7 @@ object NoteReactionViewHelper {
         val cache = entryPoint.metaRepository()
 
         val textReaction = LegacyReaction.reactionMap[reaction] ?: reaction
-        val meta = cache.get(note.account.normalizedInstanceDomain)
+        val meta = cache.get(note.account.normalizedInstanceUri)
 
         val r = Reaction(textReaction)
         val emoji = note.emojiMap[textReaction.replace(":", "")]

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
@@ -64,7 +64,7 @@ object NoteReactionViewHelper {
         val meta = cache.get(note.account.normalizedInstanceUri)
 
         val r = Reaction(textReaction)
-        val emoji = note.emojiMap[textReaction.replace(":", "")]
+        val emoji = note.toShowNote.note.emojiNameMap?.get(textReaction.replace(":", ""))
             ?: meta?.emojisMap?.get(r.getName())
 
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/ReactionViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/ReactionViewData.kt
@@ -19,9 +19,7 @@ data class ReactionViewData(
             note: Note,
             instanceEmojis: Map<String, Emoji>?,
         ): List<ReactionViewData> {
-            val noteEmojis = note.emojis?.associateBy {
-                it.name
-            }
+            val noteEmojis = note.emojiNameMap
             return reactions.map { reactionCount ->
 
                 val textReaction = LegacyReaction.reactionMap[reactionCount.reaction] ?: reactionCount.reaction

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/history/ReactionHistoryViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/history/ReactionHistoryViewModel.kt
@@ -55,7 +55,7 @@ class ReactionHistoryViewModel @AssistedInject constructor(
     private val emojis = flowOf(noteId).mapNotNull {
         accountRepository.get(it.accountId).getOrNull()
     }.flatMapLatest {
-        metaRepository.observe(it.normalizedInstanceDomain)
+        metaRepository.observe(it.normalizedInstanceUri)
     }.map {
         it?.emojis ?: emptyList()
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/picker/ReactionPickerDialog.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/picker/ReactionPickerDialog.kt
@@ -91,7 +91,7 @@ class ReactionPickerDialog : AppCompatDialogFragment(){
         }
 
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
-            metaRepository.observe(it.normalizedInstanceDomain)
+            metaRepository.observe(it.normalizedInstanceUri)
         }.mapNotNull {
             it?.emojis
         }.onEach { emojis ->

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/picker/ReactionPickerDialogViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/picker/ReactionPickerDialogViewModel.kt
@@ -22,7 +22,7 @@ class ReactionPickerDialogViewModel @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val userConfigReactions = _currentAccount.filterNotNull().flatMapLatest { ac ->
-        userEmojiConfigRepository.observeByInstanceDomain(ac.normalizedInstanceDomain).map { list ->
+        userEmojiConfigRepository.observeByInstanceDomain(ac.normalizedInstanceUri).map { list ->
             list.sortedBy {
                 it.weight
             }.map {

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/RemoteReactionEmojiSuggestionViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/viewmodel/RemoteReactionEmojiSuggestionViewModel.kt
@@ -48,7 +48,7 @@ class RemoteReactionEmojiSuggestionViewModel @Inject constructor(
         } else {
             suspend {
                 val account = accountRepository.get(remoteReaction.currentAccountId).getOrThrow()
-                metaRepository.find(account.normalizedInstanceDomain).getOrThrow().emojis?.filter {
+                metaRepository.find(account.normalizedInstanceUri).getOrThrow().emojis?.filter {
                     it.name == name
                 }
             }.asLoadingStateFlow()

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -234,21 +234,11 @@ open class PlaneNoteViewData(
         }
     }
 
-    fun update(note: Note) {
-        require(toShowNote.note.id == note.id) {
-            "更新として渡されたNote.Idと現在のIdが一致しません。"
-        }
-    }
-
     fun capture(
         noteCaptureAPIAdapter: NoteCaptureAPIAdapter,
         job: (Flow<NoteDataSource.Event>) -> Job,
     ) {
-        val flow = noteCaptureAPIAdapter.capture(toShowNote.note.id).onEach {
-            if (it is NoteDataSource.Event.Updated) {
-                update(it.note)
-            }
-        }.catch { e ->
+        val flow = noteCaptureAPIAdapter.capture(toShowNote.note.id).catch { e ->
             Log.d("PlaneNoteViewData", "error", e)
         }
         this.job = job(flow)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -110,7 +110,7 @@ open class PlaneNoteViewData(
     }?.filter {
         it.aboutMediaType == AboutMediaType.IMAGE || it.aboutMediaType == AboutMediaType.VIDEO
     } ?: emptyList()
-    val media = MediaViewData(previewableFiles, configRepository.get().getOrNull())
+    val media = MediaViewData(previewableFiles, configRepository.get().getOrNull(), coroutineScope)
 
     val isOnlyVisibleRenoteStatusMessage = MutableStateFlow<Boolean>(false)
 
@@ -187,7 +187,7 @@ open class PlaneNoteViewData(
     val subNoteFiles = subNote?.files ?: emptyList()
     val subNoteMedia = MediaViewData(subNote?.files?.map {
         FilePreviewSource.Remote(AppFile.Remote(it.id), it)
-    } ?: emptyList(), configRepository.get().getOrNull())
+    } ?: emptyList(), configRepository.get().getOrNull(), coroutineScope)
 
     val channelInfo = (toShowNote.note.type as? Note.Type.Misskey)?.channel
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -155,10 +155,6 @@ open class PlaneNoteViewData(
         }
     }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    val poll = currentNote.map {
-        it.poll
-    }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), null)
-
     //reNote先
     val subNote: NoteRelation? = toShowNote.renote
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -18,6 +18,7 @@ import net.pantasystem.milktea.model.file.AboutMediaType
 import net.pantasystem.milktea.model.file.AppFile
 import net.pantasystem.milktea.model.file.FilePreviewSource
 import net.pantasystem.milktea.model.notes.*
+import net.pantasystem.milktea.model.setting.DefaultConfig
 import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.model.url.UrlPreview
 import net.pantasystem.milktea.model.url.UrlPreviewLoadTask
@@ -189,28 +190,10 @@ open class PlaneNoteViewData(
 
     val channelInfo = (toShowNote.note.type as? Note.Type.Misskey)?.channel
 
-    val isVisibleNoteDivider = configRepository.observe().map {
-        it.isEnableNoteDivider
-    }.distinctUntilChanged().stateIn(
+    val config = configRepository.observe().stateIn(
         coroutineScope,
         SharingStarted.WhileSubscribed(5_000),
-        true
-    )
-
-    val isVisibleInstanceTicker = configRepository.observe().map {
-        it.isEnableInstanceTicker
-    }.distinctUntilChanged().stateIn(
-        coroutineScope,
-        SharingStarted.WhileSubscribed(5_000),
-        true
-    )
-
-    val isUserNameDefault = configRepository.observe().map {
-        it.isUserNameDefault
-    }.distinctUntilChanged().stateIn(
-        coroutineScope,
-        SharingStarted.WhileSubscribed(5_000),
-        false
+        DefaultConfig.config
     )
 
     val isVisibleSubNoteMediaPreview = subContentFolding.map { folding ->

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/viewmodel/PlaneNoteViewData.kt
@@ -14,7 +14,6 @@ import net.pantasystem.milktea.common_android.resource.StringSource
 import net.pantasystem.milktea.common_android_ui.getTextType
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.emoji.CustomEmojiRepository
-import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.file.AboutMediaType
 import net.pantasystem.milktea.model.file.AppFile
 import net.pantasystem.milktea.model.file.FilePreviewSource
@@ -100,10 +99,6 @@ open class PlaneNoteViewData(
             SharingStarted.WhileSubscribed(5_000),
             null
         )
-
-    var emojis = toShowNote.note.emojis ?: emptyList()
-
-    val emojiMap = HashMap<String, Emoji>(toShowNote.note.emojiNameMap ?: mapOf())
 
     private val previewableFiles = toShowNote.files?.map {
         FilePreviewSource.Remote(AppFile.Remote(it.id), it)
@@ -247,8 +242,6 @@ open class PlaneNoteViewData(
         require(toShowNote.note.id == note.id) {
             "更新として渡されたNote.Idと現在のIdが一致しません。"
         }
-        emojiMap.putAll(note.emojiNameMap ?: emptyMap())
-        emojis = emojiMap.values.toList()
     }
 
     fun capture(

--- a/modules/features/note/src/main/res/layout/item_detail_note.xml
+++ b/modules/features/note/src/main/res/layout/item_detail_note.xml
@@ -170,7 +170,7 @@
                         layout="@layout/view_translation"
                         android:layout_marginTop="8dp"
 
-                        app:emojis="@{note.emojis}"
+                        app:emojis="@{note.toShowNote.note.emojis}"
                         app:translationState="@{note.translateState}"
                         android:layout_marginBottom="8dp" />
 

--- a/modules/features/note/src/main/res/layout/item_detail_note.xml
+++ b/modules/features/note/src/main/res/layout/item_detail_note.xml
@@ -199,11 +199,11 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_below="@id/manyFilePreviewListView"
-                        android:visibility="@{note.poll == null ? View.GONE : View.VISIBLE}"
+                        android:visibility="@{note.currentNote.poll == null ? View.GONE : View.VISIBLE}"
                         tools:itemCount="2"
                         tools:listitem="@layout/item_choice"
                         noteId="@{note.toShowNote.note.id}"
-                        poll="@{note.poll}"
+                        poll="@{note.currentNote.poll}"
                         noteCardActionListenerAdapter="@{noteCardActionListener}"
 
                         />

--- a/modules/features/note/src/main/res/layout/item_detail_note.xml
+++ b/modules/features/note/src/main/res/layout/item_detail_note.xml
@@ -118,7 +118,7 @@
                     android:gravity="center_vertical"
                     android:padding="2dp"
                     instanceInfo="@{note.toShowNote.user.instance}"
-                    isEnable="@{note.isVisibleInstanceTicker}"
+                    isEnable="@{note.config.isEnableInstanceTicker}"
                     android:layout_below="@id/avatarIcon"
                     android:layout_marginTop="4dp"
                     />
@@ -507,7 +507,7 @@
                     android:layout_height="@dimen/note_divider_height"
                     android:background="?android:attr/listDivider"
                     android:layout_below="@id/noteActionButtonBaseLayout"
-                    android:visibility="@{ note.isVisibleNoteDivider ? View.VISIBLE : View.GONE}" />
+                    android:visibility="@{ note.config.isEnableNoteDivider ? View.VISIBLE : View.GONE}" />
         </RelativeLayout>
     </androidx.cardview.widget.CardView>
 

--- a/modules/features/note/src/main/res/layout/item_has_reply_to_note.xml
+++ b/modules/features/note/src/main/res/layout/item_has_reply_to_note.xml
@@ -146,7 +146,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/note_divider_height"
                     android:background="?android:attr/listDivider"
-                    android:visibility="@{ hasReplyToNote.isVisibleNoteDivider ? View.VISIBLE : View.GONE}" />
+                    android:visibility="@{ hasReplyToNote.config.isEnableNoteDivider ? View.VISIBLE : View.GONE}" />
         </LinearLayout>
     </androidx.cardview.widget.CardView>
 

--- a/modules/features/note/src/main/res/layout/item_note.xml
+++ b/modules/features/note/src/main/res/layout/item_note.xml
@@ -50,7 +50,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/note_divider_height"
                     android:background="?android:attr/listDivider"
-                    android:visibility="@{ note.isVisibleNoteDivider ? View.VISIBLE : View.GONE}" />
+                    android:visibility="@{ note.config.isEnableNoteDivider ? View.VISIBLE : View.GONE}" />
         </LinearLayout>
     </androidx.cardview.widget.CardView>
 

--- a/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
+++ b/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
@@ -148,7 +148,7 @@
                         android:gravity="center_vertical"
                         android:padding="2dp"
                         instanceInfo="@{note.toShowNote.user.instance}"
-                        isEnable="@{note.isVisibleInstanceTicker}"
+                        isEnable="@{note.config.isEnableInstanceTicker}"
                         android:singleLine="true"
                         />
                 <TextView

--- a/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
+++ b/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
@@ -231,10 +231,10 @@
                             android:layout_height="wrap_content"
                             tools:listitem="@layout/item_choice"
                             tools:itemCount="2"
-                            android:visibility="@{note.poll == null ? View.GONE : View.VISIBLE}"
+                            android:visibility="@{note.currentNote.poll == null ? View.GONE : View.VISIBLE}"
 
                             noteId="@{note.toShowNote.note.id}"
-                            poll="@{note.poll}"
+                            poll="@{note.currentNote.poll}"
                             noteCardActionListenerAdapter="@{null}"
                             />
 

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -236,10 +236,10 @@
                             android:layout_height="wrap_content"
                             tools:listitem="@layout/item_choice"
                             tools:itemCount="2"
-                            memoVisibility="@{note.poll == null ? View.GONE : View.VISIBLE}"
+                            memoVisibility="@{note.currentNote.poll == null ? View.GONE : View.VISIBLE}"
 
                             noteId="@{note.toShowNote.note.id}"
-                            poll="@{note.poll}"
+                            poll="@{note.currentNote.poll}"
                             noteCardActionListenerAdapter="@{noteCardActionListener}"
                             />
 

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -32,7 +32,7 @@
             app:subNameView="@{subName}"
             app:user="@{note.toShowNote.user}"
             app:account="@{note.account}"
-            isUserNameDefault="@{note.isUserNameDefault}"
+            isUserNameDefault="@{note.config.isUserNameDefault}"
 
             app:foldingNote="@{note}"
             app:foldingButton="@{contentFoldingButton}"
@@ -153,7 +153,7 @@
                         android:gravity="center_vertical"
                         android:padding="2dp"
                         instanceInfo="@{note.toShowNote.user.instance}"
-                        isEnable="@{note.isVisibleInstanceTicker}"
+                        isEnable="@{note.config.isEnableInstanceTicker}"
                         android:maxLines="1"
                         />
                 <TextView
@@ -264,7 +264,7 @@
                             app:clickedView="@{subNote}"
                             app:subNameView="@{subNoteSubName}"
                             app:mainNameView="@{subNoteMainName}"
-                            isUserNameDefault="@{note.isUserNameDefault}"
+                            isUserNameDefault="@{note.config.isUserNameDefault}"
                             app:user="@{note.subNote.user}"
                             app:account="@{note.account}"
                             android:layout_marginTop="4dp">

--- a/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchViewModel.kt
+++ b/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchViewModel.kt
@@ -46,7 +46,7 @@ class SearchViewModel @Inject constructor(
     }.flatMapLatest {
         suspend {
             hashtagRepository.search(
-                currentAccountWatcher.getAccount().normalizedInstanceDomain,
+                currentAccountWatcher.getAccount().normalizedInstanceUri,
                 it
             ).getOrThrow()
         }.asLoadingStateFlow()

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ImportReactionFromWebViewActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ImportReactionFromWebViewActivity.kt
@@ -141,7 +141,7 @@ class ImportReactionFromWebViewActivity : AppCompatActivity() {
 
 
     private fun getWebClientTokenFromCookie(account: Account): String? {
-        val rawCookie: String? = CookieManager.getInstance().getCookie(account.normalizedInstanceDomain)
+        val rawCookie: String? = CookieManager.getInstance().getCookie(account.normalizedInstanceUri)
         val cookies = rawCookie?.split(";")?.map { it.trim() }?.mapNotNull {
             val key = it.split("=").getOrNull(0)?.lowercase()
             val value = it.split("=").getOrNull(1)

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ReactionSettingActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/ReactionSettingActivity.kt
@@ -85,7 +85,7 @@ class ReactionSettingActivity : AppCompatActivity() {
 
 
         accountStore.observeCurrentAccount.filterNotNull().flatMapLatest {
-            metaRepository.observe(it.normalizedInstanceDomain)
+            metaRepository.observe(it.normalizedInstanceUri)
         }.distinctUntilChanged().mapNotNull {
             it?.emojis
         }.onEach { emojis ->

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/ImportReactionFromWebViewViewModel.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/ImportReactionFromWebViewViewModel.kt
@@ -41,11 +41,11 @@ class ImportReactionFromWebViewViewModel @Inject constructor(
             try {
 
                 val account = accountRepository.getCurrentAccount().getOrThrow()
-                reactionUserSettingDao.deleteAll(reactionUserSettingDao.findByInstanceDomain(account.normalizedInstanceDomain) ?: emptyList())
+                reactionUserSettingDao.deleteAll(reactionUserSettingDao.findByInstanceDomain(account.normalizedInstanceUri) ?: emptyList())
                 val settings = reactions.value.mapIndexed { i, reaction ->
                     ReactionUserSetting(
                         reaction,
-                        account.normalizedInstanceDomain,
+                        account.normalizedInstanceUri,
                         i
                     )
                 }

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/reaction/ReactionPickerSettingViewModel.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/reaction/ReactionPickerSettingViewModel.kt
@@ -50,7 +50,7 @@ class ReactionPickerSettingViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val rawSettings = reactionUserSettingDao
-                    .findByInstanceDomain(account.normalizedInstanceDomain)
+                    .findByInstanceDomain(account.normalizedInstanceUri)
                 mExistingSettingList = rawSettings ?: emptyList()
                 var settingReactions = rawSettings
                     ?: LegacyReaction.defaultReaction.mapIndexed { index, str ->
@@ -117,7 +117,7 @@ class ReactionPickerSettingViewModel @Inject constructor(
         mReactionSettingReactionNameMap[reaction] =
             ReactionUserSetting(
                 reaction,
-                account.normalizedInstanceDomain,
+                account.normalizedInstanceUri,
                 mReactionSettingReactionNameMap.size
             )
         reactionSettingsList.postValue(mReactionSettingReactionNameMap.values.toList())
@@ -143,7 +143,7 @@ class ReactionPickerSettingViewModel @Inject constructor(
     ): ReactionUserSetting {
         return ReactionUserSetting(
             reaction,
-            account.normalizedInstanceDomain,
+            account.normalizedInstanceUri,
             index
         )
     }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/reaction/UserReactionBindingModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/reaction/UserReactionBindingModel.kt
@@ -12,7 +12,7 @@ class UserReactionBindingModel(
     val user: StateFlow<User>,
 ) {
     val emojis
-        get() = note.emojis
+        get() = note.toShowNote.note.emojis
 
     val isCustomEmoji
         get() = Reaction(reaction.type).isCustomEmojiFormat()

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
@@ -116,9 +116,9 @@ class UserDetailViewModel @AssistedInject constructor(
         accountStore.observeCurrentAccount.filterNotNull(), userState.filterNotNull()
     ) { account, user ->
         val isEnableGallery =
-            featureEnables.isEnable(account.normalizedInstanceDomain, FeatureType.Gallery)
+            featureEnables.isEnable(account.normalizedInstanceUri, FeatureType.Gallery)
         val isPublicReaction = featureEnables.isEnable(
-                account.normalizedInstanceDomain,
+                account.normalizedInstanceUri,
                 FeatureType.UserReactionHistory
             ) && (user.info.isPublicReactions || user.id == User.Id(
                 account.accountId, account.remoteId

--- a/modules/features/user/src/main/res/layout/item_user_reaction.xml
+++ b/modules/features/user/src/main/res/layout/item_user_reaction.xml
@@ -40,7 +40,7 @@
                         android:layout_width="32dp"
                         android:layout_height="32dp"
 
-                        emojis="@{bindingModel.note.emojis}"
+                        emojis="@{bindingModel.emojis}"
                         reaction="@{bindingModel.reaction.type}"
                         tools:ignore="ContentDescription"
                         android:visibility="@{bindingModel.customEmoji ? View.VISIBLE : View.GONE }"/>

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/Account.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/Account.kt
@@ -112,7 +112,7 @@ internal object UrlHelper {
             if (protocolLess.startsWith("@")){
                 val acct = Acct(protocolLess)
                 if (!acct.host.isNullOrBlank()) {
-                    return acct.host
+                    return acct.host.lowercase()
                 }
             }
         } else {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/AddEmojiToUserConfigUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/emoji/AddEmojiToUserConfigUseCase.kt
@@ -15,8 +15,8 @@ class AddEmojiToUserConfigUseCase @Inject constructor(
         userEmojiConfigRepository.save(
             UserEmojiConfig(
                 reaction = emoji,
-                instanceDomain = account.normalizedInstanceDomain,
-                weight = userEmojiConfigRepository.findByInstanceDomain(account.normalizedInstanceDomain).size
+                instanceDomain = account.normalizedInstanceUri,
+                weight = userEmojiConfigRepository.findByInstanceDomain(account.normalizedInstanceUri).size
             )
         ).getOrThrow()
     }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/Note.kt
@@ -49,10 +49,37 @@ data class Note(
     val type: Type,
     val nodeInfo: NodeInfo?,
 ) : Entity {
-    data class Id(
+    class Id(
         val accountId: Long,
         val noteId: String
-    ) : EntityId
+    ) : EntityId {
+
+        private var _hashCode: Int? = null
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as Id
+
+            if (accountId != other.accountId) return false
+            if (noteId != other.noteId) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            if (_hashCode != null) return _hashCode!!
+            var result = accountId.hashCode()
+            result = 31 * result + noteId.hashCode()
+            _hashCode = result
+            return result
+        }
+
+        override fun toString(): String {
+            return "Id(accountId=$accountId, noteId='$noteId')"
+        }
+
+    }
 
 
     sealed interface Type {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/reaction/ToggleReactionUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/reaction/ToggleReactionUseCase.kt
@@ -36,7 +36,7 @@ class ToggleReactionUseCase @Inject constructor(
             val sendReaction =
                 if (
                     checkEmoji.checkEmoji(reaction)
-                    || metaRepository.find(account.normalizedInstanceDomain).getOrThrow()
+                    || metaRepository.find(account.normalizedInstanceUri).getOrThrow()
                         .isOwnEmojiBy(reactionObj)
                 ) {
                     reaction
@@ -57,7 +57,7 @@ class ToggleReactionUseCase @Inject constructor(
                     reactionHistoryRepository.create(
                         ReactionHistory(
                             sendReaction,
-                            account.normalizedInstanceDomain
+                            account.normalizedInstanceUri
                         )
                     )
                 }
@@ -67,7 +67,7 @@ class ToggleReactionUseCase @Inject constructor(
                     reactionHistoryRepository.create(
                         ReactionHistory(
                             sendReaction,
-                            account.normalizedInstanceDomain
+                            account.normalizedInstanceUri
                         )
                     )
                 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/user/User.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/user/User.kt
@@ -34,10 +34,38 @@ sealed interface User : Entity {
     val parsedResult: CustomEmojiParsedResult
 
 
-    data class Id(
+    class Id(
         val accountId: Long,
         val id: String,
-    ) : EntityId
+    ) : EntityId {
+
+        private var _hashCode: Int? = null
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as Id
+
+            if (accountId != other.accountId) return false
+            if (id != other.id) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            if (_hashCode != null) return _hashCode!!
+            var result = accountId.hashCode()
+            result = 31 * result + id.hashCode()
+            _hashCode = result
+            return result
+        }
+
+        override fun toString(): String {
+            return "Id(accountId=$accountId, id='$id')"
+        }
+
+    }
 
     data class Simple(
         override val id: Id,

--- a/modules/model/src/test/java/net/pantasystem/milktea/model/account/AccountTest.kt
+++ b/modules/model/src/test/java/net/pantasystem/milktea/model/account/AccountTest.kt
@@ -15,6 +15,6 @@ class AccountTest {
             token = "test",
             userName = "Panta"
         )
-        Assertions.assertEquals("https://misskey.pantasystem.com", account.normalizedInstanceDomain)
+        Assertions.assertEquals("https://misskey.pantasystem.com", account.normalizedInstanceUri)
     }
 }

--- a/modules/model/src/test/java/net/pantasystem/milktea/model/notes/reaction/ToggleReactionUseCaseTest.kt
+++ b/modules/model/src/test/java/net/pantasystem/milktea/model/notes/reaction/ToggleReactionUseCaseTest.kt
@@ -65,7 +65,7 @@ class ToggleReactionUseCaseTest {
         }
         val fetchMeta = mock<MetaRepository> {
             onBlocking {
-                find(account.normalizedInstanceDomain)
+                find(account.normalizedInstanceUri)
             } doReturn Result.success(meta)
         }
 
@@ -154,7 +154,7 @@ class ToggleReactionUseCaseTest {
         }
         val fetchMeta = mock<MetaRepository> {
             onBlocking {
-                find(account.normalizedInstanceDomain)
+                find(account.normalizedInstanceUri)
             } doReturn Result.success(meta)
         }
 
@@ -247,7 +247,7 @@ class ToggleReactionUseCaseTest {
         }
         val fetchMeta = mock<MetaRepository> {
             onBlocking {
-                find(account.normalizedInstanceDomain)
+                find(account.normalizedInstanceUri)
             } doReturn Result.success(meta)
         }
         val checkEmoji = mock<CheckEmoji> {
@@ -329,7 +329,7 @@ class ToggleReactionUseCaseTest {
         }
         val fetchMeta = mock<MetaRepository> {
             onBlocking {
-                find(account.normalizedInstanceDomain)
+                find(account.normalizedInstanceUri)
             } doReturn Result.success(meta)
         }
 
@@ -410,7 +410,7 @@ class ToggleReactionUseCaseTest {
         }
         val fetchMeta = mock<MetaRepository> {
             onBlocking {
-                find(account.normalizedInstanceDomain)
+                find(account.normalizedInstanceUri)
             } doReturn Result.success(meta)
         }
 
@@ -491,7 +491,7 @@ class ToggleReactionUseCaseTest {
         }
         val fetchMeta = mock<MetaRepository> {
             onBlocking {
-                find(account.normalizedInstanceDomain)
+                find(account.normalizedInstanceUri)
             } doReturn Result.success(meta)
         }
 
@@ -576,7 +576,7 @@ class ToggleReactionUseCaseTest {
         }
         val fetchMeta = mock<MetaRepository> {
             onBlocking {
-                find(account.normalizedInstanceDomain)
+                find(account.normalizedInstanceUri)
             } doReturn Result.success(meta)
         }
         val checkEmoji = mock<CheckEmoji> {

--- a/modules/worker/src/main/java/net/pantasystem/milktea/worker/meta/SyncMetaWorker.kt
+++ b/modules/worker/src/main/java/net/pantasystem/milktea/worker/meta/SyncMetaWorker.kt
@@ -35,7 +35,7 @@ class SyncMetaWorker @AssistedInject constructor(
             coroutineScope {
                 accounts.map {
                     async {
-                        instanceInfoService.sync(it.normalizedInstanceDomain)
+                        instanceInfoService.sync(it.normalizedInstanceUri)
                     }
                 }.awaitAll()
             }.forEach {


### PR DESCRIPTION
## やったこと
javaのURLクラスはhashCode呼び出し時に暗黙的にDNSにアクセスをしようとしたり
コンストラクタで例外を発生させる可能性があったりと将来的に不具合を発生させる可能性があったので
URLを使用しな実装に変更した。
また一部フィールドの命名をより適したものに変更した

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



