### PR TITLE
DriveFileの更新処理時にundefined, nullを区別できるような実装にした

### DIFF
--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/MisskeyAPI.kt
@@ -1,5 +1,6 @@
 package net.pantasystem.milktea.api.misskey
 
+import kotlinx.serialization.json.JsonObject
 import net.pantasystem.milktea.api.misskey.ap.ApResolveRequest
 import net.pantasystem.milktea.api.misskey.ap.ApResolveResult
 import net.pantasystem.milktea.api.misskey.app.CreateApp
@@ -198,7 +199,7 @@ interface MisskeyAPI {
     suspend fun getFiles(@Body fileRequest: RequestFile): Response<List<FilePropertyDTO>>
 
     @POST("api/drive/files/update")
-    suspend fun updateFile(@Body updateFileRequest: UpdateFileDTO): Response<FilePropertyDTO>
+    suspend fun updateFile(@Body updateFileRequest: JsonObject): Response<FilePropertyDTO>
 
     @POST("api/drive/files/delete")
     suspend fun deleteFile(@Body req: DeleteFileDTO): Response<Unit>

--- a/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/drive/UpdateFileDTO.kt
+++ b/modules/api/src/main/java/net/pantasystem/milktea/api/misskey/drive/UpdateFileDTO.kt
@@ -1,39 +1,75 @@
 package net.pantasystem.milktea.api.misskey.drive
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import net.pantasystem.milktea.model.drive.UpdateFileProperty
+import net.pantasystem.milktea.model.drive.ValueType
 
-@Serializable
-data class UpdateFileDTO(
-    @SerialName("i")
-    val i: String,
+//@Serializable
+//data class UpdateFileDTO(
+//    @SerialName("i")
+//    val i: String,
+//
+//    @SerialName("fileId")
+//    val fileId: String,
+//
+//    @SerialName("folderId")
+//    val folderId: String?,
+//
+//    @SerialName("name")
+//    val name: String,
+//
+//    @SerialName("comment")
+//    val comment: String?,
+//
+//    @SerialName("isSensitive")
+//    val isSensitive: Boolean,
+//) {
+//    companion object
+//}
 
-    @SerialName("fileId")
-    val fileId: String,
+//fun UpdateFileDTO.Companion.from(token: String, model: UpdateFileProperty): UpdateFileDTO {
+//    return UpdateFileDTO(
+//        i = token,
+//        comment = model.comment,
+//        fileId = model.fileId.fileId,
+//        folderId = model.folderId,
+//        isSensitive = model.isSensitive,
+//        name = model.name
+//    )
+//}
 
-    @SerialName("folderId")
-    val folderId: String?,
+@OptIn(ExperimentalSerializationApi::class)
+fun UpdateFileProperty.toJsonObject(token: String): JsonObject {
+    return buildJsonObject {
+        put("i", JsonPrimitive(token))
+        put("fileId", JsonPrimitive(fileId.fileId))
 
-    @SerialName("name")
-    val name: String,
+        when(val v = comment) {
+            is ValueType.Empty -> put("comment", JsonPrimitive(null))
+            is ValueType.Some -> put("comment", JsonPrimitive(v.value))
+            null -> Unit
+        }
 
-    @SerialName("comment")
-    val comment: String?,
+        when(val v = folderId) {
+            is ValueType.Empty -> put("folderId", JsonPrimitive(null))
+            is ValueType.Some -> put("folderId", JsonPrimitive(v.value))
+            null -> Unit
+        }
 
-    @SerialName("isSensitive")
-    val isSensitive: Boolean,
-) {
-    companion object
-}
+        when(val v = name) {
+            is ValueType.Empty -> put("name", JsonPrimitive(null))
+            is ValueType.Some -> put("name", JsonPrimitive(v.value))
+            null -> Unit
+        }
 
-fun UpdateFileDTO.Companion.from(token: String, model: UpdateFileProperty): UpdateFileDTO {
-    return UpdateFileDTO(
-        i = token,
-        comment = model.comment,
-        fileId = model.fileId.fileId,
-        folderId = model.folderId,
-        isSensitive = model.isSensitive,
-        name = model.name
-    )
+        when(val v = isSensitive) {
+            is ValueType.Empty -> put("isSensitive", JsonPrimitive(null))
+            is ValueType.Some -> put("isSensitive", JsonPrimitive(v.value))
+            null -> Unit
+        }
+
+    }
 }

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/editor/viewmodel/NoteEditorViewModel.kt
@@ -22,10 +22,7 @@ import net.pantasystem.milktea.model.ap.ApResolver
 import net.pantasystem.milktea.model.ap.ApResolverRepository
 import net.pantasystem.milktea.model.channel.Channel
 import net.pantasystem.milktea.model.channel.ChannelRepository
-import net.pantasystem.milktea.model.drive.DriveFileRepository
-import net.pantasystem.milktea.model.drive.FileProperty
-import net.pantasystem.milktea.model.drive.FilePropertyDataSource
-import net.pantasystem.milktea.model.drive.UpdateFileProperty
+import net.pantasystem.milktea.model.drive.*
 import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.file.AppFile
 import net.pantasystem.milktea.model.file.FilePreviewSource
@@ -513,10 +510,7 @@ class NoteEditorViewModel @Inject constructor(
                         driveFileRepository.update(
                             UpdateFileProperty(
                                 fileId = file.id,
-                                comment = file.comment,
-                                folderId = file.folderId,
-                                isSensitive = file.isSensitive,
-                                name = name
+                                name = ValueType.Some(name)
                             )
                         ).getOrThrow()
                     }.onFailure {
@@ -540,10 +534,7 @@ class NoteEditorViewModel @Inject constructor(
                         driveFileRepository.update(
                             UpdateFileProperty(
                                 fileId = file.id,
-                                comment = comment,
-                                folderId = file.folderId,
-                                isSensitive = file.isSensitive,
-                                name = file.name
+                                comment = ValueType.Some(comment),
                             )
                         ).getOrThrow()
                     }.onFailure {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/drive/FileProperty.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/drive/FileProperty.kt
@@ -5,7 +5,7 @@ import net.pantasystem.milktea.model.user.User
 
 import java.io.Serializable as JSerializable
 
-data class FileProperty (
+data class FileProperty(
     val id: Id,
     val name: String,
     val createdAt: Instant?,
@@ -20,28 +20,59 @@ data class FileProperty (
     val blurhash: String? = null,
     val url: String,
     val thumbnailUrl: String? = null,
-) : JSerializable{
+) : JSerializable {
     data class Id(
         val accountId: Long,
-        val fileId: String
+        val fileId: String,
     ) : JSerializable
+
     data class Properties(
         val width: Float?,
-        val height: Float?
+        val height: Float?,
     ) : JSerializable
 
     fun update(
         name: String = requireNotNull(this.name),
-        comment: String? = this.comment,
-        isSensitive: Boolean = this.isSensitive,
-        folderId: String? = this.folderId,
+        comment: String? = null,
+        isSensitive: Boolean? = null,
+        folderId: String? = null,
     ): UpdateFileProperty {
         return UpdateFileProperty(
-            name = name,
-            comment = comment,
-            fileId = this.id,
-            isSensitive = isSensitive,
-            folderId = folderId,
+            fileId = id,
+            name = if (name == this.name) null else ValueType.Some(name),
+            comment = when (comment) {
+                this.comment -> {
+                    null
+                }
+                null -> {
+                    ValueType.Empty()
+                }
+                else -> {
+                    ValueType.Some(comment)
+                }
+            },
+            isSensitive = when (isSensitive) {
+                this.isSensitive -> {
+                    null
+                }
+                null -> {
+                    null
+                }
+                else -> {
+                    ValueType.Some(isSensitive)
+                }
+            },
+            folderId = when (folderId) {
+                this.folderId -> {
+                    null
+                }
+                null -> {
+                    ValueType.Empty()
+                }
+                else -> {
+                    ValueType.Some(folderId)
+                }
+            },
         )
     }
 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/drive/UpdateFileProperty.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/drive/UpdateFileProperty.kt
@@ -7,3 +7,10 @@ data class UpdateFileProperty(
     val isSensitive: Boolean,
     val comment: String?,
 )
+
+sealed interface ValueType<T> {
+    class Empty<T> : ValueType<T>
+
+    data class Some<T>(val value: T) : ValueType<T>
+
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/drive/UpdateFileProperty.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/drive/UpdateFileProperty.kt
@@ -2,10 +2,10 @@ package net.pantasystem.milktea.model.drive
 
 data class UpdateFileProperty(
     val fileId: FileProperty.Id,
-    val folderId: String?,
-    val name: String,
-    val isSensitive: Boolean,
-    val comment: String?,
+    val folderId: ValueType<String>? = null,
+    val name: ValueType<String>? = null,
+    val isSensitive: ValueType<Boolean>? = null,
+    val comment: ValueType<String>? = null,
 )
 
 sealed interface ValueType<T> {


### PR DESCRIPTION
## やったこと
これまではDriveFileをnullと実値のある2値でしか扱えない実装をしていたが、
Misskeyのバックエンドの実装は3値(null, undefined, some)だったため、
正しく処理を実行するためには3値扱えるようにする必要性があった。
そこで3値を表現できるように再実装した。
実際にやった方法としては標準のclassを使った方法ではうまく表現できなかったので、
JsonObjectを使うようにした（地獄）。
またModelレイヤーでJsonObjectを扱うのは嫌なので、Modeレイヤーでは
ValueTypeという代数的データ型を用意しそれで3値を表現できるようにした。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1720

