### PR TITLE
リアクションカウンターの絵文字・件数表示の文字サイズを設定から変更できるようにした

### DIFF
--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -594,6 +594,7 @@
     <string name="follows_you">フォローされています</string>
     <string name="settings_note_content_font_size">ノートコンテンツ文字サイズ(%fsp)</string>
     <string name="settings_note_header_font_size">ノートヘッダー文字サイズ(%fsp)</string>
+    <string name="settings_note_reaction_counter_font_size">ノートリアクション件数表示の絵文字および文字サイズ(%fsp)</string>
     <string name="suggestion_users">おすすめユーザ</string>
     <string name="trend_posted_person_count_msg">%d人が投稿</string>
     <string name="notes_confirm_attach_quote_note_by_url">引用として添付しますか?</string>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -588,6 +588,7 @@
     <string name="follows_you">正在关注你</string>
     <string name="settings_note_content_font_size">Note content font size(%fsp)</string>
     <string name="settings_note_header_font_size">Note header font size(%fsp)</string>
+    <string name="settings_note_reaction_counter_font_size">Note reaction counter font size(%fsp)</string>
     <string name="suggestion_users">Suggestions</string>
     <string name="trend_posted_person_count_msg">%d people posting</string>
     <string name="notes_confirm_attach_quote_note_by_url">Attach as a quote post?</string>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -570,6 +570,7 @@
     <string name="settings_about_milktea_source_code">Source code(GitHub)</string>
     <string name="settings_note_content_font_size">Note content font size(%fsp)</string>
     <string name="settings_note_header_font_size">Note header font size(%fsp)</string>
+    <string name="settings_note_reaction_counter_font_size">Note reaction counter font size(%fsp)</string>
 
 
     <!-- Settings -->

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
@@ -130,6 +130,9 @@ fun Config.Companion.from(map: Map<Keys, PrefType?>): Config {
         isDisplayTimestampsAsAbsoluteDates = map.getValue<PrefType.BoolPref>(
             Keys.IsDisplayTimestampsAsAbsoluteDates
         )?.value ?: DefaultConfig.config.isDisplayTimestampsAsAbsoluteDates,
+        noteReactionCounterFontSize = map.getValue<PrefType.FloatPref>(
+            Keys.NoteReactionCounterFontSize
+        )?.value ?: DefaultConfig.config.noteReactionCounterFontSize,
     )
 }
 
@@ -234,6 +237,9 @@ fun Config.pref(key: Keys): PrefType {
         }
         Keys.IsDisplayTimestampsAsAbsoluteDates -> {
             PrefType.BoolPref(isDisplayTimestampsAsAbsoluteDates)
+        }
+        Keys.NoteReactionCounterFontSize -> {
+            PrefType.FloatPref(noteReactionCounterFontSize)
         }
     }
 }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
@@ -151,6 +151,10 @@ class ConfigKtTest {
                     config.isDisplayTimestampsAsAbsoluteDates,
                     (u as PrefType.BoolPref).value
                 )
+                Keys.NoteReactionCounterFontSize -> Assertions.assertEquals(
+                    config.noteReactionCounterFontSize,
+                    (u as PrefType.FloatPref).value
+                )
             }
         }
     }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
@@ -112,6 +112,10 @@ class KeysKtTest {
                     "IsDisplayTimestampsAsAbsoluteDates",
                     key.str()
                 )
+                Keys.NoteReactionCounterFontSize -> Assertions.assertEquals(
+                    "NoteReactionCounterFontSize",
+                    key.str()
+                )
             }
         }
     }
@@ -119,8 +123,8 @@ class KeysKtTest {
 
     @Test
     fun checkAllKeysCount() {
-        Assertions.assertEquals(30, Keys.allKeys.size)
-        Assertions.assertEquals(30, Keys.allKeys.map { it.str() }.toSet().size)
+        Assertions.assertEquals(31, Keys.allKeys.size)
+        Assertions.assertEquals(31, Keys.allKeys.map { it.str() }.toSet().size)
     }
 
 

--- a/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/ReactionCountAdapter.kt
+++ b/modules/features/note/src/main/java/net/pantasystem/milktea/note/reaction/ReactionCountAdapter.kt
@@ -13,29 +13,30 @@ import net.pantasystem.milktea.note.reaction.ReactionHelper.applyBackgroundColor
 import net.pantasystem.milktea.note.viewmodel.PlaneNoteViewData
 
 class ReactionCountAdapter(
-    val reactionCountActionListener: (ReactionCountAction) -> Unit
+    val reactionCountActionListener: (ReactionCountAction) -> Unit,
 ) : ListAdapter<ReactionViewData, ReactionHolder>(
     reactionDiffUtilItemCallback
 ) {
 
 
     companion object {
-        private val reactionDiffUtilItemCallback = object : DiffUtil.ItemCallback<ReactionViewData>() {
-            override fun areContentsTheSame(
-                oldItem: ReactionViewData,
-                newItem: ReactionViewData
-            ): Boolean {
-                return oldItem == newItem
-            }
+        private val reactionDiffUtilItemCallback =
+            object : DiffUtil.ItemCallback<ReactionViewData>() {
+                override fun areContentsTheSame(
+                    oldItem: ReactionViewData,
+                    newItem: ReactionViewData,
+                ): Boolean {
+                    return oldItem == newItem
+                }
 
-            override fun areItemsTheSame(
-                oldItem: ReactionViewData,
-                newItem: ReactionViewData
-            ): Boolean {
-                return oldItem.noteId == newItem.noteId
-                        && oldItem.reactionCount.reaction == newItem.reactionCount.reaction
+                override fun areItemsTheSame(
+                    oldItem: ReactionViewData,
+                    newItem: ReactionViewData,
+                ): Boolean {
+                    return oldItem.noteId == newItem.noteId
+                            && oldItem.reactionCount.reaction == newItem.reactionCount.reaction
+                }
             }
-        }
     }
 
     var note: PlaneNoteViewData? = null
@@ -57,21 +58,30 @@ class ReactionCountAdapter(
 }
 
 class ReactionHolder(val binding: ItemReactionBinding) : RecyclerView.ViewHolder(binding.root) {
-    fun onBind(viewData: ReactionViewData, note: PlaneNoteViewData?, reactionCountActionListener: (ReactionCountAction) -> Unit) {
+    fun onBind(
+        viewData: ReactionViewData,
+        note: PlaneNoteViewData?,
+        reactionCountActionListener: (ReactionCountAction) -> Unit,
+    ) {
 
         if (note == null) {
             Log.w("ReactionCountAdapter", "noteがNullです。正常に処理が行われない可能性があります。")
         }
-        binding.reactionLayout.applyBackgroundColor(viewData, note?.toShowNote?.note?.isMisskey ?: false)
+        binding.reactionLayout.applyBackgroundColor(
+            viewData,
+            note?.toShowNote?.note?.isMisskey ?: false
+        )
         binding.reactionLayout.bindReactionCount(
             binding.reactionText,
             binding.reactionImage,
             viewData,
-            15f,
+            note?.config?.value?.noteReactionCounterFontSize ?: 15f
         )
 
         binding.reactionCounter.text = viewData.reactionCount.count.toString()
-        binding.reactionCounter.setMemoFontSpSize(15f)
+        binding.reactionCounter.setMemoFontSpSize(
+            note?.config?.value?.noteReactionCounterFontSize ?: 15f
+        )
         binding.root.setOnLongClickListener {
             val id = note?.toShowNote?.note?.id
             if (id != null) {

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
@@ -206,7 +206,8 @@ class SettingAppearanceActivity : AppCompatActivity() {
                             SettingSwitchTile(
                                 checked = currentConfigState.isVisibleInstanceUrlInToolbar,
                                 onChanged = {
-                                    currentConfigState = currentConfigState.copy(isVisibleInstanceUrlInToolbar = it)
+                                    currentConfigState =
+                                        currentConfigState.copy(isVisibleInstanceUrlInToolbar = it)
                                 }
                             ) {
                                 Text(stringResource(id = R.string.settings_visible_instance_domain_in_toolbar))
@@ -215,7 +216,8 @@ class SettingAppearanceActivity : AppCompatActivity() {
                             SettingSwitchTile(
                                 checked = currentConfigState.isDisplayTimestampsAsAbsoluteDates,
                                 onChanged = {
-                                    currentConfigState = currentConfigState.copy(isDisplayTimestampsAsAbsoluteDates = it)
+                                    currentConfigState =
+                                        currentConfigState.copy(isDisplayTimestampsAsAbsoluteDates = it)
                                 }
                             ) {
                                 Text(stringResource(id = R.string.settings_display_timestamps_as_absolute_dates))
@@ -334,6 +336,29 @@ class SettingAppearanceActivity : AppCompatActivity() {
                                 onValueChange = {
                                     currentConfigState =
                                         currentConfigState.copy(noteContentFontSize = it)
+                                },
+                                modifier = Modifier.padding(horizontal = 16.dp)
+                            )
+
+                            Text(
+                                stringResource(
+                                    id = R.string.settings_note_reaction_counter_font_size,
+                                    currentConfigState.noteReactionCounterFontSize
+                                ),
+                                modifier = Modifier.padding(horizontal = 16.dp)
+                            )
+                            Text(
+                                stringResource(id = R.string.settings_app_restart_required),
+                                modifier = Modifier.padding(horizontal = 16.dp),
+                                color = MaterialTheme.colors.error,
+                                fontSize = 14.sp
+                            )
+                            Slider(
+                                value = currentConfigState.noteReactionCounterFontSize,
+                                valueRange = 10f..24f,
+                                onValueChange = {
+                                    currentConfigState =
+                                        currentConfigState.copy(noteReactionCounterFontSize = it)
                                 },
                                 modifier = Modifier.padding(horizontal = 16.dp)
                             )

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
@@ -52,6 +52,7 @@ data class IsAnalyticsCollectionEnabled(
  * @param isHideMediaWhenMobileNetwork モバイルネットワークの時はメディアを表示しない
  * @param noteHeaderFontSize ノートのヘッダー部分のテキストサイズ
  * @param noteContentFontSize ノートのコンテンツ部分のテキストサイズ
+ * @param noteReactionCounterFontSize ノートのリアクションカウンターのカスタム絵文字、絵文字と件数表示のフォントサイズ
  */
 data class Config(
     val isSimpleEditorEnabled: Boolean,
@@ -82,6 +83,7 @@ data class Config(
     val noteHeaderFontSize: Float,
     val noteContentFontSize: Float,
     val isDisplayTimestampsAsAbsoluteDates: Boolean,
+    val noteReactionCounterFontSize: Float,
 ) {
     companion object
 
@@ -140,6 +142,7 @@ object DefaultConfig {
         noteContentFontSize = 15f,
         noteHeaderFontSize = 15f,
         isDisplayTimestampsAsAbsoluteDates = false,
+        noteReactionCounterFontSize = 15f,
     )
 
     fun getRememberVisibilityConfig(accountId: Long): RememberVisibility.Remember {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
@@ -142,7 +142,7 @@ object DefaultConfig {
         noteContentFontSize = 15f,
         noteHeaderFontSize = 15f,
         isDisplayTimestampsAsAbsoluteDates = false,
-        noteReactionCounterFontSize = 15f,
+        noteReactionCounterFontSize = 16f,
     )
 
     fun getRememberVisibilityConfig(accountId: Long): RememberVisibility.Remember {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
@@ -32,6 +32,7 @@ val Keys.Companion.allKeys by lazy {
         Keys.NoteHeaderFontSize,
         Keys.NoteContentFontSize,
         Keys.IsDisplayTimestampsAsAbsoluteDates,
+        Keys.NoteReactionCounterFontSize,
     )
 }
 
@@ -91,6 +92,8 @@ sealed interface Keys {
 
     object IsDisplayTimestampsAsAbsoluteDates: Keys
 
+    object NoteReactionCounterFontSize : Keys
+
     companion object
 }
 
@@ -126,5 +129,6 @@ fun Keys.str(): String {
         is Keys.NoteContentFontSize -> "NoteContentFontSize"
         is Keys.NoteHeaderFontSize -> "NoteHeaderFontSize"
         is Keys.IsDisplayTimestampsAsAbsoluteDates -> "IsDisplayTimestampsAsAbsoluteDates"
+        is Keys.NoteReactionCounterFontSize -> "NoteReactionCounterFontSize"
     }
 }


### PR DESCRIPTION
## やったこと
リアクションカウンターの絵文字・件数表示の文字サイズを設定から変更できるようにした。
そのためにConfig構造体に文字サイズを表すフィールドを追加した。
リアクションカウンターの画像の表示や、文字のサイズ計算をspベースで行うようにし、
設定から取得された値を元にリアクションの画像、文字サイズを決定するようにした。
また設定を変更できるようにするために、設定画面からフィールドの値を更新できるようにした。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1724



