### PR TITLE
タイムスタンプの表示に絶対日時表示を選択できるようにした

### DIFF
--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DateFormatHelper.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DateFormatHelper.kt
@@ -34,15 +34,23 @@ object DateFormatHelper {
 
 
 
-    @BindingAdapter("elapsedTime")
+    @BindingAdapter("elapsedTime", "isDisplayTimestampsAsAbsoluteDates")
     @JvmStatic
-    fun TextView.setElapsedTime(elapsedTime: Instant?) {
+    fun TextView.setElapsedTime(elapsedTime: Instant?, isDisplayTimestampsAsAbsoluteDates: Boolean?) {
 
-        this.text = GetElapsedTimeStringSource(
-            SimpleElapsedTime(
-                elapsedTime ?: Clock.System.now()
+        this.text = if (isDisplayTimestampsAsAbsoluteDates == true) {
+            SimpleDateFormat.getDateTimeInstance().format(
+                elapsedTime?.let {
+                    Date(it.toEpochMilliseconds())
+                } ?: Date()
             )
-        ).getString(context)
+        } else {
+            GetElapsedTimeStringSource(
+                SimpleElapsedTime(
+                    elapsedTime ?: Clock.System.now()
+                )
+            ).getString(context)
+        }
     }
 
     @BindingAdapter("elapsedTime", "visibility", "isDisplayTimestampsAsAbsoluteDates")

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DateFormatHelper.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DateFormatHelper.kt
@@ -45,9 +45,9 @@ object DateFormatHelper {
         ).getString(context)
     }
 
-    @BindingAdapter("elapsedTime", "visibility")
+    @BindingAdapter("elapsedTime", "visibility", "isDisplayTimestampsAsAbsoluteDates")
     @JvmStatic
-    fun TextView.setElapsedTimeAndVisibility(elapsedTime: Instant?, visibility: Visibility?) {
+    fun TextView.setElapsedTimeAndVisibility(elapsedTime: Instant?, visibility: Visibility?, isDisplayTimestampsAsAbsoluteDates: Boolean?) {
         val visibilityIcon = when(visibility ?: Visibility.Public(false)) {
             is Visibility.Followers -> R.drawable.ic_lock_black_24dp
             is Visibility.Home -> R.drawable.ic_home_black_24dp
@@ -57,11 +57,19 @@ object DateFormatHelper {
             Visibility.Mutual -> R.drawable.ic_sync_alt_24px
             Visibility.Personal -> R.drawable.ic_person_black_24dp
         }
-        val text = GetElapsedTimeStringSource(
-            SimpleElapsedTime(
-                elapsedTime ?: Clock.System.now()
+        val text = if (isDisplayTimestampsAsAbsoluteDates == true) {
+            SimpleDateFormat.getDateTimeInstance().format(
+                elapsedTime?.let {
+                    Date(it.toEpochMilliseconds())
+                } ?: Date()
             )
-        ).getString(context)
+        } else {
+            GetElapsedTimeStringSource(
+                SimpleElapsedTime(
+                    elapsedTime ?: Clock.System.now()
+                )
+            ).getString(context)
+        }
 
         this.text = if (visibilityIcon == null) {
             text

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -598,6 +598,7 @@
     <string name="select_draft_post">下書き投稿を選択</string>
     <string name="remember_scroll_position">スクロール位置を保持する</string>
     <string name="post_only">投稿のみ</string>
+    <string name="settings_display_timestamps_as_absolute_dates">タイムスタンプを絶対表示にする</string>
     <!-- User -->
 
 

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -592,6 +592,7 @@
     <string name="select_draft_post">Select draft post</string>
     <string name="remember_scroll_position">Remember scroll position</string>
     <string name="post_only">Post only</string>
+    <string name="settings_display_timestamps_as_absolute_dates">Display timestamps as absolute dates</string>
     <!-- User -->
 
 </resources>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -597,4 +597,5 @@
     <string name="select_draft_post">Select draft post</string>
     <string name="remember_scroll_position">Remember scroll position</string>
     <string name="post_only">Post only</string>
+    <string name="settings_display_timestamps_as_absolute_dates">Display timestamps as absolute dates</string>
 </resources>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
@@ -126,7 +126,10 @@ fun Config.Companion.from(map: Map<Keys, PrefType?>): Config {
         )?.value ?: DefaultConfig.config.noteHeaderFontSize,
         noteContentFontSize = map.getValue<PrefType.FloatPref>(
             Keys.NoteContentFontSize
-        )?.value ?: DefaultConfig.config.noteContentFontSize
+        )?.value ?: DefaultConfig.config.noteContentFontSize,
+        isDisplayTimestampsAsAbsoluteDates = map.getValue<PrefType.BoolPref>(
+            Keys.IsDisplayTimestampsAsAbsoluteDates
+        )?.value ?: DefaultConfig.config.isDisplayTimestampsAsAbsoluteDates,
     )
 }
 
@@ -228,6 +231,9 @@ fun Config.pref(key: Keys): PrefType {
         }
         Keys.NoteHeaderFontSize -> {
             PrefType.FloatPref(noteHeaderFontSize)
+        }
+        Keys.IsDisplayTimestampsAsAbsoluteDates -> {
+            PrefType.BoolPref(isDisplayTimestampsAsAbsoluteDates)
         }
     }
 }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
@@ -147,6 +147,10 @@ class ConfigKtTest {
                     config.noteHeaderFontSize,
                     (u as PrefType.FloatPref).value
                 )
+                Keys.IsDisplayTimestampsAsAbsoluteDates -> Assertions.assertEquals(
+                    config.isDisplayTimestampsAsAbsoluteDates,
+                    (u as PrefType.BoolPref).value
+                )
             }
         }
     }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
@@ -108,6 +108,10 @@ class KeysKtTest {
                     "NoteHeaderFontSize",
                     key.str()
                 )
+                Keys.IsDisplayTimestampsAsAbsoluteDates -> Assertions.assertEquals(
+                    "IsDisplayTimestampsAsAbsoluteDates",
+                    key.str()
+                )
             }
         }
     }
@@ -115,8 +119,8 @@ class KeysKtTest {
 
     @Test
     fun checkAllKeysCount() {
-        Assertions.assertEquals(29, Keys.allKeys.size)
-        Assertions.assertEquals(29, Keys.allKeys.map { it.str() }.toSet().size)
+        Assertions.assertEquals(30, Keys.allKeys.size)
+        Assertions.assertEquals(30, Keys.allKeys.map { it.str() }.toSet().size)
     }
 
 

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/ImageFragment.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/ImageFragment.kt
@@ -56,6 +56,10 @@ class ImageFragment : Fragment(R.layout.fragment_image){
             return
         }
 
+        binding.swipeFinishLayout.setOnFinishEventListener {
+            requireActivity().finish()
+        }
+
         Glide.with(view.context).let {
             if (uri == null) {
                 it.load(url)

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaActivity.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/MediaActivity.kt
@@ -118,9 +118,6 @@ class MediaActivity : AppCompatActivity() {
 
         val pagerAdapter = MediaPagerAdapter(list)
         mBinding.mediaViewPager.adapter = pagerAdapter
-        mBinding.mediaViewPager.setOnFinishEventListener {
-            finish()
-        }
 
         mBinding.mediaViewPager.currentItem = fileCurrentIndex
     }

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/PhotoViewViewPager.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/PhotoViewViewPager.kt
@@ -2,12 +2,8 @@ package net.pantasystem.milktea.media
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.GestureDetector
 import android.view.MotionEvent
-import android.view.View
 import androidx.viewpager.widget.ViewPager
-import com.github.chrisbanes.photoview.PhotoView
-import kotlin.math.abs
 
 
 /**
@@ -15,132 +11,21 @@ import kotlin.math.abs
  */
 class PhotoViewViewPager : ViewPager {
 
-    fun interface OnFinishEventListener {
-        fun onFinish()
-    }
-
-    companion object {
-
-        private const val SWIPE_THRESHOLD = 150
-
-        private const val SWIPE_VELOCITY_THRESHOLD = 150
-    }
 
     constructor(context: Context) : super(context)
 
     constructor(context: Context, attrs: AttributeSet): super(context, attrs)
 
-    private var onFinishEventListener: OnFinishEventListener? = null
 
-    fun setOnFinishEventListener(listener: OnFinishEventListener?){
-        onFinishEventListener = listener
-    }
 
 
     override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
         return try{
-            if (ev?.action == MotionEvent.ACTION_DOWN) {
-                startY = ev.y
-            }
-            when(ev?.action) {
-                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-                    getPhotoView()?.animate()?.translationY(0f)?.rotation(0f)?.setDuration(200)?.start()
-                    totalTranslationY = 0f
-                }
-            }
-            if (ev != null) {
-                return gestureDetector.onTouchEvent(ev) || super.onInterceptTouchEvent(ev)
-            }
-            return super.onInterceptTouchEvent(null)
+
+            return super.onInterceptTouchEvent(ev)
         }catch(e: IllegalArgumentException){
             false
         }
-    }
-
-
-    private var startY = 0f
-
-    var lastY = 0f
-    var totalTranslationY = 0f
-
-
-    private val gestureDetector = GestureDetector(context, object : GestureDetector.SimpleOnGestureListener() {
-
-        override fun onScroll(
-            e1: MotionEvent,
-            e2: MotionEvent,
-            distanceX: Float,
-            distanceY: Float
-        ): Boolean {
-
-            if (isNotScaled()) {
-                totalTranslationY += e2.rawY - lastY
-                viewToMove()?.translationY = totalTranslationY
-                viewToMove()?.rotation = totalTranslationY / 10
-                lastY = e2.rawY
-            }
-
-            return super.onScroll(e1, e2, distanceX, distanceY)
-        }
-
-        override fun onFling(e1: MotionEvent, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
-            var result = false
-            try {
-                val diffY = e2.y.minus(e1.y)
-                if (abs(diffY) > SWIPE_THRESHOLD && abs(velocityY) > SWIPE_VELOCITY_THRESHOLD) {
-                    if (diffY <= 0) {
-                        onSwipeTop()
-                        result = true
-                    }
-                }
-            } catch (exception: Exception) {
-                exception.printStackTrace()
-            }
-            viewToMove()?.animate()?.translationY(0f)?.rotation(0f)?.setDuration(200)?.start()
-            totalTranslationY = 0f
-            return result
-        }
-
-        override fun onDown(e: MotionEvent): Boolean {
-            lastY = e.rawY
-            return super.onDown(e)
-        }
-
-
-    })
-
-
-    private fun onSwipeTop() {
-
-        if (isNotScaled()) {
-            // Only close if not zoomed in
-            onFinishEventListener?.onFinish()
-//            (context as? Activity)?.finish()
-        }
-    }
-
-    private fun getPhotoView(): PhotoView? {
-        return try {
-            findViewById(R.id.imageView)
-        } catch (e: Exception) {
-            null
-        }
-    }
-
-    private fun getPlayerView(): View? {
-        return try {
-            findViewById(R.id.player_view)
-        } catch (e: Exception) {
-            null
-        }
-    }
-
-    private fun viewToMove(): View? {
-        return getPhotoView() ?: getPlayerView()
-    }
-
-    private fun isNotScaled(): Boolean {
-        return getPhotoView() == null || getPhotoView()?.scale == 1.0F
     }
 
 

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/PlayerFragment.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/PlayerFragment.kt
@@ -73,6 +73,10 @@ class PlayerFragment : Fragment(R.layout.fragment_player){
         simpleExoPlayer.prepare()
         simpleExoPlayer.play()
 
+        view.findViewById<SwipeFinishLayout>(R.id.swipeFinishLayout).setOnFinishEventListener {
+            requireActivity().finish()
+        }
+
         mExoPlayer = simpleExoPlayer
 
     }

--- a/modules/features/media/src/main/java/net/pantasystem/milktea/media/SwipeFinishLayout.kt
+++ b/modules/features/media/src/main/java/net/pantasystem/milktea/media/SwipeFinishLayout.kt
@@ -1,0 +1,151 @@
+package net.pantasystem.milktea.media
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.View
+import android.widget.FrameLayout
+import com.github.chrisbanes.photoview.PhotoView
+import kotlin.math.abs
+
+class SwipeFinishLayout : FrameLayout {
+
+    companion object {
+
+        private const val SWIPE_THRESHOLD = 150
+
+        private const val SWIPE_VELOCITY_THRESHOLD = 150
+    }
+
+
+
+    constructor(context: Context) : super(context)
+
+    constructor(context: Context, attrs: AttributeSet): super(context, attrs)
+
+    fun interface OnFinishEventListener {
+        fun onFinish()
+    }
+
+
+
+    private var onFinishEventListener: OnFinishEventListener? = null
+
+    fun setOnFinishEventListener(listener: OnFinishEventListener?){
+        onFinishEventListener = listener
+    }
+
+
+    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+        return try{
+            if (ev?.action == MotionEvent.ACTION_DOWN) {
+                startY = ev.y
+            }
+            when(ev?.action) {
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                    getPhotoView()?.animate()?.translationY(0f)?.rotation(0f)?.setDuration(200)?.start()
+                    totalTranslationY = 0f
+                }
+            }
+            if (ev != null) {
+                return gestureDetector.onTouchEvent(ev) || super.onInterceptTouchEvent(ev)
+            }
+            return super.onInterceptTouchEvent(null)
+        }catch(e: IllegalArgumentException){
+            false
+        }
+    }
+
+
+    private var startY = 0f
+
+    var lastY = 0f
+    var totalTranslationY = 0f
+
+
+    private val gestureDetector = GestureDetector(context, object : GestureDetector.SimpleOnGestureListener() {
+
+        override fun onScroll(
+            e1: MotionEvent,
+            e2: MotionEvent,
+            distanceX: Float,
+            distanceY: Float
+        ): Boolean {
+
+            // 縦スクロールの場合
+            if (abs(e2.y - startY) > abs(e2.x - e1.x)) {
+                if (isNotScaled()) {
+                    totalTranslationY += e2.rawY - lastY
+                    viewToMove()?.translationY = totalTranslationY
+                    viewToMove()?.rotation = totalTranslationY / 10
+                    lastY = e2.rawY
+                }
+
+            }
+
+            return super.onScroll(e1, e2, distanceX, distanceY)
+        }
+
+        override fun onFling(e1: MotionEvent, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
+            var result = false
+            try {
+                val diffY = e2.y.minus(e1.y)
+                if (abs(diffY) > SWIPE_THRESHOLD && abs(velocityY) > SWIPE_VELOCITY_THRESHOLD) {
+                    if (diffY <= 0) {
+                        onSwipeTop()
+                        result = true
+                    }
+                }
+            } catch (exception: Exception) {
+                exception.printStackTrace()
+            }
+            viewToMove()?.animate()?.translationY(0f)?.rotation(0f)?.setDuration(200)?.start()
+            totalTranslationY = 0f
+            return result
+        }
+
+        override fun onDown(e: MotionEvent): Boolean {
+            lastY = e.rawY
+            return super.onDown(e)
+        }
+
+
+    })
+
+
+    private fun onSwipeTop() {
+
+        if (isNotScaled()) {
+            // Only close if not zoomed in
+            onFinishEventListener?.onFinish()
+//            (context as? Activity)?.finish()
+        }
+    }
+
+    private fun getPhotoView(): PhotoView? {
+        return try {
+            findViewById(R.id.imageView)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun getPlayerView(): View? {
+        return try {
+            findViewById(R.id.player_view)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun viewToMove(): View? {
+        return getPhotoView() ?: getPlayerView()
+    }
+
+    private fun isNotScaled(): Boolean {
+        return getPhotoView() == null || getPhotoView()?.scale == 1.0F
+    }
+
+
+}

--- a/modules/features/media/src/main/res/layout/fragment_image.xml
+++ b/modules/features/media/src/main/res/layout/fragment_image.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <com.github.chrisbanes.photoview.PhotoView
+    <net.pantasystem.milktea.media.SwipeFinishLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/swipeFinishLayout">
+        <com.github.chrisbanes.photoview.PhotoView
             android:id="@+id/imageView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>
+    </net.pantasystem.milktea.media.SwipeFinishLayout>
+
 </layout>

--- a/modules/features/media/src/main/res/layout/fragment_player.xml
+++ b/modules/features/media/src/main/res/layout/fragment_player.xml
@@ -2,8 +2,13 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:orientation="vertical" android:layout_width="match_parent"
         android:layout_height="match_parent">
-    <com.google.android.exoplayer2.ui.StyledPlayerView
+    <net.pantasystem.milktea.media.SwipeFinishLayout
+        android:id="@+id/swipeFinishLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <com.google.android.exoplayer2.ui.StyledPlayerView
             android:id="@+id/player_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>
+    </net.pantasystem.milktea.media.SwipeFinishLayout>
 </LinearLayout>

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenotesViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/RenotesViewModel.kt
@@ -15,6 +15,8 @@ import net.pantasystem.milktea.common.runCancellableCatching
 import net.pantasystem.milktea.model.notes.*
 import net.pantasystem.milktea.model.notes.repost.RenoteType
 import net.pantasystem.milktea.model.notes.repost.RenotesPagingService
+import net.pantasystem.milktea.model.setting.DefaultConfig
+import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserRepository
 
@@ -24,6 +26,7 @@ class RenotesViewModel @AssistedInject constructor(
     private val noteRepository: NoteRepository,
     private val noteCaptureAPIAdapter: NoteCaptureAPIAdapter,
     private val userRepository: UserRepository,
+    configRepository: LocalConfigRepository,
     accountStore: AccountStore,
     loggerFactory: Logger.Factory,
     @Assisted val noteId: Note.Id,
@@ -42,6 +45,12 @@ class RenotesViewModel @AssistedInject constructor(
 
 
     private val logger = loggerFactory.create("RenotesVM")
+
+    val config = configRepository.observe().stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        DefaultConfig.config,
+    )
 
     val renotes = renotesPagingService.state.map { state ->
         state.suspendConvert { renotes ->

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/item_renote_user.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/item_renote_user.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -24,6 +25,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import net.pantasystem.milktea.common_compose.CustomEmojiText
 import net.pantasystem.milktea.common_compose.getSimpleElapsedTime
 import net.pantasystem.milktea.model.user.User
+import java.text.SimpleDateFormat
+import java.util.*
 
 @ExperimentalCoroutinesApi
 @Composable
@@ -32,12 +35,22 @@ fun ItemRenoteUser(
     note: RenoteItemType,
     myId: User.Id?,
     accountHost: String?,
+    isDisplayTimestampsAsAbsoluteDates: Boolean,
     onAction: (ItemRenoteAction) -> Unit,
     isUserNameDefault: Boolean = false
 ) {
 
-    val createdAt = (note as? RenoteItemType.Renote)?.let {
-        getSimpleElapsedTime(time = it.note.note.createdAt)
+    val createdAt = (note as? RenoteItemType.Renote)?.let { renote ->
+        if (isDisplayTimestampsAsAbsoluteDates) {
+            remember(renote.note.note.createdAt) {
+                SimpleDateFormat.getDateTimeInstance().format(renote.note.note.createdAt.let {
+                    Date(it.toEpochMilliseconds())
+                })
+            }
+        } else {
+            getSimpleElapsedTime(time = renote.note.note.createdAt)
+        }
+
     }
 
     Card(

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/renote_users.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/renote/renote_users.kt
@@ -39,6 +39,7 @@ fun RenoteUsersScreen(
 
     val myId by renotesViewModel.myId.collectAsState()
     val account by renotesViewModel.account.collectAsState()
+    val config by renotesViewModel.config.collectAsState()
 
     val renotes: PageableState<List<RenoteItemType>> by renotesViewModel.renotes.asLiveData()
         .observeAsState(
@@ -72,6 +73,7 @@ fun RenoteUsersScreen(
             onScrollState = onScrollState,
             myId = myId,
             accountHost = account?.getHost(),
+            isDisplayTimestampsAsAbsoluteDates = config.isDisplayTimestampsAsAbsoluteDates,
         )
     } else {
         Column(
@@ -103,6 +105,7 @@ fun RenoteUserList(
     notes: List<RenoteItemType>,
     myId: User.Id?,
     accountHost: String?,
+    isDisplayTimestampsAsAbsoluteDates: Boolean?,
     onAction: (ItemRenoteAction) -> Unit,
     onBottomReached: () -> Unit,
     onScrollState: (Boolean) -> Unit,
@@ -141,6 +144,7 @@ fun RenoteUserList(
                 onAction = onAction,
                 myId = myId,
                 accountHost = accountHost,
+                isDisplayTimestampsAsAbsoluteDates = isDisplayTimestampsAsAbsoluteDates ?: false,
             )
         }
     }

--- a/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
+++ b/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
@@ -92,6 +92,7 @@
                 android:ellipsize="end"
                 elapsedTime="@{note.toShowNote.note.createdAt}"
                 visibility="@{note.toShowNote.note.visibility}"
+                isDisplayTimestampsAsAbsoluteDates="@{note.config.displayTimestampsAsAbsoluteDates}"
                 android:layout_alignParentEnd="true"
                 android:gravity="end"
                 tools:text="16分前"

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -95,6 +95,7 @@
                 android:ellipsize="end"
                 elapsedTime="@{note.toShowNote.note.createdAt}"
                 visibility="@{note.toShowNote.note.visibility}"
+                isDisplayTimestampsAsAbsoluteDates="@{note.config.displayTimestampsAsAbsoluteDates}"
 
                 android:layout_alignParentEnd="true"
                 android:gravity="end"

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/viewmodel/NotificationViewData.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/viewmodel/NotificationViewData.kt
@@ -1,14 +1,21 @@
 package net.pantasystem.milktea.notification.viewmodel
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import net.pantasystem.milktea.common_android.resource.StringSource
 import net.pantasystem.milktea.model.notification.*
+import net.pantasystem.milktea.model.setting.DefaultConfig
+import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
 import net.pantasystem.milktea.notification.R
 
 class NotificationViewData(
     val notification: NotificationRelation,
-    val noteViewData: PlaneNoteViewData?
+    val noteViewData: PlaneNoteViewData?,
+    configRepository: LocalConfigRepository,
+    coroutineScope: CoroutineScope,
 ) {
     enum class Type(val default: String) {
         FOLLOW("follow"),
@@ -62,6 +69,8 @@ class NotificationViewData(
     val followRequestMessageSource: StringSource? = (notification.notification as? ReceiveFollowRequestNotification?)?.let {
         StringSource(R.string.follow_requested_by, name ?: "")
     }
+
+    val config = configRepository.observe().stateIn(coroutineScope, SharingStarted.WhileSubscribed(5_000), DefaultConfig.config)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/viewmodel/NotificationViewModel.kt
+++ b/modules/features/notification/src/main/java/net/pantasystem/milktea/notification/viewmodel/NotificationViewModel.kt
@@ -22,6 +22,7 @@ import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.model.filter.WordFilterService
 import net.pantasystem.milktea.model.group.GroupRepository
 import net.pantasystem.milktea.model.notification.*
+import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.model.user.FollowRequestRepository
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewDataCache
 import javax.inject.Inject
@@ -35,6 +36,7 @@ class NotificationViewModel @Inject constructor(
     private val followRequestRepository: FollowRequestRepository,
     private val notificationRepository: NotificationRepository,
     private val noteWordFilterService: WordFilterService,
+    private val configRepository: LocalConfigRepository,
     planeNoteViewDataCacheFactory: PlaneNoteViewDataCache.Factory,
     loggerFactory: Logger.Factory,
     accountStore: AccountStore,
@@ -66,6 +68,8 @@ class NotificationViewModel @Inject constructor(
                 NotificationViewData(
                     n,
                     noteViewData,
+                    configRepository,
+                    viewModelScope,
                 )
             }
         }

--- a/modules/features/notification/src/main/res/layout/item_notification.xml
+++ b/modules/features/notification/src/main/res/layout/item_notification.xml
@@ -105,6 +105,7 @@
                         tools:text="16min"
                         android:singleLine="true"
                         elapsedTime="@{notification.notification.notification.createdAt}"
+                        isDisplayTimestampsAsAbsoluteDates="@{notification.config.displayTimestampsAsAbsoluteDates}"
                         android:layout_gravity="center"/>
             </LinearLayout>
             <LinearLayout

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
@@ -214,7 +214,7 @@ class SettingAppearanceActivity : AppCompatActivity() {
                                     currentConfigState = currentConfigState.copy(isDisplayTimestampsAsAbsoluteDates = it)
                                 }
                             ) {
-                                Text("Display timestamps as absolute dates")
+                                Text(stringResource(id = R.string.settings_display_timestamps_as_absolute_dates))
                             }
                         }
                         SettingSection(

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
@@ -207,6 +207,15 @@ class SettingAppearanceActivity : AppCompatActivity() {
                             ) {
                                 Text(stringResource(id = R.string.settings_visible_instance_domain_in_toolbar))
                             }
+
+                            SettingSwitchTile(
+                                checked = currentConfigState.isDisplayTimestampsAsAbsoluteDates,
+                                onChanged = {
+                                    currentConfigState = currentConfigState.copy(isDisplayTimestampsAsAbsoluteDates = it)
+                                }
+                            ) {
+                                Text("Display timestamps as absolute dates")
+                            }
                         }
                         SettingSection(
                             title = stringResource(id = R.string.background_image),

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/reaction/UserReactionBindingModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/reaction/UserReactionBindingModel.kt
@@ -2,6 +2,7 @@ package net.pantasystem.milktea.user.reaction
 
 import kotlinx.coroutines.flow.StateFlow
 import net.pantasystem.milktea.model.notes.reaction.Reaction
+import net.pantasystem.milktea.model.setting.Config
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.reaction.UserReaction
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
@@ -10,6 +11,7 @@ class UserReactionBindingModel(
     val reaction: UserReaction,
     val note: PlaneNoteViewData,
     val user: StateFlow<User>,
+    val config: StateFlow<Config>,
 ) {
     val emojis
         get() = note.toShowNote.note.emojis

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/reaction/UserReactionsViewModel.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/reaction/UserReactionsViewModel.kt
@@ -13,6 +13,8 @@ import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common.PageableState
 import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.account.CurrentAccountWatcher
+import net.pantasystem.milktea.model.setting.DefaultConfig
+import net.pantasystem.milktea.model.setting.LocalConfigRepository
 import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserDataSource
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewDataCache
@@ -26,6 +28,7 @@ class UserReactionsViewModel @Inject constructor(
     loggerFactory: Logger.Factory,
     planeNoteViewDataCacheFactory: PlaneNoteViewDataCache.Factory,
     private val savedStateHandle: SavedStateHandle,
+    configRepository: LocalConfigRepository,
 ) : ViewModel() {
     //    private val _userId = MutableStateFlow<User.Id?>(null)
     companion object {
@@ -48,6 +51,8 @@ class UserReactionsViewModel @Inject constructor(
 
     private val cache = planeNoteViewDataCacheFactory.create(currentAccountWatcher::getAccount, viewModelScope)
 
+    private val config = configRepository.observe().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000),  DefaultConfig.config)
+
 
     private val store = storeFactory.create(userId)
     val state = store.state.map { pageableState ->
@@ -57,7 +62,8 @@ class UserReactionsViewModel @Inject constructor(
                     reaction = it.reaction,
                     user = userDataSource.observe(it.user.id)
                         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), it.user),
-                    note = cache.get(it.note)
+                    note = cache.get(it.note),
+                    config = config,
                 )
             }
         }

--- a/modules/features/user/src/main/res/layout/item_user_reaction.xml
+++ b/modules/features/user/src/main/res/layout/item_user_reaction.xml
@@ -66,6 +66,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         elapsedTime="@{bindingModel.reaction.createdAt}"
+                        isDisplayTimestampsAsAbsoluteDates="@{bindingModel.config.displayTimestampsAsAbsoluteDates}"
                         android:textColor="?attr/colorPrimary"
                         app:emojiCompatEnabled="false"
                     />

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
@@ -81,6 +81,7 @@ data class Config(
     val isHideMediaWhenMobileNetwork: Boolean,
     val noteHeaderFontSize: Float,
     val noteContentFontSize: Float,
+    val isDisplayTimestampsAsAbsoluteDates: Boolean,
 ) {
     companion object
 
@@ -138,6 +139,7 @@ object DefaultConfig {
         isHideMediaWhenMobileNetwork = false,
         noteContentFontSize = 15f,
         noteHeaderFontSize = 15f,
+        isDisplayTimestampsAsAbsoluteDates = false,
     )
 
     fun getRememberVisibilityConfig(accountId: Long): RememberVisibility.Remember {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
@@ -31,6 +31,7 @@ val Keys.Companion.allKeys by lazy {
         Keys.IsHideMediaWhenMobileNetwork,
         Keys.NoteHeaderFontSize,
         Keys.NoteContentFontSize,
+        Keys.IsDisplayTimestampsAsAbsoluteDates,
     )
 }
 
@@ -88,6 +89,8 @@ sealed interface Keys {
 
     object NoteContentFontSize: Keys
 
+    object IsDisplayTimestampsAsAbsoluteDates: Keys
+
     companion object
 }
 
@@ -122,5 +125,6 @@ fun Keys.str(): String {
         is Keys.IsHideMediaWhenMobileNetwork -> "IsHideMediaWhenMobileNetwork"
         is Keys.NoteContentFontSize -> "NoteContentFontSize"
         is Keys.NoteHeaderFontSize -> "NoteHeaderFontSize"
+        is Keys.IsDisplayTimestampsAsAbsoluteDates -> "IsDisplayTimestampsAsAbsoluteDates"
     }
 }


### PR DESCRIPTION
## やったこと
絶対日時表記原理主義者のためにタイムラインのノート、通知のタイムスタンプ、リノート一覧のタイムスタンプの表記を
相対表記から絶対表記にできるように設定から変えられるようにした。
そのために設定に絶対表記であることを表すためのフラグを追加するようにした。
また設定画面に表示方式を切り替えるためのSwitchを追加した。

## 動作確認


## スクリーンショット(任意)


## 備考
メッセージ画面は以前の仕様のまま


## Issue番号
Closed #1707 


