### PR TITLE
ノートのタイムスタンプを絶対日時表示にする時は、下部に表示するようにした

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ThemeUtil.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ThemeUtil.kt
@@ -29,6 +29,7 @@ fun Activity.setTheme() {
         Theme.Black -> setTheme(R.style.AppThemeBlack)
         Theme.Bread -> setTheme(R.style.AppThemeBread)
         Theme.White -> setTheme(R.style.AppTheme)
+        Theme.ElephantDark -> setTheme(R.style.AppThemeMastodonDark)
     }
 
 }

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DateFormatHelper.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DateFormatHelper.kt
@@ -103,4 +103,37 @@ object DateFormatHelper {
         val javaDate = Date(date.toEpochMilliseconds())
         this.text = SimpleDateFormat.getDateTimeInstance().format(javaDate)
     }
+
+    @BindingAdapter("createdAt", "visibility")
+    @JvmStatic
+    fun TextView.setCreatedAtWithVisibility(createdAt: Instant?, visibility: Visibility?) {
+        val date = createdAt ?: Clock.System.now()
+        val javaDate = Date(date.toEpochMilliseconds())
+        val visibilityIcon = when(visibility ?: Visibility.Public(false)) {
+            is Visibility.Followers -> R.drawable.ic_lock_black_24dp
+            is Visibility.Home -> R.drawable.ic_home_black_24dp
+            is Visibility.Public -> null
+            is Visibility.Specified -> R.drawable.ic_email_black_24dp
+            is Visibility.Limited -> R.drawable.ic_groups
+            Visibility.Mutual -> R.drawable.ic_sync_alt_24px
+            Visibility.Personal -> R.drawable.ic_person_black_24dp
+        }
+        val text = SimpleDateFormat.getDateTimeInstance().format(javaDate)
+
+        this.text = if (visibilityIcon == null) {
+            text
+        } else {
+            val target = "visibility $text"
+            SpannableStringBuilder(target).apply {
+                val drawable = ContextCompat.getDrawable(context, visibilityIcon)
+                drawable?.setTint(currentTextColor)
+                val span = DrawableEmojiSpan(EmojiAdapter(this@setCreatedAtWithVisibility), visibilityIcon)
+                setSpan(span, 0, "visibility".length,0)
+                GlideApp.with(this@setCreatedAtWithVisibility)
+                    .load(drawable)
+                    .override(min(textSize.toInt(), 640))
+                    .into(span.target)
+            }
+        }
+    }
 }

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -90,6 +90,8 @@
     <string name="theme_black">ブラック</string>
     <string name="theme_dark">ダーク</string>
     <string name="theme_bread">パンケーキ</string>
+    <string name="theme_mastodon_dark">ダーク(🐘)</string>
+
 
     <string name="title_activity_media">MediaActivity</string>
     <string name="dummy_button">Dummy Button</string>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -90,6 +90,8 @@
     <string name="theme_black">黑色</string>
     <string name="theme_dark">暗色</string>
     <string name="theme_bread">薄饼</string>
+    <string name="theme_mastodon_dark">Elephant Dark</string>
+
 
     <string name="title_activity_media">媒体活动</string>
     <string name="dummy_button">虚拟按钮</string>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
     <string name="theme_black">AMOLED</string>
     <string name="theme_dark">Dark</string>
     <string name="theme_bread">Pancake</string>
+    <string name="theme_mastodon_dark">Elephant Dark</string>
 
     <string name="title_activity_media">MediaActivity</string>
     <string name="dummy_button">Dummy Button</string>

--- a/modules/common_resource/src/main/res/values/themes.xml
+++ b/modules/common_resource/src/main/res/values/themes.xml
@@ -102,4 +102,20 @@
     </style>
 
 
+    <style name="AppThemeMastodonDark" parent="AppThemeDark">
+        <item name="colorPrimary">#FF8C8DFE</item>
+        <item name="colorPrimaryDark">#FF282c37</item>
+        <item name="colorSurface">#FF282C37</item>
+        <item name="colorSecondary">#FF595aff</item>
+        <item name="appBarLayoutStyle">@style/Widget.MaterialComponents.Toolbar.PrimarySurface</item>
+        <item name="toolbarStyle">@style/Widget.MaterialComponents.Toolbar.PrimarySurface</item>
+        <item name="tabStyle">@style/Widget.MaterialComponents.TabLayout.PrimarySurface</item>
+        <item name="bottomNavigationStyle">@style/BottomNavigationView4Dark</item>
+        <item name="colorSelectedReactionCounterBackground">#FF8C8DFE</item>
+        <item name="colorNormalReactionCounterBackground">#FF424859</item>
+
+<!--        <item name="android:navigationBarColor">@color/colorBreadPrimary</item>-->
+
+    </style>
+
 </resources>

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Theme.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Theme.kt
@@ -9,6 +9,7 @@ fun Theme.toInt(): Int {
         is Theme.Black -> 1
         is Theme.Dark -> 2
         is Theme.Bread -> 3
+        Theme.ElephantDark -> 4
     }
 }
 
@@ -18,6 +19,7 @@ fun Theme.Companion.from(n: Int): Theme {
         1 -> Theme.Black
         2 -> Theme.Dark
         3 -> Theme.Bread
+        4 -> Theme.ElephantDark
         else -> DefaultConfig.config.theme
     }
 }

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -106,6 +106,7 @@
                 android:textColor="?attr/colorPrimary"
                 app:emojiCompatEnabled="false"
                 android:onClick="@{() -> noteCardActionListener.onNoteCardClicked(note.note.note)}"
+                android:visibility="@{note.config.displayTimestampsAsAbsoluteDates ? View.GONE : View.VISIBLE}"
                 />
 
         <net.pantasystem.milktea.common_android.ui.AutoCollapsingLayout
@@ -423,11 +424,28 @@
                 android:onClick="@{ ()-> note.expandReactions() }"
                 />
 
+        <TextView
+                android:id="@+id/absoluteTimestamp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                createdAt="@{note.toShowNote.note.createdAt}"
+                app:layout_constraintTop_toBottomOf="@id/expandAllReactionCounts"
+                app:layout_constraintStart_toEndOf="@id/avatarIcon"
+                tools:text="10秒前"
+                android:singleLine="true"
+                android:ellipsize="end"
+                android:layout_marginStart="8dp"
+                android:visibility="@{note.config.displayTimestampsAsAbsoluteDates ? View.VISIBLE : View.GONE}"
+                android:textColor="?attr/colorPrimary"
+                android:onClick="@{() -> noteCardActionListener.onNoteCardClicked(note.note.note)}"
+
+            />
+
         <LinearLayout
                 android:id="@+id/noteActionButtonsBase"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                app:layout_constraintTop_toBottomOf="@id/expandAllReactionCounts"
+                app:layout_constraintTop_toBottomOf="@id/absoluteTimestamp"
                 app:layout_constraintStart_toEndOf="@id/avatarIcon"
                 app:layout_constraintEnd_toEndOf="parent"
                 android:gravity="center_vertical"

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -429,6 +429,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 createdAt="@{note.toShowNote.note.createdAt}"
+                visibility="@{note.toShowNote.note.visibility}"
                 app:layout_constraintTop_toBottomOf="@id/expandAllReactionCounts"
                 app:layout_constraintStart_toEndOf="@id/avatarIcon"
                 tools:text="10秒前"
@@ -438,6 +439,7 @@
                 android:visibility="@{note.config.displayTimestampsAsAbsoluteDates ? View.VISIBLE : View.GONE}"
                 android:textColor="?attr/colorPrimary"
                 android:onClick="@{() -> noteCardActionListener.onNoteCardClicked(note.note.note)}"
+                android:layout_marginTop="2dp"
 
             />
 

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
@@ -91,6 +91,10 @@ class SettingAppearanceActivity : AppCompatActivity() {
             ThemeUiState(
                 Theme.Bread,
                 R.string.theme_bread,
+            ),
+            ThemeUiState(
+                Theme.ElephantDark,
+                R.string.theme_mastodon_dark,
             )
         )
     }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Theme.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Theme.kt
@@ -5,10 +5,12 @@ sealed interface Theme {
     object Black : Theme
     object Dark : Theme
     object Bread : Theme
+
+    object ElephantDark : Theme
     companion object
 }
 
 
 fun Theme.isNightTheme(): Boolean {
-    return this is Theme.Black || this is Theme.Dark
+    return this is Theme.Black || this is Theme.Dark || this is Theme.ElephantDark
 }


### PR DESCRIPTION
## やったこと
ノートのタイムスタンプを絶対日時表示にする時は、下部に表示するようにした。
また相対時刻表示を行っていたTextViewは非表示にするようにした。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1711



