### PR TITLE
CalckeyのRecommended TimelineのStreamingを受信できるようにした

### DIFF
--- a/modules/api_streaming/src/main/java/net/pantasystem/milktea/api_streaming/channel/ChannelAPI.kt
+++ b/modules/api_streaming/src/main/java/net/pantasystem/milktea/api_streaming/channel/ChannelAPI.kt
@@ -22,6 +22,7 @@ class ChannelAPI(
         object Local : Type
         object Hybrid : Type
         object Global : Type
+        object RecommendedTimeline : Type
         data class UserList(
             val userListId: String
         ) : Type
@@ -43,6 +44,7 @@ class ChannelAPI(
         Type.Local to hashSetOf(),
         Type.Hybrid to hashSetOf(),
         Type.Global to hashSetOf(),
+        Type.RecommendedTimeline to hashSetOf(),
     )
 
     private var typeIdMap = mapOf<Type, String>()
@@ -167,6 +169,7 @@ class ChannelAPI(
             is Type.UserList -> Send.Connect.Type.USER_LIST
             is Type.Antenna -> Send.Connect.Type.ANTENNA
             is Type.Channel -> Send.Connect.Type.CHANNEL
+            is Type.RecommendedTimeline -> Send.Connect.Type.RECOMMENDED_TIMELINE
         }
 
         val id = typeIdMap[type] ?: UUID.randomUUID().toString()

--- a/modules/api_streaming/src/main/java/net/pantasystem/milktea/api_streaming/sends.kt
+++ b/modules/api_streaming/src/main/java/net/pantasystem/milktea/api_streaming/sends.kt
@@ -30,6 +30,7 @@ sealed class Send {
             @SerialName("userList") USER_LIST,
             @SerialName("antenna") ANTENNA,
             @SerialName("channel") CHANNEL,
+            @SerialName("recommendedTimeline") RECOMMENDED_TIMELINE,
         }
 
         @Serializable

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteStreamingImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteStreamingImpl.kt
@@ -40,6 +40,7 @@ class NoteStreamingImpl @Inject constructor(
                     || pageable is Pageable.Mastodon.PublicTimeline
                     || pageable is Pageable.Mastodon.ListTimeline
                     || pageable is Pageable.Mastodon.HashTagTimeline
+                    || pageable is Pageable.CalckeyRecommendedTimeline
         }.flatMapLatest { ac ->
             when (pageable) {
                 is Pageable.GlobalTimeline -> {
@@ -75,6 +76,11 @@ class NoteStreamingImpl @Inject constructor(
                 is Pageable.ChannelTimeline -> {
                     requireNotNull(channelAPIProvider.get(ac))
                         .connect(ChannelAPI.Type.Channel(channelId = pageable.channelId))
+                        .convertToNote(getAccount, pageable)
+                }
+                is Pageable.CalckeyRecommendedTimeline -> {
+                    requireNotNull(channelAPIProvider.get(ac))
+                        .connect(ChannelAPI.Type.RecommendedTimeline)
                         .convertToNote(getAccount, pageable)
                 }
                 is Pageable.Mastodon -> {


### PR DESCRIPTION
## やったこと
CalckeyのRecommended TimelineのStreamingを受信できるようにしました。
そのためにStreamingの実装の種別にrecommended timelineを追加し
さらにその内容を受信できるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1556 


