### PR TITLE
カスタム絵文字周りのパフォーマンスを改善

### DIFF
--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/CustomEmojiDecorator.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/CustomEmojiDecorator.kt
@@ -37,7 +37,7 @@ class CustomEmojiDecorator {
             GlideApp.with(view)
                 .asDrawable()
                 .load(it.result.getUrl(accountHost))
-                .override(min(view.textSize.toInt(), 640))
+                .override(min(view.textSize.toInt(), 20))
                 .into(span.target)
             builder.setSpan(span, it.start, it.end, 0)
         }
@@ -57,7 +57,7 @@ class CustomEmojiDecorator {
             val span = DrawableEmojiSpan(emojiAdapter, it.result.getUrl(accountHost))
             GlideApp.with(view)
                 .asDrawable()
-                .override(min(view.textSize.toInt(), 640))
+                .override(min(view.textSize.toInt(), 20))
                 .load(it.result.getUrl(accountHost))
                 .into(span.target)
             builder.setSpan(span, it.start, it.end, 0)
@@ -79,7 +79,7 @@ class CustomEmojiDecorator {
             GlideApp.with(view)
                 .asDrawable()
                 .load(it.result.getUrl(accountHost))
-                .override(min(view.textSize.toInt(), 640))
+                .override(min(view.textSize.toInt(), 20))
                 .into(span.target)
             builder.setSpan(span, it.start, it.end, 0)
         }

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
@@ -77,12 +77,7 @@ abstract class EmojiSpan<T: Any?>(val key: T) : ReplacementSpan(){
         val imageHeight = size.intrinsicHeight
 
         // 画像がテキストの高さよりも大きい場合、画像をテキストと同じ高さに縮小する
-        val scale = if (imageHeight > textHeight) {
-            textHeight / imageHeight.toFloat()
-        } else {
-            1.0f
-        }
-
+        val scale = textHeight / imageHeight.toFloat()
         // テキストの高さに合わせた画像の幅
         return (imageWidth * scale).toInt()
     }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
@@ -30,6 +30,7 @@ import net.pantasystem.milktea.common_navigation.UserDetailNavigationArgs
 import net.pantasystem.milktea.model.emoji.Emoji
 import java.lang.ref.WeakReference
 import kotlin.math.max
+import kotlin.math.min
 
 object MFMDecorator {
 
@@ -312,7 +313,7 @@ object MFMDecorator {
                 spannableString.setSpan(emojiSpan, skippedEmoji.start, skippedEmoji.end, 0)
                 GlideApp.with(textView)
                     .load(emojiElement.emoji.url)
-                    .override(max(textView.textSize.toInt(), 10))
+                    .override(min(max(textView.textSize.toInt(), 10), 20))
                                         .addListener(object : RequestListener<Drawable> {
                         override fun onLoadFailed(
                             e: GlideException?,
@@ -322,7 +323,7 @@ object MFMDecorator {
                         ): Boolean {
                             val t = this@LazyEmojiDecorator.textView.get()
                             if (t != null && !skipEmojis.contains(emojiElement.emoji) && t.getTag(R.id.TEXT_VIEW_MFM_TAG_ID) == lazyDecorateResult.sourceText) {
-                                if (retryCounter < 100) {
+                                if (retryCounter < 10) {
 
                                     t.text = decorate(
                                         t,

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiChoicesAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiChoicesAdapter.kt
@@ -52,6 +52,7 @@ class EmojiChoicesAdapter(
                     .load(item.emoji.url ?: item.emoji.uri)
                         // FIXME: webpの場合うまく表示できなくなる
 //                    .centerCrop()
+                    .override(60)
                     .into(holder.binding.reactionImagePreview)
                 holder.binding.reactionStringPreview.setMemoVisibility(View.GONE)
                 holder.binding.reactionImagePreview.setMemoVisibility(View.VISIBLE)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/InstanceInfoHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/view/InstanceInfoHelper.kt
@@ -30,7 +30,7 @@ object InstanceInfoHelper {
             val iconDrawable = DrawableEmojiSpan(emojiAdapter, info?.faviconUrl)
             Glide.with(this)
                 .load(info!!.faviconUrl)
-                .override(min(this.textSize.toInt(), 640))
+                .override(min(this.textSize.toInt(), 20))
                 .into(iconDrawable.target)
             text =  SpannableStringBuilder(":${info.faviconUrl}:${info.name}").apply {
                 setSpan(iconDrawable, 0, ":${info.faviconUrl}:".length, 0)


### PR DESCRIPTION
## やったこと
画像がより小さなサイズで読み込まれるようにして
RAMの消費量を少なくしGCの発生頻度や
GPUのRAMの消費量を少なくすることによって
スクロールがよりスムーズに動くようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
#1628 


