### PR TITLE
他アカウントのクリップでもタブに追加できるようにした

### DIFF
--- a/modules/common_navigation/src/main/java/net/pantasystem/milktea/common_navigation/ClipNavigation.kt
+++ b/modules/common_navigation/src/main/java/net/pantasystem/milktea/common_navigation/ClipNavigation.kt
@@ -6,7 +6,8 @@ interface ClipListNavigation : ActivityNavigation<ClipListNavigationArgs>
 
 data class ClipListNavigationArgs(
     val accountId: Long? = null,
-    val mode: Mode = Mode.View
+    val mode: Mode = Mode.View,
+    val addTabToAccountId: Long? = null,
 ) {
     enum class Mode {
         AddToTab,

--- a/modules/features/clip/src/main/java/net/pantasystem/milktea/clip/ClipListActivity.kt
+++ b/modules/features/clip/src/main/java/net/pantasystem/milktea/clip/ClipListActivity.kt
@@ -73,6 +73,7 @@ class ClipListNavigationImpl @Inject constructor(
     companion object {
         const val EXTRA_ACCOUNT_ID = "ClipListActivity.EXTRA_ACCOUNT_ID"
         const val EXTRA_MODE = "ClipListActivity.EXTRA_MODE"
+        const val EXTRA_ADD_TAB_TO_ACCOUNT_ID = "ClipListActivity.EXTRA_ADD_TAB_TO_ACCOUNT_ID"
     }
 
     override fun newIntent(args: ClipListNavigationArgs): Intent {
@@ -80,6 +81,7 @@ class ClipListNavigationImpl @Inject constructor(
             args.accountId?.let {
                 putExtra(EXTRA_ACCOUNT_ID, it)
             }
+            putExtra(EXTRA_ADD_TAB_TO_ACCOUNT_ID, args.addTabToAccountId)
             putExtra(EXTRA_MODE, args.mode.name)
         }
     }

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/PageSettingActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/PageSettingActivity.kt
@@ -92,7 +92,11 @@ class PageSettingActivity : AppCompatActivity() {
                 )))
                 PageType.CLIP_NOTES -> startActivity(
                     clipListNavigation.newIntent(
-                        ClipListNavigationArgs(mode = ClipListNavigationArgs.Mode.AddToTab)
+                        ClipListNavigationArgs(
+                            mode = ClipListNavigationArgs.Mode.AddToTab,
+                            accountId = pt.relatedAccount.accountId,
+                            addTabToAccountId = mPageSettingViewModel.account.value?.accountId
+                        )
                     )
                 )
                 PageType.USERS_GALLERY_POSTS -> {

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageCandidateGenerator.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageCandidateGenerator.kt
@@ -25,7 +25,6 @@ class PageCandidateGenerator @Inject constructor(
         val isSameAccount = related.accountId == currentAccount?.accountId || currentAccount == null
         val restrictionTypes = setOf(
             PageType.NOTIFICATION,
-            PageType.CLIP_NOTES,
             PageType.SEARCH,
             PageType.SEARCH,
             PageType.SEARCH_HASH,

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/clip/ToggleClipAddToTabUseCase.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/clip/ToggleClipAddToTabUseCase.kt
@@ -39,7 +39,7 @@ class ToggleClipAddToTabUseCase @Inject constructor(
                 Page(
                     title = title,
                     weight = -1,
-                    accountId = clip.id.accountId,
+                    accountId = addTabToAccountId ?: clip.id.accountId,
                     pageable = Pageable.ClipNotes(
                         clipId = clip.id.clipId,
                     ),


### PR DESCRIPTION
## やったこと
他アカウントのクリップでもタブに追加できるようにした。
そのためにクリップ一覧画面のEXTRAの項目に
タブに追加する先のアカウントのIdを指定できるようにし、
タブ追加のロジックにもIdを指定できるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1691 


