### PR TITLE
絵文字ピッカーの画像の比率を維持して表示するようにした

### DIFF
--- a/modules/common_android_ui/build.gradle
+++ b/modules/common_android_ui/build.gradle
@@ -98,5 +98,6 @@ dependencies {
     implementation libs.coil.compose
     testImplementation libs.junit.jupiter.api
     testRuntimeOnly libs.junit.jupiter.engine
+    implementation libs.flexbox
 
 }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/tab/TabViewCompositeClickListener.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/tab/TabViewCompositeClickListener.kt
@@ -1,0 +1,32 @@
+package net.pantasystem.milktea.common_android_ui.tab
+
+
+import com.google.android.material.tabs.TabLayout
+import java.util.*
+
+class TabViewCompositeClickListener(private val mTabLayout: TabLayout) {
+
+    private val listeners: MutableList<(tab: TabLayout.Tab, position: Int) -> Unit> = ArrayList()
+
+    fun addListener(listener: (tab: TabLayout.Tab, position: Int) -> Unit) {
+        listeners.add(listener)
+    }
+
+    fun removeListener(listener: (tab: TabLayout.Tab, position: Int) -> Unit) {
+        listeners.remove(listener)
+    }
+
+    fun build() {
+        for (i in 0 until mTabLayout.tabCount) {
+            mTabLayout.getTabAt(i)!!.view.setOnClickListener {
+                for (listener in listeners) {
+                    listener(mTabLayout.getTabAt(i)!!, i)
+                }
+            }
+        }
+    }
+
+    fun getListeners(): List<(tab: TabLayout.Tab, position: Int) -> Unit> {
+        return listeners
+    }
+}

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/tab/TabbedFlexboxListMediator.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/tab/TabbedFlexboxListMediator.kt
@@ -1,0 +1,240 @@
+package net.pantasystem.milktea.common_android_ui.tab
+
+
+import androidx.recyclerview.widget.LinearSmoothScroller
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.SmoothScroller
+import com.google.android.flexbox.FlexboxLayoutManager
+import com.google.android.material.tabs.TabLayout
+import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
+
+/**
+ * This class is made to provide the ability to sync between RecyclerView's specific items with
+ * TabLayout tabs.
+ *
+ * @param mRecyclerView     The RecyclerView that is going to be synced with the TabLayout
+ * @param mTabLayout        The TabLayout that is going to be synced with the RecyclerView specific
+ *                          items.
+ * @param mIndices          The indices of the RecyclerView's items that is going to be playing a
+ *                          role of "check points" for the syncing operation.
+ * @param mIsSmoothScroll   Defines the ability of smooth scroll when clicking the tabs of the
+ *                          TabLayout.
+ */
+class TabbedFlexboxListMediator(
+    private val mRecyclerView: RecyclerView,
+    private val mTabLayout: TabLayout,
+    private var mIndices: List<Int>,
+    private var mIsSmoothScroll: Boolean = false
+) {
+
+    private var mIsAttached = false
+
+    private var mRecyclerState = RecyclerView.SCROLL_STATE_IDLE
+    private var mTabClickFlag = false
+
+    private val smoothScroller: SmoothScroller =
+        object : LinearSmoothScroller(mRecyclerView.context) {
+            override fun getVerticalSnapPreference(): Int {
+                return SNAP_TO_START
+            }
+        }
+
+    private var tabViewCompositeClickListener: TabViewCompositeClickListener =
+        TabViewCompositeClickListener(mTabLayout)
+
+    /**
+     * Calling this method will ensure that the data that has been provided to the mediator is
+     * valid for use, and start syncing between the the RecyclerView and the TabLayout.
+     *
+     * Call this method when you have:
+     *      1- provided a RecyclerView Adapter,
+     *      2- provided a TabLayout with the appropriate number of tabs,
+     *      3- provided indices of the recyclerview items that you are syncing the tabs with. (You
+     *         need to be providing indices of at most the number of Tabs inflated in the TabLayout.)
+     */
+    fun attach() {
+        mRecyclerView.adapter
+            ?: throw RuntimeException("Cannot attach with no Adapter provided to RecyclerView")
+
+        if (mTabLayout.tabCount == 0)
+            throw RuntimeException("Cannot attach with no tabs provided to TabLayout")
+
+        if (mIndices.size > mTabLayout.tabCount)
+            throw RuntimeException("Cannot attach using more indices than the available tabs")
+
+        notifyIndicesChanged()
+        mIsAttached = true
+    }
+
+    /**
+     * Calling this method will ensure to stop the synchronization between the RecyclerView and
+     * the TabLayout.
+     */
+
+    fun detach() {
+        clearListeners()
+        mIsAttached = false
+    }
+
+    /**
+     * This method will ensure that the synchronization is up-to-date with the data provided.
+     */
+    private fun reAttach() {
+        detach()
+        attach()
+    }
+
+    /**
+     * Calling this method will
+     */
+    fun updateMediatorWithNewIndices(newIndices: List<Int>): TabbedFlexboxListMediator {
+        mIndices = newIndices
+
+        if (mIsAttached) {
+            reAttach()
+        }
+
+        return this
+    }
+
+    /**
+     * This method will ensure that any listeners that have been added by the mediator will be
+     * removed, including the one listener from
+     * @see TabbedListMediator#addOnViewOfTabClickListener((TabLayout.Tab, int) -> Unit)
+     */
+
+    private fun clearListeners() {
+        mRecyclerView.clearOnScrollListeners()
+        for (i in 0 until mTabLayout.tabCount) {
+            mTabLayout.getTabAt(i)!!.view.setOnClickListener(null)
+        }
+        for (i in tabViewCompositeClickListener.getListeners().indices) {
+            tabViewCompositeClickListener.getListeners().toMutableList().removeAt(i)
+        }
+        mTabLayout.removeOnTabSelectedListener(onTabSelectedListener)
+        mRecyclerView.removeOnScrollListener(onScrollListener)
+    }
+
+    /**
+     * This method will attach the listeners required to make the synchronization possible.
+     */
+
+    private fun notifyIndicesChanged() {
+        tabViewCompositeClickListener.addListener { _, _ -> mTabClickFlag = true }
+        tabViewCompositeClickListener.build()
+        mTabLayout.addOnTabSelectedListener(onTabSelectedListener)
+        mRecyclerView.addOnScrollListener(onScrollListener)
+    }
+
+    private val onTabSelectedListener = object : OnTabSelectedListener {
+        override fun onTabSelected(tab: TabLayout.Tab) {
+
+            if (!mTabClickFlag) return
+
+            val position = tab.position
+
+            if (mIsSmoothScroll) {
+                smoothScroller.targetPosition = mIndices[position]
+                mRecyclerView.layoutManager?.startSmoothScroll(smoothScroller)
+            } else {
+//                (mRecyclerView.layoutManager as FlexboxLayoutManager?)?.scrollToPositionWithOffset(
+//                    mIndices[position],
+//                    0
+//                )
+                (mRecyclerView.layoutManager as FlexboxLayoutManager?)?.scrollToPosition(mIndices[position])
+                mTabClickFlag = false
+            }
+        }
+
+        override fun onTabUnselected(tab: TabLayout.Tab) {}
+        override fun onTabReselected(tab: TabLayout.Tab) {}
+    }
+
+    private val onScrollListener = object : RecyclerView.OnScrollListener() {
+        override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+            mRecyclerState = newState
+            if (mIsSmoothScroll && newState == RecyclerView.SCROLL_STATE_IDLE) {
+                mTabClickFlag = false
+            }
+        }
+
+        override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+            super.onScrolled(recyclerView, dx, dy)
+            if (mTabClickFlag) {
+                return
+            }
+
+            val flexboxLayoutManager: FlexboxLayoutManager =
+                recyclerView.layoutManager as FlexboxLayoutManager?
+                    ?: throw RuntimeException("No FlexboxLayoutManager attached to the RecyclerView.")
+
+            var itemPosition =
+                flexboxLayoutManager.findFirstCompletelyVisibleItemPosition()
+
+            if (itemPosition == -1) {
+                itemPosition =
+                    flexboxLayoutManager.findFirstVisibleItemPosition()
+            }
+
+            if (mRecyclerState == RecyclerView.SCROLL_STATE_DRAGGING
+                || mRecyclerState == RecyclerView.SCROLL_STATE_SETTLING
+            ) {
+                for (i in mIndices.indices) {
+                    if (itemPosition == mIndices[i]) {
+                        if (!mTabLayout.getTabAt(i)!!.isSelected) {
+                            mTabLayout.getTabAt(i)!!.select()
+                        }
+                        if (flexboxLayoutManager.findLastCompletelyVisibleItemPosition() == mIndices[mIndices.size - 1]) {
+                            if (!mTabLayout.getTabAt(mIndices.size - 1)!!.isSelected) {
+                                mTabLayout.getTabAt(mIndices.size - 1)!!.select()
+                            }
+                            return
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @return the state of the mediator, either attached or not.
+     */
+
+    fun isAttached(): Boolean {
+        return mIsAttached
+    }
+
+    /**
+     * @return the state of the mediator, is smooth scrolling or not.
+     */
+
+    fun isSmoothScroll(): Boolean {
+        return mIsSmoothScroll
+    }
+
+    /**
+     * @param smooth sets up the mediator with smooth scrolling
+     */
+
+    fun setSmoothScroll(smooth: Boolean) {
+        mIsSmoothScroll = smooth
+    }
+
+    /**
+     * @param listener the listener the will applied on "the view" of the tab. This method is useful
+     * when attaching a click listener on the tabs of the TabLayout.
+     * Note that this method is REQUIRED in case of the need of adding a click listener on the view
+     * of a tab layout. Since the mediator uses a click flag @see TabbedListMediator#mTabClickFlag
+     * it's taking the place of the normal on click listener, and thus the need of the composite click
+     * listener pattern, so adding listeners should be done using this method.
+     */
+
+    fun addOnViewOfTabClickListener(
+        listener: (tab: TabLayout.Tab, position: Int) -> Unit
+    ) {
+        tabViewCompositeClickListener.addListener(listener)
+        if (mIsAttached) {
+            notifyIndicesChanged()
+        }
+    }
+}

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/CustomEmojiImageViewSizeHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/CustomEmojiImageViewSizeHelper.kt
@@ -1,0 +1,29 @@
+@file:Suppress("UNCHECKED_CAST")
+
+package net.pantasystem.milktea.note.reaction
+
+import android.content.Context
+import android.view.ViewGroup
+import android.widget.ImageView
+
+object CustomEmojiImageViewSizeHelper {
+
+    fun<T: ViewGroup.LayoutParams> ImageView.applySizeByAspectRatio(baseHeightDp: Int, aspectRatio: Float?) {
+        val (imageViewWidthPx, imageViewHeightPx) = context.calculateImageWidthAndHeightSize(baseHeightDp, aspectRatio)
+        val params = layoutParams as T
+        params.height = imageViewHeightPx.toInt()
+        params.width = imageViewWidthPx.toInt()
+        layoutParams = params
+    }
+
+    fun Context.calculateImageWidthAndHeightSize(baseHeightDp: Int, aspectRatio: Float?): Pair<Float, Float> {
+        val metrics = resources.displayMetrics
+        val heightPx = baseHeightDp * metrics.density
+        val imageViewWidthPx = if (aspectRatio == null) {
+            heightPx
+        } else {
+            (heightPx * aspectRatio)
+        }
+        return heightPx to imageViewWidthPx
+    }
+}

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/CustomEmojiImageViewSizeHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/CustomEmojiImageViewSizeHelper.kt
@@ -24,6 +24,6 @@ object CustomEmojiImageViewSizeHelper {
         } else {
             (heightPx * aspectRatio)
         }
-        return heightPx to imageViewWidthPx
+        return imageViewWidthPx to heightPx
     }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/NoteReactionViewHelper.kt
@@ -5,7 +5,6 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.core.view.updateLayoutParams
 import androidx.databinding.BindingAdapter
 import dagger.hilt.android.EntryPointAccessors
 import net.pantasystem.milktea.common.glide.GlideApp
@@ -13,6 +12,8 @@ import net.pantasystem.milktea.common_android.ui.VisibilityHelper.setMemoVisibil
 import net.pantasystem.milktea.common_android_ui.BindingProvider
 import net.pantasystem.milktea.model.notes.reaction.LegacyReaction
 import net.pantasystem.milktea.model.notes.reaction.Reaction
+import net.pantasystem.milktea.note.reaction.CustomEmojiImageViewSizeHelper.applySizeByAspectRatio
+import net.pantasystem.milktea.note.reaction.CustomEmojiImageViewSizeHelper.calculateImageWidthAndHeightSize
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
 
 
@@ -40,21 +41,18 @@ object NoteReactionViewHelper {
         } else {
             reactionImageTypeView.setMemoVisibility(View.VISIBLE)
             reactionTextTypeView.setMemoVisibility(View.GONE)
-            val metrics = context.resources.displayMetrics
-            val imageViewHeightPx = REACTION_IMAGE_WIDTH_SIZE_DP * metrics.density
-            val imageAspectRatio = ImageAspectRatioCache.get(emoji.url ?: emoji.uri) ?: emoji.aspectRatio
-            val imageViewWidthPx = if (imageAspectRatio == null) {
-                imageViewHeightPx
-            } else {
-                (imageViewHeightPx * imageAspectRatio)
-            }
+            val imageAspectRatio =
+                ImageAspectRatioCache.get(emoji.url ?: emoji.uri) ?: emoji.aspectRatio
 
-            reactionImageTypeView.updateLayoutParams<LinearLayout.LayoutParams> {
-                this@updateLayoutParams.also {
-                    it.height = imageViewHeightPx.toInt()
-                    it.width = imageViewWidthPx.toInt()
-                }
-            }
+            val (imageViewWidthPx, imageViewHeightPx) = reactionImageTypeView.context.calculateImageWidthAndHeightSize(
+                REACTION_IMAGE_WIDTH_SIZE_DP,
+                imageAspectRatio
+            )
+            reactionImageTypeView.applySizeByAspectRatio<LinearLayout.LayoutParams>(
+                REACTION_IMAGE_WIDTH_SIZE_DP,
+                imageAspectRatio
+            )
+
 
             GlideApp.with(reactionImageTypeView.context)
                 .load(emoji.url ?: emoji.uri)
@@ -63,7 +61,7 @@ object NoteReactionViewHelper {
                 .into(reactionImageTypeView)
         }
     }
-    
+
 
     @JvmStatic
     fun setReactionCount(

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiListItemsAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/choices/EmojiListItemsAdapter.kt
@@ -3,6 +3,7 @@ package net.pantasystem.milktea.note.reaction.choices
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -15,9 +16,12 @@ import net.pantasystem.milktea.note.EmojiType
 import net.pantasystem.milktea.note.R
 import net.pantasystem.milktea.note.databinding.ItemEmojiChoiceBinding
 import net.pantasystem.milktea.note.databinding.ItemEmojiListItemHeaderBinding
+import net.pantasystem.milktea.note.reaction.CustomEmojiImageViewSizeHelper.applySizeByAspectRatio
+import net.pantasystem.milktea.note.reaction.ImageAspectRatioCache
 import net.pantasystem.milktea.note.reaction.SaveImageAspectRequestListener
 
 class EmojiListItemsAdapter(
+    private val isApplyImageAspectRatio: Boolean,
     private val onEmojiSelected: (EmojiType) -> Unit,
     private val onEmojiLongClicked: (EmojiType) -> Boolean,
 ) : ListAdapter<EmojiListItemType, EmojiListItemsAdapter.VH>(
@@ -49,7 +53,7 @@ class EmojiListItemsAdapter(
     }
 
     sealed class VH(view: View) : RecyclerView.ViewHolder(view)
-    class EmojiVH(val binding: ItemEmojiChoiceBinding) : VH(binding.root) {
+    class EmojiVH(val binding: ItemEmojiChoiceBinding, private val isApplyImageAspectRatio: Boolean) : VH(binding.root) {
 
         fun onBind(
             item: EmojiType, onEmojiSelected: (EmojiType) -> Unit,
@@ -57,6 +61,14 @@ class EmojiListItemsAdapter(
         ) {
             when (item) {
                 is EmojiType.CustomEmoji -> {
+                    if (isApplyImageAspectRatio) {
+                        binding.reactionImagePreview.applySizeByAspectRatio<LinearLayout.LayoutParams>(
+                            20,
+                            item.emoji.aspectRatio ?: ImageAspectRatioCache.get(
+                                item.emoji.url ?: item.emoji.uri
+                            )
+                        )
+                    }
                     GlideApp.with(binding.reactionImagePreview)
                         .load(item.emoji.url ?: item.emoji.uri)
                         // FIXME: webpの場合うまく表示できなくなる
@@ -68,6 +80,7 @@ class EmojiListItemsAdapter(
                             )
                         )
                         .into(binding.reactionImagePreview)
+
                     binding.reactionStringPreview.setMemoVisibility(View.GONE)
                     binding.reactionImagePreview.setMemoVisibility(View.VISIBLE)
                 }
@@ -122,7 +135,8 @@ class EmojiListItemsAdapter(
                         false
                     )
                 return EmojiVH(
-                    binding
+                    binding,
+                    isApplyImageAspectRatio
                 )
             }
         }

--- a/modules/features/note/src/main/res/layout/item_emoji_choice.xml
+++ b/modules/features/note/src/main/res/layout/item_emoji_choice.xml
@@ -3,7 +3,7 @@
         xmlns:android="http://schemas.android.com/apk/res/android">
 
     <FrameLayout
-            android:layout_width="36dp"
+            android:layout_width="wrap_content"
             android:layout_height="36dp"
             android:padding="4dp"
             android:layout_margin="4dp"
@@ -11,14 +11,14 @@
             >
         <ImageView
                 android:id="@+id/reactionImagePreview"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
                 android:layout_gravity="center"
                 tools:visibility="gone"
                 tools:ignore="ContentDescription" />
         <TextView
                 android:id="@+id/reactionStringPreview"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 tools:text="😇"
                 tools:visibility="visible"


### PR DESCRIPTION
## やったこと
絵文字ピッカーの画像の比率を維持して表示できるようにするために、
FlexboxLayoutManagerを使用するようにしました。
また一部レイアウトを動的に変更するためのロジックを共通処理として切り出すようにしました。
また使用しているライブラリがFlexboxLayoutManagerに対応していなかったので、独自の改造をしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1680 

