### PR TITLE
先頭を表示していない時はストリーミングを自動的に停止するようにした

### DIFF
--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
@@ -13,6 +13,8 @@ import net.pantasystem.milktea.common_android_ui.BindingProvider
 import net.pantasystem.milktea.model.notes.reaction.LegacyReaction
 import net.pantasystem.milktea.model.notes.reaction.Reaction
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
+import kotlin.math.max
+import kotlin.math.min
 
 object NoteReactionViewHelper {
 
@@ -39,6 +41,7 @@ object NoteReactionViewHelper {
 
             GlideApp.with(reactionImageTypeView.context)
                 .load(emoji.url ?: emoji.uri)
+                .override(min(max(reactionImageTypeView.height, 20), 40))
                 // FIXME: webpの場合エラーが発生してうまく表示できなくなってしまう
 //                .fitCenter()
                 .into(reactionImageTypeView)

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/TimelineFragment.kt
@@ -275,11 +275,7 @@ class TimelineFragment : Fragment(R.layout.fragment_swipe_refresh_recycler_view)
                         mViewModel.loadOld()
                     }
 
-                    if (lm.findFirstVisibleItemPosition() <= 3) {
-                        mViewModel.onVisibleFirst()
-                    }
-
-                    mViewModel.onPositionChanged(lm.findFirstVisibleItemPosition())
+                    mViewModel.onScrollPositionChanged(lm.findFirstVisibleItemPosition())
 
                 }
             }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -215,13 +215,19 @@ class TimelineViewModel @AssistedInject constructor(
         }
     }
 
-    fun onPositionChanged(position: Int) {
+    fun onScrollPositionChanged(firstVisiblePosition: Int) {
+        if (firstVisiblePosition <= 3) {
+            onVisibleFirst()
+        } else {
+            // NOTE: 先頭を表示していない時はストリーミングを停止する
+            timelineStore.suspendStreaming()
+        }
         viewModelScope.launch {
-            timelineStore.releaseUnusedPages(position)
+            timelineStore.releaseUnusedPages(firstVisiblePosition)
         }
     }
 
-    fun onVisibleFirst() {
+    private fun onVisibleFirst() {
         viewModelScope.launch {
             if (this@TimelineViewModel.isActive
                 && !timelineStore.isActiveStreaming


### PR DESCRIPTION
## やったこと
先頭を表示していないにもかかわらずストリーミングをONにしてしまうと
無駄に投稿がメモリ上に展開されてしまいリソースの無駄になってしまうので
先頭を表示していない時はストリーミングを停止するようにした。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1659 


