### PR TITLE
他アカウントの通知とギャラリーをタブに追加できるようにした

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/PageableFragmentFactoryImpl.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/PageableFragmentFactoryImpl.kt
@@ -19,10 +19,10 @@ class PageableFragmentFactoryImpl @Inject constructor(): PageableFragmentFactory
                 NoteDetailFragment.newInstance(page)
             }
             is Pageable.Notification ->{
-                NotificationFragment()
+                NotificationFragment.newInstance(page.attachedAccountId ?: page.accountId)
             }
             is Pageable.Gallery -> {
-                return GalleryPostsFragment.newInstance(pageable, page.accountId)
+                return GalleryPostsFragment.newInstance(pageable, page.attachedAccountId ?: page.accountId)
             }
             else ->{
                 TimelineFragment.newInstance(page)
@@ -57,7 +57,7 @@ class PageableFragmentFactoryImpl @Inject constructor(): PageableFragmentFactory
                 NoteDetailFragment.newInstance(pageable.noteId, accountId)
             }
             is Pageable.Notification ->{
-                NotificationFragment()
+                NotificationFragment.newInstance(accountId)
             }
             is Pageable.Gallery -> {
                 return GalleryPostsFragment.newInstance(pageable, accountId)

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationFragment.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/NotificationFragment.kt
@@ -46,6 +46,18 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class NotificationFragment : Fragment(R.layout.fragment_notification) {
 
+    companion object {
+        fun newInstance(specifiedAccountId: Long? = null): NotificationFragment {
+            return NotificationFragment().apply {
+                arguments = Bundle().apply {
+                    specifiedAccountId?.also {
+                        putLong(NotificationViewModel.EXTRA_SPECIFIED_ACCOUNT_ID, it)
+                    }
+                }
+            }
+        }
+    }
+
 
     lateinit var mLinearLayoutManager: LinearLayoutManager
     private val mViewModel: NotificationViewModel by viewModels()

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageCandidateGenerator.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageCandidateGenerator.kt
@@ -24,8 +24,6 @@ class PageCandidateGenerator @Inject constructor(
 
         val isSameAccount = related.accountId == currentAccount?.accountId || currentAccount == null
         val restrictionTypes = setOf(
-            PageType.NOTIFICATION,
-            PageType.SEARCH,
             PageType.SEARCH,
             PageType.SEARCH_HASH,
             PageType.USER,

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageCandidateGenerator.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/viewmodel/page/PageCandidateGenerator.kt
@@ -28,12 +28,6 @@ class PageCandidateGenerator @Inject constructor(
             PageType.SEARCH_HASH,
             PageType.USER,
             PageType.DETAIL,
-            PageType.GALLERY_FEATURED,
-            PageType.GALLERY_POPULAR,
-            PageType.GALLERY_POSTS,
-            PageType.MY_GALLERY_POSTS,
-            PageType.I_LIKED_GALLERY_POSTS,
-            PageType.USERS_GALLERY_POSTS,
         )
         return when (related.instanceType) {
             Account.InstanceType.MISSKEY -> {


### PR DESCRIPTION
## やったこと
他アカウントの通知とギャラリーをタブに追加できるようにした。
そのためにFragmentを生成する時に参照するアカウントのIdを指定するようにした。
またそのIdを元にアカウントの取得を行いAPIから取得するようにした。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1700



