### PR TITLE
ユーザのプロフィールにリノートを除いた投稿のみのタイムラインを表示できるようにした

### DIFF
--- a/modules/common/src/main/java/net/pantasystem/milktea/common/coroutines/Throttle.kt
+++ b/modules/common/src/main/java/net/pantasystem/milktea/common/coroutines/Throttle.kt
@@ -1,0 +1,13 @@
+package net.pantasystem.milktea.common.coroutines
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.transform
+
+fun <T> Flow<T>.throttleLatest(delayMillis: Long): Flow<T> = this
+    .conflate()
+    .transform {
+        emit(it)
+        delay(delayMillis)
+    }

--- a/modules/common/src/main/java/net/pantasystem/milktea/common/glide/apng/ApngDecoder.kt
+++ b/modules/common/src/main/java/net/pantasystem/milktea/common/glide/apng/ApngDecoder.kt
@@ -1,6 +1,5 @@
 package net.pantasystem.milktea.common.glide.apng
 
-import android.util.Log
 import com.bumptech.glide.load.Options
 import com.bumptech.glide.load.ResourceDecoder
 import com.bumptech.glide.load.engine.Resource
@@ -10,7 +9,6 @@ import com.github.penfeizhou.animation.decode.FrameSeqDecoder
 import com.github.penfeizhou.animation.io.ByteBufferReader
 import com.github.penfeizhou.animation.loader.ByteBufferLoader
 import com.github.penfeizhou.animation.loader.Loader
-import okhttp3.internal.toHexString
 import java.nio.ByteBuffer
 
 
@@ -37,18 +35,14 @@ class ByteBufferApngDecoder : ResourceDecoder<ByteBuffer, FrameSeqDecoder<*, *>>
     }
 
     override fun handles(source: ByteBuffer, options: Options): Boolean {
-        Log.d("ByteBufferApngDecoder", "apng decoder on decode")
         val byteBufferArray = ByteArray(8)
         source.get(byteBufferArray, 0, 4)
         val header = ByteBuffer.wrap(byteBufferArray).long ushr 32
         if (header != PNG) {
-            Log.d("ByteBufferApngDecoder", "is not png:${header.toHexString()}")
             return false
         }
 
-        val result = APNGParser.isAPNG(ByteBufferReader(source))
-        Log.d("ByteBufferApngDecoder", "handlers isApng:$result")
-        return result
+        return APNGParser.isAPNG(ByteBufferReader(source))
 
     }
 

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -597,6 +597,7 @@
     <string name="notes_confirm_attach_quote_note_by_url">引用として添付しますか?</string>
     <string name="select_draft_post">下書き投稿を選択</string>
     <string name="remember_scroll_position">スクロール位置を保持する</string>
+    <string name="post_only">投稿のみ</string>
     <!-- User -->
 
 

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -591,6 +591,7 @@
     <string name="notes_confirm_attach_quote_note_by_url">Attach as a quote post?</string>
     <string name="select_draft_post">Select draft post</string>
     <string name="remember_scroll_position">Remember scroll position</string>
+    <string name="post_only">Post only</string>
     <!-- User -->
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -596,4 +596,5 @@
     <string name="notes_confirm_attach_quote_note_by_url">Attach as a quote post?</string>
     <string name="select_draft_post">Select draft post</string>
     <string name="remember_scroll_position">Remember scroll position</string>
+    <string name="post_only">Post only</string>
 </resources>

--- a/modules/features/account/src/main/java/net/pantasystem/milktea/account/AccountTabPagerAdapter.kt
+++ b/modules/features/account/src/main/java/net/pantasystem/milktea/account/AccountTabPagerAdapter.kt
@@ -31,6 +31,7 @@ class AccountTabPagerAdapter(
                     withFiles = true
                 )
             )
+
             is AccountTabTypes.PinNote -> userPinnedNotesFragmentFactory.create(tab.userId)
             is AccountTabTypes.Reactions -> UserReactionsFragment.newInstance(tab.userId)
             is AccountTabTypes.UserTimeline -> pageableFragmentFactory.create(
@@ -65,6 +66,18 @@ class AccountTabPagerAdapter(
             )
             AccountTabTypes.Account -> AccountFragment()
             AccountTabTypes.Message -> MessagingHistoryFragment()
+            is AccountTabTypes.MastodonUserTimelineOnlyPosts -> pageableFragmentFactory.create(
+                Pageable.Mastodon.UserTimeline(
+                    tab.userId.id,
+                    excludeReblogs = true,
+                )
+            )
+            is AccountTabTypes.UserTimelineOnlyPosts -> pageableFragmentFactory.create(
+                Pageable.UserTimeline(
+                    tab.userId.id,
+                    includeMyRenotes = false,
+                )
+            )
         }
 
     }

--- a/modules/features/account/src/main/java/net/pantasystem/milktea/account/AccountTabViewModel.kt
+++ b/modules/features/account/src/main/java/net/pantasystem/milktea/account/AccountTabViewModel.kt
@@ -34,6 +34,7 @@ class AccountTabViewModel @Inject constructor(
                     if (isEnableMessaging) AccountTabTypes.Message else null,
                     AccountTabTypes.UserTimeline(userId),
                     AccountTabTypes.UserTimelineWithReplies(userId),
+                    AccountTabTypes.UserTimelineOnlyPosts(userId),
                     AccountTabTypes.PinNote(userId),
                     AccountTabTypes.Media(userId),
                     if (isEnableGallery) AccountTabTypes.Gallery(
@@ -47,6 +48,7 @@ class AccountTabViewModel @Inject constructor(
                     AccountTabTypes.Account,
                     AccountTabTypes.MastodonUserTimeline(userId),
                     AccountTabTypes.MastodonUserTimelineWithReplies(userId),
+                    AccountTabTypes.MastodonUserTimelineOnlyPosts(userId),
                     AccountTabTypes.MastodonMedia(userId)
                 )
             }
@@ -70,6 +72,8 @@ sealed class AccountTabTypes(
     data class UserTimelineWithReplies(val userId: User.Id) :
         AccountTabTypes(R.string.notes_and_replies)
 
+    data class UserTimelineOnlyPosts(val userId: User.Id) : AccountTabTypes(R.string.post_only)
+
     data class PinNote(val userId: User.Id) : AccountTabTypes(R.string.pin)
     data class Gallery(val userId: User.Id, val accountId: Long) :
         AccountTabTypes(R.string.gallery)
@@ -78,6 +82,8 @@ sealed class AccountTabTypes(
     data class Media(val userId: User.Id) : AccountTabTypes(R.string.media)
 
     data class MastodonUserTimeline(val userId: User.Id) : AccountTabTypes(R.string.post)
+
+    data class MastodonUserTimelineOnlyPosts(val userId: User.Id) : AccountTabTypes(R.string.post_only)
     data class MastodonUserTimelineWithReplies(val userId: User.Id) :
         AccountTabTypes(R.string.notes_and_replies)
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/timeline/viewmodel/TimelineViewModel.kt
@@ -23,6 +23,7 @@ import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.account.CurrentAccountWatcher
 import net.pantasystem.milktea.model.account.UnauthorizedException
 import net.pantasystem.milktea.model.account.page.Pageable
+import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.NoteStreaming
 import net.pantasystem.milktea.model.notes.TimelineScrollPositionRepository
 import net.pantasystem.milktea.model.setting.LocalConfigRepository
@@ -260,7 +261,14 @@ class TimelineViewModel @AssistedInject constructor(
     private suspend fun saveNowScrollPosition() {
         if (isSaveScrollPosition && pageId != null) {
             val listState = timelineListState.value
-            listState.filterIsInstance<TimelineListItem.Note>().getOrNull(position)?.note?.note?.note?.id?.let {
+            var savePos = position - 1
+            while(savePos < listState.size && listState.getOrNull(savePos) !is TimelineListItem.Note) {
+                savePos++
+            }
+            val savePosId: Note.Id? = listState.getOrNull(savePos)?.let {
+                (it as? TimelineListItem.Note)?.note?.note?.note?.id
+            }
+            savePosId?.also {
                 timelineScrollPositionRepository.save(
                     pageId.value,
                     it

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
@@ -513,6 +513,18 @@ class UserTimelinePagerAdapterV2(
                     excludeReplies = false,
                 )
             )
+            is UserDetailTabType.MastodonUserTimelineOnlyPosts -> pageableFragmentFactory.create(
+                Pageable.Mastodon.UserTimeline(
+                    tab.userId.id,
+                    excludeReblogs = true,
+                )
+            )
+            is UserDetailTabType.UserTimelineOnlyPosts -> pageableFragmentFactory.create(
+                Pageable.UserTimeline(
+                    tab.userId.id,
+                    includeMyRenotes = false,
+                )
+            )
         }
 
     }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
@@ -233,7 +233,7 @@ class UserDetailViewModel @AssistedInject constructor(
         viewModelScope.launch {
             userState.value?.let { user ->
                 blockRepository.create(user.id).mapCancellableCatching {
-                    userRepository.sync(user.id)
+                    userRepository.sync(user.id).getOrThrow()
                 }.onFailure {
                     logger.error("block failed", it)
                     _errors.tryEmit(it)
@@ -311,7 +311,7 @@ class UserDetailViewModel @AssistedInject constructor(
             runCancellableCatching {
                 getUserId()
             }.mapCancellableCatching {
-                renoteMuteRepository.create(it)
+                renoteMuteRepository.create(it).getOrThrow()
             }.onFailure {
                 _errors.tryEmit(it)
             }
@@ -323,7 +323,7 @@ class UserDetailViewModel @AssistedInject constructor(
             runCancellableCatching {
                 getUserId()
             }.mapCancellableCatching {
-                renoteMuteRepository.delete(it)
+                renoteMuteRepository.delete(it).getOrThrow()
             }.onFailure {
                 _errors.tryEmit(it)
             }

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/viewmodel/UserDetailViewModel.kt
@@ -127,6 +127,7 @@ class UserDetailViewModel @AssistedInject constructor(
             Account.InstanceType.MISSKEY -> {
                 listOfNotNull(
                     UserDetailTabType.UserTimeline(user.id),
+                    UserDetailTabType.UserTimelineOnlyPosts(user.id),
                     UserDetailTabType.UserTimelineWithReplies(user.id),
                     UserDetailTabType.PinNote(user.id),
                     UserDetailTabType.Media(user.id),
@@ -139,6 +140,7 @@ class UserDetailViewModel @AssistedInject constructor(
             Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> {
                 listOf(
                     UserDetailTabType.MastodonUserTimeline(user.id),
+                    UserDetailTabType.MastodonUserTimelineOnlyPosts(user.id),
                     UserDetailTabType.MastodonUserTimelineWithReplies(user.id),
                     UserDetailTabType.MastodonMedia(user.id)
                 )
@@ -374,6 +376,9 @@ sealed class UserDetailTabType(
 
     data class UserTimeline(val userId: User.Id) : UserDetailTabType(R.string.post)
     data class UserTimelineWithReplies(val userId: User.Id) : UserDetailTabType(R.string.notes_and_replies)
+
+    data class UserTimelineOnlyPosts(val userId: User.Id) : UserDetailTabType(R.string.post_only)
+
     data class PinNote(val userId: User.Id) : UserDetailTabType(R.string.pin)
     data class Gallery(val userId: User.Id, val accountId: Long) :
         UserDetailTabType(R.string.gallery)
@@ -383,5 +388,8 @@ sealed class UserDetailTabType(
 
     data class MastodonUserTimeline(val userId: User.Id) : UserDetailTabType(R.string.post)
     data class MastodonUserTimelineWithReplies(val userId: User.Id) : UserDetailTabType(R.string.notes_and_replies)
+
+    data class MastodonUserTimelineOnlyPosts(val userId: User.Id) : UserDetailTabType(R.string.post_only)
+
     data class MastodonMedia(val userId: User.Id) : UserDetailTabType(R.string.media)
 }


### PR DESCRIPTION
## やったこと
ユーザのプロフィールにリノートを除いた投稿のみのタイムラインを表示できるようにした。
そのためにタブの項目リストにその項目を表現するUIモデルと
それに応じてFragmentを生成できるようにするためにViewPagerのAdapterに変更を加えた

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号



