### PR TITLE
Calckeyでリプライを表示することができない不具合を修正

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
@@ -153,7 +153,7 @@ interface MisskeyAPI {
     suspend fun showNote(@Body requestNote: NoteRequest): Response<NoteDTO>
 
     @POST("api/notes/children")
-    suspend fun children(@Body noteRequest: NoteRequest): Response<List<NoteDTO>>
+    suspend fun children(@Body req: GetNoteChildrenRequest): Response<List<NoteDTO>>
 
     @POST("api/notes/conversation")
     suspend fun conversation(@Body noteRequest: NoteRequest): Response<List<NoteDTO>>

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/GetNoteChildrenRequest.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/notes/GetNoteChildrenRequest.kt
@@ -1,0 +1,11 @@
+package net.pantasystem.milktea.api.misskey.notes
+
+import kotlinx.serialization.SerialName
+
+@kotlinx.serialization.Serializable
+data class GetNoteChildrenRequest(
+    @SerialName("i") val i: String,
+    @SerialName("noteId") val noteId: String,
+    @SerialName("limit") val limit: Int,
+    @SerialName("depth") val depth: Int,
+)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/impl/NoteRepositoryImpl.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
+import net.pantasystem.milktea.api.misskey.notes.GetNoteChildrenRequest
 import net.pantasystem.milktea.api.misskey.notes.NoteDTO
 import net.pantasystem.milktea.api.misskey.notes.NoteRequest
 import net.pantasystem.milktea.common.*
@@ -33,7 +34,7 @@ class NoteRepositoryImpl @Inject constructor(
     val getAccount: GetAccount,
     private val noteApiAdapter: NoteApiAdapter,
     private val noteThreadRecordDAO: NoteThreadRecordDAO,
-    @IODispatcher private val ioDispatcher: CoroutineDispatcher
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : NoteRepository {
 
     private val logger = loggerFactory.create("NoteRepositoryImpl")
@@ -45,23 +46,28 @@ class NoteRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun renote(noteId: Note.Id): Result<Note> = runCancellableCatching{
+    override suspend fun renote(noteId: Note.Id): Result<Note> = runCancellableCatching {
         withContext(ioDispatcher) {
             val account = getAccount.get(noteId.accountId)
-            when(account.instanceType) {
+            when (account.instanceType) {
                 Account.InstanceType.MISSKEY -> {
                     val n = find(noteId).getOrThrow()
-                    create(CreateNote(
-                        author = account, renoteId = noteId,
-                        text = null,
-                        visibility = n.visibility
-                    )).getOrThrow()
+                    create(
+                        CreateNote(
+                            author = account, renoteId = noteId,
+                            text = null,
+                            visibility = n.visibility
+                        )
+                    ).getOrThrow()
                 }
                 Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     val toot = mastodonAPIProvider.get(account).reblog(noteId.noteId)
                         .throwIfHasError()
                         .body()
-                    noteDataSourceAdder.addTootStatusDtoIntoDataSource(account, requireNotNull(toot))
+                    noteDataSourceAdder.addTootStatusDtoIntoDataSource(
+                        account,
+                        requireNotNull(toot)
+                    )
                 }
             }
         }
@@ -70,7 +76,7 @@ class NoteRepositoryImpl @Inject constructor(
     override suspend fun unrenote(noteId: Note.Id): Result<Unit> = runCancellableCatching {
         withContext(ioDispatcher) {
             val account = getAccount.get(noteId.accountId)
-            when(account.instanceType) {
+            when (account.instanceType) {
                 Account.InstanceType.MISSKEY -> delete(noteId).getOrThrow()
                 Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                     val res = mastodonAPIProvider.get(account).unreblog(noteId.noteId)
@@ -83,12 +89,15 @@ class NoteRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun delete(noteId: Note.Id): Result<Note> = runCancellableCatching{
+    override suspend fun delete(noteId: Note.Id): Result<Note> = runCancellableCatching {
         withContext(ioDispatcher) {
             val account = getAccount.get(noteId.accountId)
             val note = find(noteId).getOrThrow()
-            when(val result = noteApiAdapter.delete(noteId)) {
-                is DeleteNoteResultType.Mastodon -> noteDataSourceAdder.addTootStatusDtoIntoDataSource(account, result.status)
+            when (val result = noteApiAdapter.delete(noteId)) {
+                is DeleteNoteResultType.Mastodon -> noteDataSourceAdder.addTootStatusDtoIntoDataSource(
+                    account,
+                    result.status
+                )
                 DeleteNoteResultType.Misskey -> note
             }
         }
@@ -149,32 +158,31 @@ class NoteRepositoryImpl @Inject constructor(
     }
 
 
-    override suspend fun vote(noteId: Note.Id, choice: Poll.Choice): Result<Unit> = runCancellableCatching {
-        withContext(ioDispatcher) {
-            val account = getAccount.get(noteId.accountId)
-            val note = find(noteId).getOrThrow()
-            when(val type = note.type) {
-                is Note.Type.Mastodon -> {
-                    mastodonAPIProvider.get(account).voteOnPoll(
-                        requireNotNull(type.pollId),
-                        choices = listOf(choice.index)
-                    )
-                }
-                is Note.Type.Misskey -> {
-                    misskeyAPIProvider.get(account).vote(
-                        Vote(
-                            i = getAccount.get(noteId.accountId).token,
-                            choice = choice.index,
-                            noteId = noteId.noteId
+    override suspend fun vote(noteId: Note.Id, choice: Poll.Choice): Result<Unit> =
+        runCancellableCatching {
+            withContext(ioDispatcher) {
+                val account = getAccount.get(noteId.accountId)
+                val note = find(noteId).getOrThrow()
+                when (val type = note.type) {
+                    is Note.Type.Mastodon -> {
+                        mastodonAPIProvider.get(account).voteOnPoll(
+                            requireNotNull(type.pollId),
+                            choices = listOf(choice.index)
                         )
-                    ).throwIfHasError()
+                    }
+                    is Note.Type.Misskey -> {
+                        misskeyAPIProvider.get(account).vote(
+                            Vote(
+                                i = getAccount.get(noteId.accountId).token,
+                                choice = choice.index,
+                                noteId = noteId.noteId
+                            )
+                        ).throwIfHasError()
+                    }
                 }
+
             }
-
         }
-    }
-
-
 
 
     private suspend fun fetchIn(noteIds: List<Note.Id>) {
@@ -208,7 +216,7 @@ class NoteRepositoryImpl @Inject constructor(
     override suspend fun syncThreadContext(noteId: Note.Id): Result<Unit> = runCancellableCatching {
         withContext(ioDispatcher) {
             val account = getAccount.get(noteId.accountId)
-            when(account.instanceType) {
+            when (account.instanceType) {
                 Account.InstanceType.MISSKEY -> {
                     val ancestors = requireNotNull(
                         misskeyAPIProvider.get(account).conversation(
@@ -271,7 +279,7 @@ class NoteRepositoryImpl @Inject constructor(
     override suspend fun createThreadMute(noteId: Note.Id): Result<Unit> = runCancellableCatching {
         withContext(ioDispatcher) {
             val account = getAccount.get(noteId.accountId)
-            when(val result = noteApiAdapter.createThreadMute(noteId)) {
+            when (val result = noteApiAdapter.createThreadMute(noteId)) {
                 is ToggleThreadMuteResultType.Mastodon -> {
                     noteDataSourceAdder.addTootStatusDtoIntoDataSource(account, result.status)
                 }
@@ -283,7 +291,7 @@ class NoteRepositoryImpl @Inject constructor(
     override suspend fun deleteThreadMute(noteId: Note.Id): Result<Unit> = runCancellableCatching {
         withContext(ioDispatcher) {
             val account = getAccount.get(noteId.accountId)
-            when(val result = noteApiAdapter.deleteThreadMute(noteId)) {
+            when (val result = noteApiAdapter.deleteThreadMute(noteId)) {
                 is ToggleThreadMuteResultType.Mastodon -> {
                     noteDataSourceAdder.addTootStatusDtoIntoDataSource(account, result.status)
                 }
@@ -292,40 +300,41 @@ class NoteRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun findNoteState(noteId: Note.Id): Result<NoteState> = runCancellableCatching {
-        withContext(ioDispatcher) {
-            val account = getAccount.get(noteId.accountId)
-            when(account.instanceType) {
-                Account.InstanceType.MISSKEY -> {
-                    misskeyAPIProvider.get(account.normalizedInstanceUri).noteState(
-                        NoteRequest(
-                            i = account.token,
-                            noteId = noteId.noteId
-                        )
-                    ).throwIfHasError().body()!!.let {
-                        NoteState(
-                            isFavorited = it.isFavorited,
-                            isMutedThread = it.isMutedThread,
-                            isWatching = when(val watching = it.isWatching) {
-                                null -> NoteState.Watching.None
-                                else -> NoteState.Watching.Some(watching)
-                            }
-                        )
+    override suspend fun findNoteState(noteId: Note.Id): Result<NoteState> =
+        runCancellableCatching {
+            withContext(ioDispatcher) {
+                val account = getAccount.get(noteId.accountId)
+                when (account.instanceType) {
+                    Account.InstanceType.MISSKEY -> {
+                        misskeyAPIProvider.get(account.normalizedInstanceUri).noteState(
+                            NoteRequest(
+                                i = account.token,
+                                noteId = noteId.noteId
+                            )
+                        ).throwIfHasError().body()!!.let {
+                            NoteState(
+                                isFavorited = it.isFavorited,
+                                isMutedThread = it.isMutedThread,
+                                isWatching = when (val watching = it.isWatching) {
+                                    null -> NoteState.Watching.None
+                                    else -> NoteState.Watching.Some(watching)
+                                }
+                            )
+                        }
+                    }
+                    Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
+                        find(noteId).mapCancellableCatching {
+                            NoteState(
+                                isFavorited = (it.type as Note.Type.Mastodon).favorited ?: false,
+                                isMutedThread = (it.type as Note.Type.Mastodon).muted ?: false,
+                                isWatching = NoteState.Watching.None,
+                            )
+                        }.getOrThrow()
                     }
                 }
-                Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
-                    find(noteId).mapCancellableCatching {
-                        NoteState(
-                            isFavorited = (it.type as Note.Type.Mastodon).favorited ?: false,
-                            isMutedThread = (it.type as Note.Type.Mastodon).muted ?: false,
-                            isWatching = NoteState.Watching.None,
-                        )
-                    }.getOrThrow()
-                }
-            }
 
+            }
         }
-    }
 
     override fun observeIn(noteIds: List<Note.Id>): Flow<List<Note>> {
         return noteDataSource.observeIn(noteIds)
@@ -336,21 +345,36 @@ class NoteRepositoryImpl @Inject constructor(
     }
 
     private suspend fun convertAndAdd(account: Account, type: NoteResultType): Note {
-        return when(type) {
-            is NoteResultType.Mastodon -> noteDataSourceAdder.addTootStatusDtoIntoDataSource(account, type.status)
-            is NoteResultType.Misskey -> noteDataSourceAdder.addNoteDtoToDataSource(account, type.note)
+        return when (type) {
+            is NoteResultType.Mastodon -> noteDataSourceAdder.addTootStatusDtoIntoDataSource(
+                account,
+                type.status
+            )
+            is NoteResultType.Misskey -> noteDataSourceAdder.addNoteDtoToDataSource(
+                account,
+                type.note
+            )
         }
     }
 
     private suspend fun getMisskeyDescendants(targetNoteId: Note.Id): List<NoteDTO> {
         val account = getAccount.get(targetNoteId.accountId)
-        return requireNotNull(misskeyAPIProvider.get(account).children(NoteRequest(
-            i = account.token,
-            noteId = targetNoteId.noteId
-        )).throwIfHasError().body())
+        return requireNotNull(
+            misskeyAPIProvider.get(account).children(
+                GetNoteChildrenRequest(
+                    i = account.token,
+                    noteId = targetNoteId.noteId,
+                    limit = 30,
+                    depth = 2,
+                )
+            ).throwIfHasError().body()
+        )
     }
 
-    private suspend fun syncRecursiveThreadContext4Misskey(targetNoteId: Note.Id, appendTo: Note.Id) {
+    private suspend fun syncRecursiveThreadContext4Misskey(
+        targetNoteId: Note.Id,
+        appendTo: Note.Id,
+    ) {
         val account = getAccount.get(appendTo.accountId)
         val descendants = getMisskeyDescendants(targetNoteId).map {
             noteDataSourceAdder.addNoteDtoToDataSource(account, it)


### PR DESCRIPTION
## やったこと
Calckeyではdepthパラメーターの指定がないと
一切リプライを取得することができない仕様になっている。
なのでdepthパラメーターを与えてリクエストを送信するようにした

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1615 



