### PR TITLE
タグタイムラインを表示している時に投稿画面を開いた時はタグを引き継ぐようにした

### DIFF
--- a/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/FabClickHandler.kt
+++ b/app/src/main/java/jp/panta/misskeyandroidclient/ui/main/FabClickHandler.kt
@@ -9,6 +9,7 @@ import net.pantasystem.milktea.common_viewmodel.CurrentPageableTimelineViewModel
 import net.pantasystem.milktea.common_viewmodel.SuitableType
 import net.pantasystem.milktea.common_viewmodel.suitableType
 import net.pantasystem.milktea.gallery.GalleryPostsActivity
+import net.pantasystem.milktea.model.account.page.Pageable
 import net.pantasystem.milktea.model.channel.Channel
 import net.pantasystem.milktea.note.NoteEditorActivity
 
@@ -20,14 +21,28 @@ internal class FabClickHandler(
 
     fun onClicked() {
         activity.apply {
-            when(val type = currentPageableTimelineViewModel.currentType.value) {
+            when (val type = currentPageableTimelineViewModel.currentType.value) {
                 CurrentPageType.Account -> {
-                    AccountSwitchingDialog().show(activity.supportFragmentManager, "AccountSwitchingDialog")
+                    AccountSwitchingDialog().show(
+                        activity.supportFragmentManager,
+                        "AccountSwitchingDialog"
+                    )
                 }
                 is CurrentPageType.Page -> {
                     when (val suitableType = type.pageable.suitableType()) {
                         is SuitableType.Other -> {
-                            startActivity(NoteEditorActivity.newBundle(this, accountId = type.accountId))
+                            val text = when (val pageable = type.pageable) {
+                                is Pageable.SearchByTag -> "#${pageable.tag}"
+                                is Pageable.Mastodon.HashTagTimeline -> "#${pageable.hashtag}"
+                                else -> ""
+                            }
+                            startActivity(
+                                NoteEditorActivity.newBundle(
+                                    this,
+                                    accountId = type.accountId,
+                                    text = text
+                                )
+                            )
                         }
                         is SuitableType.Gallery -> {
                             val intent = Intent(this, GalleryPostsActivity::class.java)

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/page/PageTypeHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/account/page/PageTypeHelper.kt
@@ -36,7 +36,6 @@ object PageTypeHelper{
             MASTODON_LOCAL_TIMELINE -> context.getString(R.string.local_timeline)
             MASTODON_PUBLIC_TIMELINE -> context.getString(R.string.global_timeline)
             MASTODON_HOME_TIMELINE -> context.getString(R.string.home_timeline)
-            MASTODON_HASHTAG_TIMELINE -> context.getString(R.string.tag)
             MASTODON_LIST_TIMELINE -> context.getString(R.string.list)
             MASTODON_USER_TIMELINE -> context.getString(R.string.user)
             CALCKEY_RECOMMENDED_TIMELINE -> context.getString(R.string.calckey_recomended_timeline)

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/MastodonTimelineStorePagingStoreImpl.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/notes/MastodonTimelineStorePagingStoreImpl.kt
@@ -97,12 +97,7 @@ internal class MastodonTimelineStorePagingStoreImpl(
             is Pageable.Mastodon.TrendTimeline -> {
                 return@runCancellableCatching emptyList()
             }
-            is Pageable.Mastodon.TagTimeline -> {
-                api.getHashtagTimeline(
-                    tag = pageableTimeline.tag,
-                    minId = minId,
-                ).throwIfHasError().body()!!
-            }
+
         }.let { list ->
             if (isShouldUseLinkHeader()) {
                 filterNotExistsStatuses(list)
@@ -210,12 +205,6 @@ internal class MastodonTimelineStorePagingStoreImpl(
             is Pageable.Mastodon.TrendTimeline -> {
                 api.getTrendStatuses(
                     offset = (getState().content as? StateContent.Exist)?.rawContent?.size ?: 0
-                ).getBodyOrFail()
-            }
-            is Pageable.Mastodon.TagTimeline -> {
-                api.getHashtagTimeline(
-                    tag = pageableTimeline.tag,
-                    maxId = maxId,
                 ).getBodyOrFail()
             }
         }!!.let { list ->

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/NoteEditorActivity.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/NoteEditorActivity.kt
@@ -16,6 +16,7 @@ import net.pantasystem.milktea.model.file.toAppFile
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.note.databinding.ActivityNoteEditorBinding
 import net.pantasystem.milktea.note.editor.NoteEditorFragment
+import net.pantasystem.milktea.note.editor.viewmodel.NoteEditorSavedStateKey
 import net.pantasystem.milktea.note.editor.viewmodel.NoteEditorViewModel
 import javax.inject.Inject
 
@@ -43,6 +44,7 @@ class NoteEditorActivity : AppCompatActivity() {
             mentions: List<String>? = null,
             channelId: Channel.Id? = null,
             accountId: Long? = null,
+            text: String? = null,
         ): Intent {
             return Intent(context, NoteEditorActivity::class.java).apply {
                 replyTo?.let {
@@ -73,6 +75,9 @@ class NoteEditorActivity : AppCompatActivity() {
                     putExtra(EXTRA_SPECIFIED_ACCOUNT_ID, it)
                 }
 
+                text?.let {
+                    putExtra(NoteEditorSavedStateKey.Text.name, it)
+                }
             }
         }
     }

--- a/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultViewPagerAdapter.kt
+++ b/modules/features/search/src/main/java/net/pantasystem/milktea/search/SearchResultViewPagerAdapter.kt
@@ -38,7 +38,7 @@ class SearchResultViewPagerAdapter(
                 )
             )
             SearchResultTabItem.Type.SearchMastodonPostsByTag -> pageableFragmentFactory.create(
-                Pageable.Mastodon.TagTimeline(item.query)
+                Pageable.Mastodon.HashTagTimeline(item.query)
             )
             SearchResultTabItem.Type.SearchMastodonUsers -> SearchUserFragment.newInstance(item.query)
         }

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/PageSettingActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/PageSettingActivity.kt
@@ -67,7 +67,7 @@ class PageSettingActivity : AppCompatActivity() {
 //
         mPageSettingViewModel.pageAddedEvent.observe(this) { pt ->
             when (pt.type) {
-                PageType.SEARCH, PageType.SEARCH_HASH, PageType.MASTODON_HASHTAG_TIMELINE -> startActivity(
+                PageType.SEARCH, PageType.SEARCH_HASH, PageType.MASTODON_TAG_TIMELINE -> startActivity(
                     searchNavigation.newIntent(SearchNavType.SearchScreen())
                 )
                 PageType.USER -> {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageParams.kt
@@ -162,12 +162,6 @@ data class PageParams(
                 MASTODON_HOME_TIMELINE -> {
                     Pageable.Mastodon.HomeTimeline
                 }
-                MASTODON_HASHTAG_TIMELINE -> {
-                    Pageable.Mastodon.HashTagTimeline(
-                        requireNotNull(tag),
-                        isOnlyMedia = withFiles,
-                    )
-                }
                 MASTODON_LIST_TIMELINE -> {
                     Pageable.Mastodon.ListTimeline(
                         listId = requireNotNull(listId),
@@ -199,7 +193,7 @@ data class PageParams(
                     )
                 }
                 MASTODON_TAG_TIMELINE -> {
-                    Pageable.Mastodon.TagTimeline(
+                    Pageable.Mastodon.HashTagTimeline(
                         requireNotNull(tag)
                     )
                 }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageType.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageType.kt
@@ -26,7 +26,6 @@ enum class PageType(val defaultName: String, val label: String){
     MASTODON_LOCAL_TIMELINE("MastodonLocalTimeline", "MASTODON_LOCAL_TIMELINE"),
     MASTODON_PUBLIC_TIMELINE("MastodonPublicTimeline", "MASTODON_PUBLIC_TIMELINE"),
     MASTODON_HOME_TIMELINE("MastodonHomeTimeline", "MASTODON_HOME_TIMELINE"),
-    MASTODON_HASHTAG_TIMELINE("MastodonHashtagTimeline", "MASTODON_HASHTAG_TIMELINE"),
     MASTODON_LIST_TIMELINE("MastodonListTimeline", "MASTODON_LIST_TIMELINE"),
     MASTODON_USER_TIMELINE("MastodonUserTimeline", "MASTODON_USER_TIMELINE"),
     MASTODON_BOOKMARK_TIMELINE("MastodonBookmarkTimeline", "MASTODON_BOOKMARK_TIMELINE"),

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/Pageable.kt
@@ -413,7 +413,7 @@ sealed class Pageable : Serializable {
             Mastodon(), CanOnlyMedia<HashTagTimeline>, SincePaginate, UntilPaginate {
             override fun toParams(): PageParams {
                 return PageParams(
-                    type = PageType.MASTODON_HASHTAG_TIMELINE,
+                    type = PageType.MASTODON_TAG_TIMELINE,
                     tag = hashtag,
                     withFiles = isOnlyMedia
                 )
@@ -489,17 +489,6 @@ sealed class Pageable : Serializable {
                     type = PageType.MASTODON_SEARCH_TIMELINE,
                     query = query,
                     userId = userId,
-                )
-            }
-        }
-
-        data class TagTimeline(
-            val tag: String,
-        ) : Mastodon(), SincePaginate, UntilPaginate {
-            override fun toParams(): PageParams {
-                return PageParams(
-                    type = PageType.MASTODON_TAG_TIMELINE,
-                    tag = tag,
                 )
             }
         }

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageableTemplate.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/account/page/PageableTemplate.kt
@@ -31,7 +31,7 @@ class PageableTemplate(val account: Account?) {
     }
     fun tag(tag: String): Page {
         return when(account?.instanceType) {
-            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> Page(account.accountId, tag, 0, Pageable.Mastodon.TagTimeline(tag.replace("#", "")))
+            Account.InstanceType.MASTODON, Account.InstanceType.PLEROMA -> Page(account.accountId, tag, 0, Pageable.Mastodon.HashTagTimeline(tag.replace("#", "")))
             else -> Page(account?.accountId?: - 1, tag, 0, Pageable.SearchByTag(tag.replace("#", "")))
         }
     }


### PR DESCRIPTION
## やったこと
タグタイムラインを表示している時に投稿画面を開いた時はタグを引き継ぐようにした。
そのために投稿画面を他Activityから本文を指定して開けるようにしました。
またMastodonのタグタイムラインの種別を表すenumが二つ重複して実装されていたので、
片方の実装を削除し、一つの実装に統一するようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1722 

