### PR TITLE
userを指定して投稿を検索できるようにした

### DIFF
--- a/modules/common_navigation/src/main/java/net/pantasystem/milktea/common_navigation/SearchNavigation.kt
+++ b/modules/common_navigation/src/main/java/net/pantasystem/milktea/common_navigation/SearchNavigation.kt
@@ -4,7 +4,8 @@ interface SearchNavigation : ActivityNavigation<SearchNavType>
 
 sealed interface SearchNavType {
     val searchWord: String?
-    data class ResultScreen(override val searchWord: String) : SearchNavType
-    data class SearchScreen(override val searchWord: String? = null) : SearchNavType
+    val acct: String?
+    data class ResultScreen(override val searchWord: String, override val acct: String? = null) : SearchNavType
+    data class SearchScreen(override val searchWord: String? = null, override val acct: String? = null) : SearchNavType
 
 }

--- a/modules/common_resource/src/main/res/menu/activity_user_menu.xml
+++ b/modules/common_resource/src/main/res/menu/activity_user_menu.xml
@@ -2,6 +2,10 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <item   android:id="@+id/nav_search_by_user"
+            android:title="@string/search"
+            android:icon="@drawable/ic_search_black_24dp"
+            app:showAsAction="ifRoom" />
     <item
             android:id="@+id/nav_add_to_tab"
             android:title="@string/add_to_tab"

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/MastodonTimelineStorePagingStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/MastodonTimelineStorePagingStoreImpl.kt
@@ -201,7 +201,8 @@ internal class MastodonTimelineStorePagingStoreImpl(
                     q = pageableTimeline.query,
                     type = "statuses",
                     maxId = maxId,
-                    offset = (getState().content as? StateContent.Exist)?.rawContent?.size ?: 0
+                    offset = (getState().content as? StateContent.Exist)?.rawContent?.size ?: 0,
+                    accountId = pageableTimeline.userId
                 ).throwIfHasError().also {
                     updateMaxIdFrom(it)
                 }.body()?.statuses

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/PageParams.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/PageParams.kt
@@ -24,5 +24,6 @@ fun PageParams.toNoteRequest(i: String?) : NoteRequest {
         offset = offset,
         markAsRead = markAsRead,
         channelId = channelId,
+        userId = userId
     )
 }

--- a/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchActivity.kt
+++ b/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchActivity.kt
@@ -44,6 +44,7 @@ class SearchActivity : AppCompatActivity() {
     private var mSearchView: SearchView? = null
 
     private var mSearchWord: String? = null
+    private var mAcct: String? = null
 
     private val binding: ActivitySearchBinding by dataBinding()
 
@@ -60,6 +61,7 @@ class SearchActivity : AppCompatActivity() {
 
         supportActionBar?.setDisplayShowTitleEnabled(false)
         mSearchWord = intent.getStringExtra(EXTRA_SEARCH_WORD)
+        mAcct = intent.getStringExtra(SearchResultViewModel.EXTRA_ACCT)
 
         findViewById<ComposeView>(R.id.composeBase).setContent {
             MdcTheme {
@@ -154,6 +156,7 @@ class SearchActivity : AppCompatActivity() {
                 is SubmitResult.Search -> {
                     val intent = Intent(this@SearchActivity, SearchResultActivity::class.java)
                     intent.putExtra(SearchResultActivity.EXTRA_SEARCH_WORLD, searchWord)
+                    intent.putExtra(SearchResultViewModel.EXTRA_ACCT, mAcct)
                     startActivity(intent)
                     overridePendingTransition(0, 0)
                     finish()

--- a/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultActivity.kt
+++ b/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultActivity.kt
@@ -75,6 +75,8 @@ class SearchResultActivity : AppCompatActivity() {
             ?: intent.data?.getQueryParameter("keyword")
 
         searchResultViewModel.setKeyword(keyword ?: "")
+        searchResultViewModel.setAcct(intent.getStringExtra(SearchResultViewModel.EXTRA_ACCT))
+
 
         mSearchWord = keyword
 

--- a/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultActivity.kt
+++ b/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultActivity.kt
@@ -187,12 +187,18 @@ class SearchNavigationImpl  @Inject constructor(
             is SearchNavType.ResultScreen -> {
                 val intent = Intent(activity, SearchResultActivity::class.java)
                 intent.putExtra(SearchResultActivity.EXTRA_SEARCH_WORLD, args.searchWord)
+                if (args.acct != null) {
+                    intent.putExtra(SearchResultViewModel.EXTRA_ACCT, args.acct)
+                }
                 intent
             }
             is SearchNavType.SearchScreen -> {
                 val intent = Intent(activity, SearchActivity::class.java)
                 if (args.searchWord != null) {
                     intent.putExtra(SearchActivity.EXTRA_SEARCH_WORD, args.searchWord)
+                }
+                if (args.acct != null) {
+                    intent.putExtra(SearchResultViewModel.EXTRA_ACCT, args.acct)
                 }
                 intent
             }

--- a/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultViewModel.kt
+++ b/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultViewModel.kt
@@ -4,43 +4,79 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import net.pantasystem.milktea.app_store.account.AccountStore
+import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common.mapCancellableCatching
 import net.pantasystem.milktea.common_android.resource.StringSource
 import net.pantasystem.milktea.model.account.Account
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.account.page.PageableTemplate
+import net.pantasystem.milktea.model.user.Acct
+import net.pantasystem.milktea.model.user.User
+import net.pantasystem.milktea.model.user.UserRepository
 import javax.inject.Inject
 
 @HiltViewModel
 class SearchResultViewModel @Inject constructor(
+    loggerFactory: Logger.Factory,
     private val accountStore: AccountStore,
     private val accountRepository: AccountRepository,
+    private val userRepository: UserRepository,
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     companion object {
         const val EXTRA_KEYWORD =
             "net.pantasystem.milktea.search.SearchResultViewModel.EXTRA_KEYWORD"
+        const val EXTRA_ACCT = "net.pantasystem.milktea.search.SearchResultActivity.EXTRA_ACCT"
+
+    }
+
+    private val logger by lazy {
+        loggerFactory.create("SearchResultVM")
     }
 
     private val keyword = savedStateHandle.getStateFlow(EXTRA_KEYWORD, "")
+    private val acct = savedStateHandle.getStateFlow<String?>(EXTRA_ACCT, null)
+    private val user = combine(
+        acct,
+        accountStore.observeCurrentAccount.filterNotNull()
+    ) { acct, ac ->
+        userRepository.findByUserName(
+            ac.accountId,
+            Acct(acct ?: "").userName,
+            Acct(acct ?: "").host
+        )
+    }.catch {
+        logger.debug("ユーザの情報の取得に失敗", e = it)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     val uiState = combine(
         accountStore.observeCurrentAccount,
-        keyword
-    ) { currentAccount, keyword ->
+        keyword,
+        acct,
+        user
+    ) { currentAccount, keyword, acct, user ->
         SearchResultUiState(
             currentAccount = currentAccount,
-            keyword = keyword
+            keyword = keyword,
+            acct = acct,
+            user = user
         )
-    }
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        SearchResultUiState(null, "", null, null)
+    )
 
     fun setKeyword(q: String) {
         savedStateHandle[EXTRA_KEYWORD] = q
     }
 
+    fun setAcct(acct: String?) {
+        savedStateHandle[EXTRA_ACCT] = acct
+    }
     fun toggleAddToTab() {
         viewModelScope.launch {
             val keyword = savedStateHandle.get<String>(EXTRA_KEYWORD) ?: return@launch
@@ -67,8 +103,10 @@ class SearchResultViewModel @Inject constructor(
 data class SearchResultUiState(
     val currentAccount: Account?,
     val keyword: String,
+    val acct: String?,
+    val user: User?,
 ) {
-    val isTag: Boolean = keyword.startsWith("#")
+    val isTag: Boolean = keyword.startsWith("#") && acct == null
 
     val tabItems: List<SearchResultTabItem> = when (currentAccount?.instanceType) {
         Account.InstanceType.MISSKEY -> listOfNotNull(
@@ -83,6 +121,7 @@ data class SearchResultUiState(
                     title = StringSource(R.string.timeline),
                     type = SearchResultTabItem.Type.SearchMisskeyPosts,
                     query = keyword,
+                    userId = user?.id?.id,
                 )
             },
             if (isTag) SearchResultTabItem(
@@ -94,6 +133,7 @@ data class SearchResultUiState(
                 title = StringSource(R.string.user),
                 type = SearchResultTabItem.Type.SearchMisskeyUsers,
                 query = keyword,
+                userId = user?.id?.id,
             )
         )
         Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> listOfNotNull(
@@ -108,6 +148,7 @@ data class SearchResultUiState(
                     title = StringSource(R.string.timeline),
                     type = SearchResultTabItem.Type.SearchMastodonPosts,
                     query = keyword,
+                    userId = user?.id?.id,
                 )
             },
             SearchResultTabItem(
@@ -125,6 +166,7 @@ data class SearchResultTabItem(
     val title: StringSource,
     val type: Type,
     val query: String,
+    val userId: String? = null,
 ) {
     enum class Type {
         SearchMisskeyPosts,

--- a/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultViewPagerAdapter.kt
+++ b/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultViewPagerAdapter.kt
@@ -20,9 +20,9 @@ class SearchResultViewPagerAdapter(
 
     override fun createFragment(position: Int): Fragment {
         val item = items[position]
-        return when(item.type) {
+        return when (item.type) {
             SearchResultTabItem.Type.SearchMisskeyPosts -> pageableFragmentFactory.create(
-                Pageable.Search(query = item.query)
+                Pageable.Search(query = item.query, userId = item.userId)
             )
             SearchResultTabItem.Type.SearchMisskeyPostsByTag -> pageableFragmentFactory.create(
                 Pageable.SearchByTag(tag = item.query)
@@ -31,9 +31,15 @@ class SearchResultViewPagerAdapter(
                 Pageable.SearchByTag(tag = item.query, withFiles = true)
             )
             SearchResultTabItem.Type.SearchMisskeyUsers -> SearchUserFragment.newInstance(item.query)
-            SearchResultTabItem.Type.SearchMastodonPosts -> pageableFragmentFactory.create(Pageable.Mastodon.SearchTimeline(item.query))
+            SearchResultTabItem.Type.SearchMastodonPosts -> pageableFragmentFactory.create(
+                Pageable.Mastodon.SearchTimeline(
+                    item.query,
+                    userId = item.userId
+                )
+            )
             SearchResultTabItem.Type.SearchMastodonPostsByTag -> pageableFragmentFactory.create(
-                Pageable.Mastodon.TagTimeline(item.query))
+                Pageable.Mastodon.TagTimeline(item.query)
+            )
             SearchResultTabItem.Type.SearchMastodonUsers -> SearchUserFragment.newInstance(item.query)
         }
     }
@@ -64,5 +70,15 @@ class SearchResultViewPagerAdapter(
         }
         val result = DiffUtil.calculateDiff(callback)
         result.dispatchUpdatesTo(this)
+    }
+
+    override fun getItemId(position: Int): Long {
+        return items[position].hashCode().toLong()
+    }
+
+    override fun containsItem(itemId: Long): Boolean {
+        return items.map {
+            it.hashCode().toLong()
+        }.contains(itemId)
     }
 }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
@@ -113,6 +113,9 @@ class UserDetailActivity : AppCompatActivity() {
     @Inject
     lateinit var pageableFragmentFactory: PageableFragmentFactory
 
+    @Inject
+    lateinit var searchNavigation: SearchNavigation
+
 
     @ExperimentalCoroutinesApi
     val mViewModel: UserDetailViewModel by viewModels {
@@ -400,6 +403,16 @@ class UserDetailActivity : AppCompatActivity() {
             R.id.renoteMute -> {
                 mViewModel.muteRenotes()
             }
+            R.id.nav_search_by_user -> {
+                startActivity(searchNavigation.newIntent(
+                    SearchNavType.SearchScreen(
+                        acct = mViewModel.userState.value?.let {
+                                "@${it.userName}@${it.host}"
+                            }
+                        )
+                    )
+                )
+            }
             else -> return false
 
         }
@@ -429,7 +442,7 @@ class UserDetailActivity : AppCompatActivity() {
 
     private fun applyRemoteUserStateLayoutBackgroundColor(
         binding: ActivityUserDetailBinding,
-        config: Config
+        config: Config,
     ) {
         val typed = TypedValue()
         if (config.theme is Theme.Bread) {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
@@ -194,7 +194,8 @@ data class PageParams(
                 }
                 MASTODON_SEARCH_TIMELINE -> {
                     Pageable.Mastodon.SearchTimeline(
-                        requireNotNull(query)
+                        query = requireNotNull(query),
+                        userId = userId,
                     )
                 }
                 MASTODON_TAG_TIMELINE -> {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
@@ -481,12 +481,14 @@ sealed class Pageable : Serializable {
         }
 
         data class SearchTimeline(
-            val query: String
+            val query: String,
+            val userId: String? = null,
         ) : Mastodon() {
             override fun toParams(): PageParams {
                 return PageParams(
                     type = PageType.MASTODON_SEARCH_TIMELINE,
-                    query = query
+                    query = query,
+                    userId = userId,
                 )
             }
         }


### PR DESCRIPTION
## やったこと
user指定で検索できるようにするために
プロフィール画面に検索ボタンを配置し
検索画面にUserIdを引き渡せるような実装にしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号


