### PR TITLE
Pleroma(Akkoma)にログインできるようにした

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/apps/App.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/apps/App.kt
@@ -43,6 +43,16 @@ data class App(
             redirectUri = redirectUri,
         )
     }
+
+    fun toPleromaModel() : AppType.Pleroma {
+        return AppType.Pleroma(
+            id = id,
+            name = name,
+            clientSecret = clientSecret,
+            clientId = clientId,
+            redirectUri = redirectUri,
+        )
+    }
 }
 
 @Serializable

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/TootPreviewCardDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/mastodon/status/TootPreviewCardDTO.kt
@@ -17,29 +17,29 @@ data class TootPreviewCardDTO(
     val description: String,
 
     @SerialName("author_name")
-    val authorName: String,
+    val authorName: String? = null,
 
     @SerialName("author_url")
-    val authorUrl: String,
+    val authorUrl: String? = null,
 
     @SerialName("provider_url")
     val providerUrl: String,
 
     @SerialName("html")
-    val html: String,
+    val html: String? = null,
 
     @SerialName("width")
-    val width: Int,
+    val width: Int? = null,
 
     @SerialName("height")
-    val height: Int,
+    val height: Int? = null,
 
     @SerialName("image")
     val image: String?,
 
     @SerialName("embed_url")
-    val embedUrl: String?,
+    val embedUrl: String? = null,
 
     @SerialName("blurhash")
-    val blurhash: String?
+    val blurhash: String? = null,
 )

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/auth/App.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/auth/App.kt
@@ -47,7 +47,19 @@ fun AppType.Companion.fromDTO(app: net.pantasystem.milktea.api.mastodon.apps.App
     return app.toModel()
 }
 
+fun AppType.Companion.fromPleromaDTO(app: net.pantasystem.milktea.api.mastodon.apps.App): AppType {
+    return app.toPleromaModel()
+}
+
 fun AppType.Mastodon.generateAuthUrl(baseURL: String, scope: String): String {
+    val encodedClientId = URLEncoder.encode(clientId, "utf-8")
+    val encodedRedirectUri = URLEncoder.encode(redirectUri, "utf-8")
+    val encodedResponseType = URLEncoder.encode("code", "utf-8")
+    val encodedScope = URLEncoder.encode(scope, "utf-8")
+    return "$baseURL/oauth/authorize?client_id=${encodedClientId}&redirect_uri=$encodedRedirectUri&response_type=$encodedResponseType&scope=$encodedScope"
+}
+
+fun AppType.Pleroma.generateAuthUrl(baseURL: String, scope: String): String {
     val encodedClientId = URLEncoder.encode(clientId, "utf-8")
     val encodedRedirectUri = URLEncoder.encode(redirectUri, "utf-8")
     val encodedResponseType = URLEncoder.encode("code", "utf-8")
@@ -60,6 +72,17 @@ fun AppType.Mastodon.generateAuthUrl(baseURL: String, scope: String): String {
  * @param code redirectUrl+codeで帰ってきたコード
  */
 fun AppType.Mastodon.createObtainToken(scope: String, code: String): ObtainToken {
+    return ObtainToken(
+        clientId = clientId,
+        clientSecret = clientSecret,
+        scope = scope,
+        redirectUri = redirectUri,
+        code = code,
+        grantType = "authorization_code"
+    )
+}
+
+fun AppType.Pleroma.createObtainToken(scope: String, code: String): ObtainToken {
     return ObtainToken(
         clientId = clientId,
         clientSecret = clientSecret,

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/TextType.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/TextType.kt
@@ -36,7 +36,7 @@ fun getTextType(account: Account, note: NoteRelation, instanceEmojis: Map<String
                 )
             }
         }
-        Account.InstanceType.MASTODON -> {
+        Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
             note.note.text?.let {
                 val option = note.note.type as? Note.Type.Mastodon
                 TextType.Mastodon(

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/account/SignOutUseCaseImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/account/SignOutUseCaseImpl.kt
@@ -26,7 +26,7 @@ class SignOutUseCaseImpl @Inject constructor(
                     subscriptionUnRegistration
                         .unregister(account.accountId)
                 }
-                Account.InstanceType.MASTODON -> {}
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {}
             }
         }.mapCancellableCatching {
             accountRepository.delete(account)
@@ -40,7 +40,7 @@ class SignOutUseCaseImpl @Inject constructor(
                         socketWithAccountProvider.get(account.accountId)?.disconnect()
                     }
                 }
-                Account.InstanceType.MASTODON -> {}
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {}
             }
         }.mapCancellableCatching {
             accountStore.initialize()

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/account/converter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/account/converter.kt
@@ -27,6 +27,19 @@ fun AccessToken.Mastodon.newAccount(
     )
 }
 
+fun AccessToken.Pleroma.newAccount(
+    instanceDomain: String
+): Account {
+    return Account(
+        remoteId = this.account.id,
+        userName = this.account.username,
+        instanceDomain = instanceDomain,
+        token = accessToken,
+        instanceType = Account.InstanceType.PLEROMA,
+        pages = emptyList()
+    )
+}
+
 fun AccessToken.MisskeyIdAndPassword.newAccount(instanceDomain: String): Account {
     return this.user.newAccount(
         instanceDomain,
@@ -43,6 +56,9 @@ fun AccessToken.newAccount(instanceDomain: String): Account {
             this.newAccount(instanceDomain)
         }
         is AccessToken.MisskeyIdAndPassword -> {
+            this.newAccount(instanceDomain)
+        }
+        is AccessToken.Pleroma -> {
             this.newAccount(instanceDomain)
         }
     }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/account/db/AccountRecord.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/account/db/AccountRecord.kt
@@ -111,6 +111,7 @@ class AccountInstanceTypeConverter {
         return when (type) {
             Account.InstanceType.MISSKEY -> "misskey"
             Account.InstanceType.MASTODON -> "mastodon"
+            Account.InstanceType.PLEROMA -> "pleroma"
         }
     }
 
@@ -120,6 +121,7 @@ class AccountInstanceTypeConverter {
         return when (type) {
             "misskey" -> Account.InstanceType.MISSKEY
             "mastodon" -> Account.InstanceType.MASTODON
+            "pleroma" -> Account.InstanceType.PLEROMA
             else -> throw IllegalArgumentException("未知のアカウント種別です")
         }
     }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/ap/ApResolverRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/ap/ApResolverRepositoryImpl.kt
@@ -53,7 +53,7 @@ class ApResolverRepositoryImpl @Inject constructor(
                         }
                     }
                 }
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     val body = mastodonAPIProvider.get(account).search(
                         q = uri,
                         resolve = true

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/auth/Authorization.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/auth/Authorization.kt
@@ -43,6 +43,16 @@ sealed interface Authorization {
             }
         }
 
+        data class Pleroma(
+            override val instanceBaseURL: String,
+            val client: AppType.Pleroma,
+            val scope: String
+        ) : Waiting4UserAuthorization {
+            override fun generateAuthUrl(): String {
+                return client.generateAuthUrl(instanceBaseURL, scope)
+            }
+        }
+
     }
 
 
@@ -72,6 +82,13 @@ fun Authorization.Waiting4UserAuthorization.Companion.from(state: TemporarilyAut
                 session = state.session,
                 instanceBaseURL = state.instanceDomain,
                 viaName = state.viaName
+            )
+        }
+        is TemporarilyAuthState.Pleroma -> {
+            Authorization.Waiting4UserAuthorization.Pleroma(
+                client = state.app,
+                instanceBaseURL = state.instanceDomain,
+                scope = state.scope
             )
         }
     }

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/auth/custom/AccessToken.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/auth/custom/AccessToken.kt
@@ -27,6 +27,14 @@ sealed interface AccessToken {
         val createdAt: Long,
         val account: MastodonAccountDTO
     ) : AccessToken
+
+    data class Pleroma(
+        override val accessToken: String,
+        val tokenType: String,
+        val scope: String,
+        val createdAt: Long,
+        val account: MastodonAccountDTO
+    ) : AccessToken
 }
 
 
@@ -40,6 +48,16 @@ fun MisskeyAccessToken.toModel(appSecret: String) : AccessToken.Misskey {
 
 fun MastodonAccessToken.toModel(account: MastodonAccountDTO) : AccessToken.Mastodon {
     return AccessToken.Mastodon(
+        accessToken = accessToken,
+        tokenType = tokenType,
+        createdAt = createdAt,
+        scope = scope,
+        account = account
+    )
+}
+
+fun MastodonAccessToken.toPleromaModel(account: MastodonAccountDTO): AccessToken.Pleroma {
+    return AccessToken.Pleroma(
         accessToken = accessToken,
         tokenType = tokenType,
         createdAt = createdAt,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/auth/custom/CustomAuthBridge.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/auth/custom/CustomAuthBridge.kt
@@ -23,6 +23,13 @@ sealed interface TemporarilyAuthState {
         val scope: String,
 
     ) : TemporarilyAuthState
+
+    data class Pleroma(
+        override val instanceDomain: String,
+        override val enabledDateEnd: Date,
+        val app: AppType.Pleroma,
+        val scope: String,
+    ) : TemporarilyAuthState
 }
 
 fun AppType.Misskey.createAuth(instanceDomain: String, session: Session, timeLimit: Date = Date(System.currentTimeMillis() + 3600 * 1000)): TemporarilyAuthState.Misskey {
@@ -38,6 +45,15 @@ fun AppType.Misskey.createAuth(instanceDomain: String, session: Session, timeLim
 
 fun AppType.Mastodon.createAuth(instanceDomain: String, scope: String, timeLimit: Date = Date(System.currentTimeMillis() + 3600 * 1000)): TemporarilyAuthState.Mastodon {
     return TemporarilyAuthState.Mastodon(
+        scope = scope,
+        instanceDomain = instanceDomain,
+        enabledDateEnd = timeLimit,
+        app = this
+    )
+}
+
+fun AppType.Pleroma.createAuth(instanceDomain: String, scope: String, timeLimit: Date = Date(System.currentTimeMillis() + 3600 * 1000)): TemporarilyAuthState.Pleroma {
+    return TemporarilyAuthState.Pleroma(
         scope = scope,
         instanceDomain = instanceDomain,
         enabledDateEnd = timeLimit,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/auth/custom/CustomAuthStore.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/auth/custom/CustomAuthStore.kt
@@ -63,6 +63,20 @@ class CustomAuthStore(private val sharedPreferences: SharedPreferences){
                     apply()
                 }
             }
+            is TemporarilyAuthState.Pleroma -> {
+                sharedPreferences.edit().apply {
+                    putString(MASTODON_SCOPE, customAuthBridge.scope)
+                    putString(INSTANCE_DOMAIN, customAuthBridge.instanceDomain)
+                    putString(REDIRECT_URI, customAuthBridge.app.redirectUri)
+
+                    putLong(ENABLED_DATE_END, customAuthBridge.enabledDateEnd.time)
+                    putString(MASTODON_APP_CLIENT_ID, customAuthBridge.app.clientId)
+                    putString(MASTODON_APP_CLIENT_SECRET, customAuthBridge.app.clientSecret)
+                    putString(MASTODON_APP_ID, customAuthBridge.app.id)
+                    putString(MASTODON_APP_NAME, customAuthBridge.app.name)
+                    putString(TYPE, "pleroma")
+                }.apply()
+            }
         }
 
 
@@ -96,6 +110,20 @@ class CustomAuthStore(private val sharedPreferences: SharedPreferences){
                 "mastodon" -> {
                     TemporarilyAuthState.Mastodon(
                         app = AppType.Mastodon(
+                            clientId = it.getString(MASTODON_APP_CLIENT_ID, null)?: return null,
+                            clientSecret = it.getString(MASTODON_APP_CLIENT_SECRET, null)?: return null,
+                            redirectUri = it.getString(REDIRECT_URI, null)?: return null,
+                            id = it.getString(MASTODON_APP_ID, null)?: return null,
+                            name = it.getString(MASTODON_APP_NAME, null)?: return null,
+                        ),
+                        instanceDomain = instanceDomain,
+                        enabledDateEnd = enabledDate,
+                        scope = it.getString(MASTODON_SCOPE, null)?: return null
+                    )
+                }
+                "pleroma" -> {
+                    TemporarilyAuthState.Pleroma(
+                        app = AppType.Pleroma(
                             clientId = it.getString(MASTODON_APP_CLIENT_ID, null)?: return null,
                             clientSecret = it.getString(MASTODON_APP_CLIENT_SECRET, null)?: return null,
                             redirectUri = it.getString(REDIRECT_URI, null)?: return null,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/uploaders.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/uploaders.kt
@@ -72,7 +72,7 @@ class OkHttpFileUploaderProvider(
                         instances[account.accountId]
                             ?: throw IllegalStateException("生成したはずのインスタンスが消滅しました！！")
                     }
-                    Account.InstanceType.MASTODON -> {
+                    Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                         map[account.accountId] = MastodonOkHttpFileUploader(
                             context,
                             account,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/emoji/CustomEmojiApiAdapter.kt
@@ -32,6 +32,14 @@ internal class CustomEmojiApiAdapterImpl @Inject constructor(
                     it.toEmoji()
                 }
             }
+            is NodeInfo.SoftwareType.Pleroma -> {
+                val emojis = mastodonAPIProvider.get("https://${nodeInfo.host}").getCustomEmojis()
+                    .throwIfHasError()
+                    .body()
+                emojis?.map {
+                    it.toEmoji()
+                }
+            }
             is NodeInfo.SoftwareType.Misskey -> {
                 if (
                     nodeInfo.type.getVersion() >= Version("13")

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/list/UserListRepositoryWebAPIImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/list/UserListRepositoryWebAPIImpl.kt
@@ -48,7 +48,7 @@ class UserListRepositoryWebAPIImpl @Inject constructor(
                         it.toEntity(account)
                     }
                 }
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     val body = mastodonAPIProvider.get(account).getMyLists()
                         .throwIfHasError()
                         .body()
@@ -142,7 +142,7 @@ class UserListRepositoryWebAPIImpl @Inject constructor(
                         .throwIfHasError()
                     res.body()!!.toEntity(account)
                 }
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     val res = mastodonAPIProvider.get(account).getList(userListId.userListId)
                         .throwIfHasError()
                     requireNotNull(res.body()).toModel(account)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/markers/MarkerRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/markers/MarkerRepositoryImpl.kt
@@ -31,7 +31,7 @@ class MarkerRepositoryImpl @Inject constructor(
             val account = accountRepository.get(accountId).getOrThrow()
             when(account.instanceType) {
                 Account.InstanceType.MISSKEY -> throw IllegalArgumentException("Not support markers feature when use misskey.")
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     val body = mastodonAPIProvider.get(account).getMarkers(types.map {
                         it.name.lowercase()
                     }).throwIfHasError().body()
@@ -51,7 +51,7 @@ class MarkerRepositoryImpl @Inject constructor(
             val account = accountRepository.get(accountId).getOrThrow()
             when(account.instanceType) {
                 Account.InstanceType.MISSKEY -> throw IllegalArgumentException("Not support markers feature when use misskey.")
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     val body = mastodonAPIProvider.get(account).saveMarkers(
                         markers = SaveMarkersRequest(
                             home = params.home?.let {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/FavoriteNoteTimelinePagingStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/FavoriteNoteTimelinePagingStoreImpl.kt
@@ -94,7 +94,7 @@ internal class FavoriteNoteTimelinePagingStoreImpl(
                         FavoriteType.Misskey(it)
                     }
                 }
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     // NOTE: ページが末端であるかをチェックしている
                     if (getSinceId() == null && !isEmpty()) {
                         return@runCancellableCatching emptyList()
@@ -125,7 +125,7 @@ internal class FavoriteNoteTimelinePagingStoreImpl(
                         FavoriteType.Misskey(it)
                     }
                 }
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     // NOTE: ページが末端であるかをチェックしている
                     if (getUntilId() == null && !isEmpty()) {
                         return@runCancellableCatching emptyList()

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteCaptureAPIAdapterImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/NoteCaptureAPIAdapterImpl.kt
@@ -128,7 +128,7 @@ class NoteCaptureAPIAdapterImpl(
                             }.launchIn(coroutineScope)
                         noteIdWithJob[id] = job
                     }
-                    Account.InstanceType.MASTODON -> {
+                    Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                         val job = requireNotNull(streamingAPIProvider.get(account)).connectUser().catch { e ->
                             logger.error("ノート更新イベント受信中にエラー発生", e = e)
                         }.onEach {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/bookmark/BookmarkRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/bookmark/BookmarkRepositoryImpl.kt
@@ -29,7 +29,7 @@ class BookmarkRepositoryImpl @Inject constructor(
             val account = accountRepository.get(noteId.accountId).getOrThrow()
             when(account.instanceType) {
                 Account.InstanceType.MISSKEY -> favoriteRepository.create(noteId).getOrThrow()
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     val body = mastodonAPIProvider.get(account).bookmarkStatus(noteId.noteId)
                         .throwIfHasError()
                         .body()
@@ -44,7 +44,7 @@ class BookmarkRepositoryImpl @Inject constructor(
             val account = accountRepository.get(noteId.accountId).getOrThrow()
             when(account.instanceType) {
                 Account.InstanceType.MISSKEY -> favoriteRepository.delete(noteId).getOrThrow()
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     val body = mastodonAPIProvider.get(account).unbookmarkStatus(noteId.noteId)
                         .throwIfHasError()
                         .body()

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/favorite/FavoriteAPIAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/favorite/FavoriteAPIAdapter.kt
@@ -27,7 +27,7 @@ class FavoriteAPIAdapter @Inject constructor(
                     .throwIfHasError()
                 SuccessfulResponseData.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val status = mastodonAPIProvider.get(account).favouriteStatus(noteId.noteId)
                     .throwIfHasError()
                     .body()
@@ -44,7 +44,7 @@ class FavoriteAPIAdapter @Inject constructor(
                     .throwIfHasError()
                 SuccessfulResponseData.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val status = mastodonAPIProvider.get(account).unfavouriteStatus(noteId.noteId)
                     .throwIfHasError()
                     .body()

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteApiAdapter.kt
@@ -61,7 +61,7 @@ class NoteApiAdapter @Inject constructor(
                 val noteDTO = result.getOrThrow()
                 NoteResultType.Misskey(requireNotNull(noteDTO))
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val fileIds = coroutineScope {
                     createNote.files?.map { appFile ->
                         async {
@@ -113,7 +113,7 @@ class NoteApiAdapter @Inject constructor(
                 ).throwIfHasError().body()
                 NoteResultType.Misskey(requireNotNull(body))
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val body = mastodonAPIProvider.get(account)
                     .getStatus(noteId.noteId)
                     .throwIfHasError().body()
@@ -134,7 +134,7 @@ class NoteApiAdapter @Inject constructor(
                 ).throwIfHasError()
                 DeleteNoteResultType.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val body = mastodonAPIProvider.get(account).deleteStatus(noteId.noteId)
                     .throwIfHasError()
                     .body()
@@ -155,7 +155,7 @@ class NoteApiAdapter @Inject constructor(
                 ).throwIfHasError()
                 ToggleThreadMuteResultType.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val body = mastodonAPIProvider.get(account)
                     .muteConversation(noteId.noteId)
                     .throwIfHasError()
@@ -177,7 +177,7 @@ class NoteApiAdapter @Inject constructor(
                 ).throwIfHasError()
                 ToggleThreadMuteResultType.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val body = mastodonAPIProvider.get(account).unmuteConversation(noteId.noteId)
                     .throwIfHasError()
                     .body()

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -52,7 +52,7 @@ class NoteRepositoryImpl @Inject constructor(
                         visibility = n.visibility
                     )).getOrThrow()
                 }
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     val toot = mastodonAPIProvider.get(account).reblog(noteId.noteId)
                         .throwIfHasError()
                         .body()
@@ -67,7 +67,7 @@ class NoteRepositoryImpl @Inject constructor(
             val account = getAccount.get(noteId.accountId)
             when(account.instanceType) {
                 Account.InstanceType.MISSKEY -> delete(noteId).getOrThrow()
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     val res = mastodonAPIProvider.get(account).unreblog(noteId.noteId)
                         .throwIfHasError()
                         .body()
@@ -216,7 +216,7 @@ class NoteRepositoryImpl @Inject constructor(
                         noteDataSourceAdder.addNoteDtoToDataSource(account, it)
                     }
                 }
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     val body = mastodonAPIProvider.get(account).getStatusesContext(noteId.noteId)
                         .throwIfHasError()
                         .body()
@@ -247,7 +247,7 @@ class NoteRepositoryImpl @Inject constructor(
                         noteDataSourceAdder.addNoteDtoToDataSource(account, it)
                     }
                 }
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     val body = mastodonAPIProvider.get(account).getStatusesContext(noteId.noteId)
                         .throwIfHasError()
                         .body()
@@ -314,7 +314,7 @@ class NoteRepositoryImpl @Inject constructor(
                         )
                     }
                 }
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     find(noteId).mapCancellableCatching {
                         NoteState(
                             isFavorited = (it.type as Note.Type.Mastodon).favorited ?: false,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/ReactionRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/reaction/impl/ReactionRepositoryImpl.kt
@@ -55,7 +55,7 @@ class ReactionRepositoryImpl @Inject constructor(
                                 noteDataSource.add(note.onIReacted(createReaction.reaction))
                             }
                         }
-                        Account.InstanceType.MASTODON -> {
+                        Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                             if (nodeInfoRepository.find(account.getHost())
                                     .getOrThrow().type !is NodeInfo.SoftwareType.Mastodon.Fedibird
                             ) {
@@ -98,7 +98,7 @@ class ReactionRepositoryImpl @Inject constructor(
                                 && noteDataSource.add(note.onIUnReacted())
                             .getOrThrow() != AddResult.Canceled))
                     }
-                    Account.InstanceType.MASTODON -> {
+                    Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                         if (nodeInfoRepository.find(account.getHost())
                                 .getOrThrow().type !is NodeInfo.SoftwareType.Mastodon.Fedibird
                         ) {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notification/impl/NotificationRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notification/impl/NotificationRepositoryImpl.kt
@@ -6,14 +6,12 @@ import net.pantasystem.milktea.api_streaming.Send
 import net.pantasystem.milktea.api_streaming.toJson
 import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.common.throwIfHasError
-import net.pantasystem.milktea.data.api.mastodon.MastodonAPIProvider
 import net.pantasystem.milktea.data.api.misskey.MisskeyAPIProvider
 import net.pantasystem.milktea.data.infrastructure.notification.db.UnreadNotificationDAO
 import net.pantasystem.milktea.data.streaming.SocketWithAccountProvider
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.markers.MarkerRepository
-import net.pantasystem.milktea.model.markers.Markers
 import net.pantasystem.milktea.model.markers.SaveMarkerParams
 import net.pantasystem.milktea.model.notification.Notification
 import net.pantasystem.milktea.model.notification.NotificationDataSource
@@ -40,7 +38,7 @@ class NotificationRepositoryImpl @Inject constructor(
                     )
                 ).throwIfHasError()
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val latest = unreadNotificationDAO.getLatestUnreadId(accountId)
                     ?: return@runCancellableCatching
                 markerRepository.save(

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notification/impl/NotificationStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notification/impl/NotificationStoreImpl.kt
@@ -62,7 +62,7 @@ class NotificationStoreImpl(
                     misskeyAPIProvider = misskeyAPIProvider,
                 )
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 MstNotificationEntityLoader(
                     account = account,
                     mastodonAPIProvider = mastodonAPIProvider,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notification/impl/NotificationStreamingImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notification/impl/NotificationStreamingImpl.kt
@@ -57,7 +57,7 @@ class NotificationStreamingImpl @Inject constructor(
                         notificationCacheAdder.addAndConvert(account, it.body)
                     }
                 }
-                Account.InstanceType.MASTODON -> requireNotNull(streamingAPIProvider.get(account)).connectUser()
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> requireNotNull(streamingAPIProvider.get(account)).connectUser()
                     .mapNotNull {
                         (it as? Event.Notification)?.notification
                     }.mapNotNull {

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/report/ReportRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/report/ReportRepositoryImpl.kt
@@ -38,7 +38,7 @@ internal class ReportRepositoryImpl @Inject constructor(
                     )
                     res.throwIfHasError()
                 }
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     mastodonAPIProvider.get(account).createReport(
                         CreateReportRequest(
                             accountId = report.userId.id,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/FollowFollowerPagingModel.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/FollowFollowerPagingModel.kt
@@ -189,7 +189,7 @@ class FollowFollowerPagingModelImpl(
                         else -> throw IllegalStateException("not support follow follower list")
                     }
                 }
-                Account.InstanceType.MASTODON -> {
+                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     MastodonLoader(
                         requestType,
                         account,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/FollowRequestApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/FollowRequestApiAdapter.kt
@@ -37,7 +37,7 @@ class FollowRequestApiAdapter @Inject constructor(
                     ).throwIfHasError()
                 FollowRequestResult.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val body = mastodonAPIProvider.get(account).acceptFollowRequest(userId.id)
                     .throwIfHasError()
                     .body()
@@ -58,7 +58,7 @@ class FollowRequestApiAdapter @Inject constructor(
                 ).throwIfHasError()
                 FollowRequestResult.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val body = mastodonAPIProvider.get(account).rejectFollowRequest(userId.id)
                     .throwIfHasError()
                     .body()
@@ -82,7 +82,7 @@ class FollowRequestApiAdapter @Inject constructor(
                     requireNotNull(body)
                 )
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val res = mastodonAPIProvider.get(account).getFollowRequests(
                     maxId = untilId,
                     minId = sinceId,

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/UserApiAdapter.kt
@@ -52,7 +52,7 @@ internal class UserApiAdapterImpl @Inject constructor(
                     detail
                 )
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val res = mastodonAPIProvider.get(account).getAccount(userId.id)
                     .throwIfHasError()
                     .body()
@@ -93,7 +93,7 @@ internal class UserApiAdapterImpl @Inject constructor(
                 )
                 SearchResult.Misskey(body)
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val body = requireNotNull(
                     mastodonAPIProvider.get(account).search(
                         if (host == null) userName else "$userName@$host"

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/block/BlockApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/block/BlockApiAdapter.kt
@@ -34,7 +34,7 @@ class BlockApiAdapterImpl @Inject constructor(
                     .throwIfHasError()
                 UserActionResult.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val body = mastodonAPIProvider.get(account).blockAccount(userId.id)
                     .throwIfHasError()
                     .body()
@@ -56,7 +56,7 @@ class BlockApiAdapterImpl @Inject constructor(
                     .throwIfHasError()
                 UserActionResult.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val body = mastodonAPIProvider.get(account).unblockAccount(userId.id)
                     .throwIfHasError()
                     .body()

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/follow/FollowApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/follow/FollowApiAdapter.kt
@@ -35,7 +35,7 @@ internal class FollowApiAdapterImpl @Inject constructor(
                 ).throwIfHasError()
                 UserActionResult.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 mastodonAPIProvider.get(account).follow(userId.id)
                     .throwIfHasError().body().let {
                         UserActionResult.Mastodon(requireNotNull(it))
@@ -54,7 +54,7 @@ internal class FollowApiAdapterImpl @Inject constructor(
                     .body()
                 UserActionResult.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 mastodonAPIProvider.get(account).unfollow(userId.id)
                     .throwIfHasError()
                     .body().let {
@@ -77,7 +77,7 @@ internal class FollowApiAdapterImpl @Inject constructor(
                 ).throwIfHasError()
                 UserActionResult.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 mastodonAPIProvider.get(account).unfollow(userId.id).throwIfHasError()
                     .body().let {
                         UserActionResult.Mastodon(requireNotNull(it))

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/mute/MuteApiAdapter.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/user/mute/MuteApiAdapter.kt
@@ -41,7 +41,7 @@ internal class MuteApiAdapterImpl @Inject constructor(
                 ).throwIfHasError()
                 UserActionResult.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val body = mastodonAPIProvider.get(account).muteAccount(
                     createMute.userId.id,
                     MuteAccountRequest(
@@ -68,7 +68,7 @@ internal class MuteApiAdapterImpl @Inject constructor(
                 ).throwIfHasError()
                 UserActionResult.Misskey
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 val body = mastodonAPIProvider.get(account).unmuteAccount(userId.id)
                     .throwIfHasError()
                     .body()

--- a/modules/features/account/src/main/java/net/pantasystem/milktea/account/AccountTabViewModel.kt
+++ b/modules/features/account/src/main/java/net/pantasystem/milktea/account/AccountTabViewModel.kt
@@ -42,7 +42,7 @@ class AccountTabViewModel @Inject constructor(
                     AccountTabTypes.Reactions(userId),
                 )
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 listOf(
                     AccountTabTypes.Account,
                     AccountTabTypes.MastodonUserTimeline(userId),

--- a/modules/features/auth/src/main/java/net/pantasystem/milktea/auth/viewmodel/app/AppAuthViewModel.kt
+++ b/modules/features/auth/src/main/java/net/pantasystem/milktea/auth/viewmodel/app/AppAuthViewModel.kt
@@ -162,6 +162,7 @@ class AppAuthViewModel @Inject constructor(
                 is StateContent.Exist -> {
                     val instanceBase = when (val info = meta.rawContent) {
                         is InstanceType.Mastodon -> "https://${info.instance.uri}"
+                        is InstanceType.Pleroma -> info.instance.uri
                         is InstanceType.Misskey -> info.instance.uri
                     }
                     logger.debug { "instanceBaseUrl: $instanceBase" }
@@ -178,6 +179,8 @@ class AppAuthViewModel @Inject constructor(
                 is StateContent.NotExist -> throw IllegalStateException()
             }
         }.asLoadingStateFlow()
+    }.catch {
+        logger.error("アプリの作成に失敗", it)
     }.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(5_000),

--- a/modules/features/auth/src/main/java/net/pantasystem/milktea/auth/viewmodel/app/UIState.kt
+++ b/modules/features/auth/src/main/java/net/pantasystem/milktea/auth/viewmodel/app/UIState.kt
@@ -56,6 +56,11 @@ sealed interface InstanceType {
         val instance: Meta,
         override val softwareType: NodeInfo.SoftwareType.Misskey?,
     ) : InstanceType
+
+    data class Pleroma(
+        val instance: MastodonInstanceInfo,
+        override val softwareType: NodeInfo.SoftwareType?
+    ) : InstanceType
 }
 
 sealed interface GenerateTokenResult {

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageSettingViewModel.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageSettingViewModel.kt
@@ -79,7 +79,7 @@ class PageSettingViewModel @Inject constructor(
                     emptyList()
                 }
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 listOf(
                     PageType.MASTODON_HOME_TIMELINE,
                     PageType.MASTODON_LOCAL_TIMELINE,

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
@@ -136,7 +136,7 @@ class UserDetailViewModel @AssistedInject constructor(
                     if (isPublicReaction) UserDetailTabType.Reactions(user.id) else null,
                 )
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 listOf(
                     UserDetailTabType.MastodonUserTimeline(user.id),
                     UserDetailTabType.MastodonUserTimelineWithReplies(user.id),

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/Account.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/Account.kt
@@ -17,7 +17,7 @@ data class Account(
 ) : Serializable {
 
     enum class InstanceType {
-        MISSKEY, MASTODON
+        MISSKEY, MASTODON, PLEROMA
     }
 
     constructor(

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/MakeDefaultPagesUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/MakeDefaultPagesUseCase.kt
@@ -64,7 +64,7 @@ class MakeDefaultPagesUseCase(
                 }
                 defaultPages
             }
-            Account.InstanceType.MASTODON -> {
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 listOf(
                     PageableTemplate(account).mastodonHomeTimeline(pageDefaultStrings.homeTimeline),
                     PageableTemplate(account).mastodonLocalTimeline(pageDefaultStrings.localTimeline),

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/app/AppType.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/app/AppType.kt
@@ -12,7 +12,7 @@ sealed interface AppType {
         override val callbackUrl: String?,
         val isAuthorized: Boolean? = null,
         val permission: List<String> = emptyList(),
-        override val secret: String? = null
+        override val secret: String? = null,
     ) : AppType
 
     companion object;
@@ -28,6 +28,24 @@ sealed interface AppType {
         val clientSecret: String,
 
         ) : AppType {
+        override val callbackUrl: String
+            get() = redirectUri
+        override val secret: String
+            get() = clientSecret
+
+        companion object
+    }
+
+    data class Pleroma(
+        val id: String,
+        override val name: String,
+
+        val clientId: String,
+
+        val redirectUri: String,
+
+        val clientSecret: String,
+    ) : AppType {
         override val callbackUrl: String
             get() = redirectUri
         override val secret: String

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/file/UpdateAppFileSensitiveUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/file/UpdateAppFileSensitiveUseCase.kt
@@ -33,7 +33,7 @@ class UpdateAppFileSensitiveUseCase @Inject constructor(
                         )
                         AppFile.Remote(fileProperty.id)
                     }
-                    Account.InstanceType.MASTODON -> {
+                    Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                         val fileProperty = filePropertyDataSource.find(appFile.id).getOrThrow()
                         filePropertyDataSource.add(
                             fileProperty.copy(

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/instance/InstanceInfoService.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/instance/InstanceInfoService.kt
@@ -32,6 +32,11 @@ open class InstanceInfoService @Inject constructor(
                         metaRepository.find(instanceDomain).getOrThrow()
                     )
                 }
+                is NodeInfo.SoftwareType.Pleroma -> {
+                    InstanceInfoType.Pleroma(
+                        mastodonInstanceInfoRepository.find(instanceDomain).getOrThrow()
+                    )
+                }
                 is NodeInfo.SoftwareType.Other -> throw NoSuchElementException()
             }
         }
@@ -47,6 +52,10 @@ open class InstanceInfoService @Inject constructor(
                 is NodeInfo.SoftwareType.Misskey -> {
                     metaRepository.sync(instanceDomain)
                     customEmojiRepository.sync(it.host).getOrThrow()
+                }
+                is NodeInfo.SoftwareType.Pleroma -> {
+                    mastodonInstanceInfoRepository.sync(instanceDomain).getOrThrow()
+                    customEmojiRepository.sync(it.host)
                 }
                 is NodeInfo.SoftwareType.Other -> throw NoSuchElementException()
             }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/instance/InstanceInfoType.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/instance/InstanceInfoType.kt
@@ -4,9 +4,12 @@ sealed interface InstanceInfoType {
     data class Misskey(val meta: Meta) : InstanceInfoType
     data class Mastodon(val info: MastodonInstanceInfo) : InstanceInfoType
 
+    data class Pleroma(val info: MastodonInstanceInfo) : InstanceInfoType
+
     val iconUrl: String? get() {
         return when(this) {
             is Mastodon -> "https://${info.uri}/favicon.ico"
+            is Pleroma -> "https://${info.uri}/favicon.ico"
             is Misskey -> meta.iconUrl
         }
     }
@@ -14,6 +17,7 @@ sealed interface InstanceInfoType {
     val uri: String get() {
         return when(this) {
             is Mastodon -> "https://${info.uri}"
+            is Pleroma -> "https://${info.uri}"
             is Misskey -> meta.uri
         }
     }
@@ -21,6 +25,7 @@ sealed interface InstanceInfoType {
     val maxNoteTextLength: Int get() {
         return when(this) {
             is Mastodon -> info.configuration?.statuses?.maxCharacters ?: 500
+            is Pleroma -> info.configuration?.statuses?.maxCharacters ?: 500
             is Misskey -> meta.maxNoteTextLength ?: 3000
         }
     }
@@ -28,6 +33,7 @@ sealed interface InstanceInfoType {
     val maxFileCount: Int get() {
         return when(this) {
             is Mastodon -> info.configuration?.statuses?.maxMediaAttachments ?: 4
+            is Pleroma -> info.configuration?.statuses?.maxMediaAttachments ?: 4
             is Misskey -> if (meta.getVersion() >= Version("12.100.2")) {
                 16
             } else {
@@ -37,8 +43,10 @@ sealed interface InstanceInfoType {
     }
 
     val maxReactionsPerAccount: Int get() {
+        // TODO: Pleromaの場合はリアクション可能な件数の判定方法が異なるのであとで修正する
         return when(this) {
             is Mastodon -> info.configuration?.emojiReactions?.maxReactionsPerAccount ?: 0
+            is Pleroma -> info.configuration?.emojiReactions?.maxReactionsPerAccount ?: 0
             is Misskey -> 1
         }
     }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/list/UserListTabToggleAddToTabUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/list/UserListTabToggleAddToTabUseCase.kt
@@ -35,7 +35,7 @@ class UserListTabToggleAddToTabUseCase @Inject constructor(
                         Account.InstanceType.MISSKEY -> Pageable.UserListTimeline(
                             listId.userListId
                         )
-                        Account.InstanceType.MASTODON -> Pageable.Mastodon.ListTimeline(
+                        Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> Pageable.Mastodon.ListTimeline(
                             listId.userListId
                         )
                     }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/nodeinfo/NodeInfo.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/nodeinfo/NodeInfo.kt
@@ -52,6 +52,17 @@ data class NodeInfo(
 
         }
 
+        sealed interface Pleroma : SoftwareType {
+            data class Normal(
+                override val name: String,
+                override val version: String
+            ) : Pleroma
+
+            data class Akkoma(
+                override val name: String,
+                override val version: String
+            ) : Pleroma
+        }
         data class Other(
             override val version: String,
             override val name: String
@@ -65,6 +76,8 @@ data class NodeInfo(
         "fedibird" -> SoftwareType.Mastodon.Fedibird(version = software.version, name = software.name)
         "meisskey" -> SoftwareType.Misskey.Meisskey(version = software.version, name = software.name)
         "foundkey" -> SoftwareType.Misskey.Foundkey(version = software.version, name = software.name)
+        "pleroma" -> SoftwareType.Pleroma.Normal(version = software.version, name = software.name)
+        "akkoma" -> SoftwareType.Pleroma.Akkoma(version = software.version, name = software.name)
         else -> SoftwareType.Other(version = software.version, name = software.name)
     }
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/notes/reaction/ToggleReactionUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/notes/reaction/ToggleReactionUseCase.kt
@@ -103,6 +103,15 @@ class ToggleReactionUseCase @Inject constructor(
 
                     reactionObj.getNameAndHost()
                 }
+                is InstanceInfoType.Pleroma -> {
+                    val maxCount = instanceType.maxReactionsPerAccount
+                    if (maxCount < 1) {
+                        return null
+                    }
+
+                    // TODO: ユニコード絵文字の場合コロンは不要かもしれない
+                    ":${reactionObj.getNameAndHost()}:"
+                }
                 is InstanceInfoType.Misskey -> {
                     val name = reactionObj.getName()
                         ?: return null


### PR DESCRIPTION
## やったこと
アカウントの種別に新たにPleromaを追加し
認証のロジックにPleroma用の処理を追加しました。
またMastodonと互換性があるのでAPIの処理の分岐はMastodonとして処理をするようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
#1591



