### PR TITLE
投稿の本文のカスタム絵文字の倍率を変更できるようにした

### DIFF
--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/CustomEmojiDecorator.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/CustomEmojiDecorator.kt
@@ -2,6 +2,7 @@ package net.pantasystem.milktea.common_android.ui.text
 
 import android.text.SpannableStringBuilder
 import android.text.Spanned
+import android.text.style.RelativeSizeSpan
 import android.widget.TextView
 import net.pantasystem.milktea.common.glide.GlideApp
 import net.pantasystem.milktea.model.emoji.CustomEmojiParsedResult
@@ -93,7 +94,6 @@ class CustomEmojiDecorator {
                 emojiAdapter,
                 it.result.getUrl(accountHost),
                 aspectRatio,
-                customEmojiScale,
             )
             val height = max(view.textSize * 0.75f, 10f)
             val width = when(aspectRatio) {
@@ -107,6 +107,7 @@ class CustomEmojiDecorator {
                 .override((width * customEmojiScale).toInt(), (height * customEmojiScale).toInt())
                 .into(span.target)
             builder.setSpan(span, it.start, it.end, 0)
+            builder.setSpan(RelativeSizeSpan(customEmojiScale), it.start, it.end, 0)
         }
 
 

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/CustomEmojiDecorator.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/CustomEmojiDecorator.kt
@@ -8,6 +8,7 @@ import net.pantasystem.milktea.model.emoji.CustomEmojiParsedResult
 import net.pantasystem.milktea.model.emoji.CustomEmojiParser
 import net.pantasystem.milktea.model.emoji.Emoji
 import net.pantasystem.milktea.model.emoji.EmojiResolvedType
+import kotlin.math.max
 
 class CustomEmojiDecorator {
 
@@ -78,6 +79,7 @@ class CustomEmojiDecorator {
         accountHost: String?,
         result: CustomEmojiParsedResult,
         view: TextView,
+        customEmojiScale: Float = 1f,
     ): Spanned {
 
         val emojiAdapter = EmojiAdapter(view)
@@ -86,15 +88,23 @@ class CustomEmojiDecorator {
         result.emojis.filter {
             it.result is EmojiResolvedType.Resolved
         }.map {
+            val aspectRatio = (it.result as? EmojiResolvedType.Resolved)?.emoji?.aspectRatio
             val span = DrawableEmojiSpan(
                 emojiAdapter,
                 it.result.getUrl(accountHost),
-                (it.result as? EmojiResolvedType.Resolved)?.emoji?.aspectRatio
+                aspectRatio,
+                customEmojiScale,
             )
+            val height = max(view.textSize * 0.75f, 10f)
+            val width = when(aspectRatio) {
+                null -> height
+                else -> height * aspectRatio
+            }
+
             GlideApp.with(view)
                 .asDrawable()
                 .load(it.result.getUrl(accountHost))
-                .override(view.textSize.toInt())
+                .override((width * customEmojiScale).toInt(), (height * customEmojiScale).toInt())
                 .into(span.target)
             builder.setSpan(span, it.start, it.end, 0)
         }

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DrawableEmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/DrawableEmojiSpan.kt
@@ -9,10 +9,13 @@ import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 import com.github.penfeizhou.animation.apng.APNGDrawable
 
-class DrawableEmojiSpan(var adapter: EmojiAdapter?, k: Any?, aspectRatio: Float? = null) : EmojiSpan<Any?>(k, aspectRatio = aspectRatio){
+class DrawableEmojiSpan(
+    var adapter: EmojiAdapter?,
+    k: Any?,
+    aspectRatio: Float? = null,
+    emojiScale: Float = 1f,
+) : EmojiSpan<Any?>(k, aspectRatio = aspectRatio, emojiScale = emojiScale) {
     //val weakReference: WeakReference<View> = WeakReference(view)
-
-
 
 
 //    /**
@@ -74,11 +77,11 @@ class DrawableEmojiSpan(var adapter: EmojiAdapter?, k: Any?, aspectRatio: Float?
 }
 
 private class DrawableEmojiTarget(
-    val span: DrawableEmojiSpan
+    val span: DrawableEmojiSpan,
 ) : CustomTarget<Drawable>() {
     override fun onResourceReady(
         resource: Drawable,
-        transition: Transition<in Drawable>?
+        transition: Transition<in Drawable>?,
     ) {
         span.imageDrawable = resource
 
@@ -118,6 +121,7 @@ private class DrawableEmojiTarget(
             }
         }
     }
+
     override fun onLoadCleared(placeholder: Drawable?) {
 
     }

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
@@ -48,7 +48,7 @@ abstract class EmojiSpan<T: Any?>(val key: T, val aspectRatio: Float? = null, va
         val size = calculateEmojiSize(textHeight * emojiScale)
         val metrics = paint.fontMetricsInt
         if (fm != null) {
-            fm.top = metrics.top
+            fm.top = metrics.top - (textHeight * emojiScale - textHeight).toInt()
             fm.ascent = metrics.ascent
             fm.descent = metrics.descent
             fm.bottom = metrics.bottom
@@ -56,7 +56,7 @@ abstract class EmojiSpan<T: Any?>(val key: T, val aspectRatio: Float? = null, va
 
         // NOTE: 画像のサイズが不明かつ初めてサイズを取得しようとした時は暫定的なサイズを返す
         if (size == null || beforeTextSize != 0) {
-            beforeTextSize = (paint.textSize * 1.2).toInt()
+            beforeTextSize = (paint.textSize * emojiScale).toInt()
             return beforeTextSize
         }
 

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
@@ -11,7 +11,7 @@ import kotlin.math.min
  * @param key 画像の種別を識別するためのキー値で、画像のURLなどが入る
  * @param aspectRatio 画像の比率が入る
  */
-abstract class EmojiSpan<T: Any?>(val key: T, val aspectRatio: Float? = null) : ReplacementSpan(){
+abstract class EmojiSpan<T: Any?>(val key: T, val aspectRatio: Float? = null, val emojiScale: Float = 1f) : ReplacementSpan(){
 
     companion object {
         /**
@@ -45,7 +45,7 @@ abstract class EmojiSpan<T: Any?>(val key: T, val aspectRatio: Float? = null) : 
     ): Int {
         val textHeight = paint.textSize
 
-        val size = calculateEmojiSize(textHeight)
+        val size = calculateEmojiSize(textHeight * emojiScale)
         val metrics = paint.fontMetricsInt
         if (fm != null) {
             fm.top = metrics.top
@@ -105,8 +105,8 @@ abstract class EmojiSpan<T: Any?>(val key: T, val aspectRatio: Float? = null) : 
      * Drawableのサイズを必要なサイズにリサイズを行う処理
      */
     private fun updateImageDrawableSize(paint: Paint) {
-        val emojiHeight = min((paint.textSize).toInt(), 128)
-        val size = calculateEmojiSize(min((paint.textSize), 128f))
+        val emojiHeight = min((paint.textSize * emojiScale).toInt(), 128)
+        val size = calculateEmojiSize(min((paint.textSize * emojiScale), 128f))
         val imageWidth = size?.first ?: -1f
         val imageHeight = size?.second?: -1f
 

--- a/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
+++ b/modules/common_android/src/main/java/net/pantasystem/milktea/common_android/ui/text/EmojiSpan.kt
@@ -45,32 +45,7 @@ abstract class EmojiSpan<T: Any?>(val key: T, val aspectRatio: Float? = null) : 
     ): Int {
         val textHeight = paint.textSize
 
-        val drawable = imageDrawable
-        val size = key?.let {
-            drawableSizeCache[key]
-        } ?: drawable?.let {
-            // NOTE: drawableSizeCacheに画像のサイズが登録されていない場合は、drawableからサイズを取得する
-            EmojiSizeCache(
-                intrinsicHeight = it.intrinsicHeight,
-                intrinsicWidth = it.intrinsicWidth
-            )
-        } ?: aspectRatio?.let {
-            // NOTE: drawableが読み込まれていない状態の時は、文字の高さと画像の比率から横幅のサイズを取得する
-            EmojiSizeCache(
-                intrinsicHeight = textHeight.toInt(),
-                intrinsicWidth = (textHeight * aspectRatio).toInt()
-            )
-        }
-
-        // NOTE: keyが存在しかつdrawableが存在する場合は、drawableSizeCacheを更新する
-        key?.run {
-            drawableSizeCache[key] ?: drawable?.let {
-                EmojiSizeCache(
-                    intrinsicHeight = it.intrinsicHeight,
-                    intrinsicWidth = it.intrinsicWidth
-                )
-            }
-        }
+        val size = calculateEmojiSize(textHeight)
         val metrics = paint.fontMetricsInt
         if (fm != null) {
             fm.top = metrics.top
@@ -84,20 +59,13 @@ abstract class EmojiSpan<T: Any?>(val key: T, val aspectRatio: Float? = null) : 
             beforeTextSize = (paint.textSize * 1.2).toInt()
             return beforeTextSize
         }
-        key?.run {
-            drawableSizeCache[key] = size
-        }
 
         // NOTE: 暫定的なサイズではない場合はbeforeTextSizeを0にする必要性がある
         beforeTextSize = 0
 
-        val imageWidth = size.intrinsicWidth
-        val imageHeight = size.intrinsicHeight
+        val imageWidth = size.first
 
-        // 画像がテキストの高さよりも大きい場合、画像をテキストと同じ高さに縮小する
-        val scale = textHeight / imageHeight.toFloat()
-        // テキストの高さに合わせた画像の幅
-        return (imageWidth * scale).toInt()
+        return imageWidth.toInt()
     }
 
     override fun updateDrawState(ds: TextPaint) {
@@ -138,27 +106,9 @@ abstract class EmojiSpan<T: Any?>(val key: T, val aspectRatio: Float? = null) : 
      */
     private fun updateImageDrawableSize(paint: Paint) {
         val emojiHeight = min((paint.textSize).toInt(), 128)
-        val drawable = imageDrawable
-
-        // drawableSizeCacheあるいはdrawableあるいはaspectRatioと文字サイズから画像のwidth, heightを得る処理
-        val size = key?.let {
-            drawableSizeCache[key]
-        } ?: drawable?.let {
-            EmojiSizeCache(
-                intrinsicWidth = it.intrinsicWidth,
-                intrinsicHeight = it.intrinsicHeight
-            )
-        } ?: aspectRatio?.let {
-            EmojiSizeCache(
-                intrinsicHeight = emojiHeight,
-                intrinsicWidth = (emojiHeight.toFloat() * aspectRatio).toInt()
-            )
-        } ?: return
-        key?.run {
-            drawableSizeCache[key] = size
-        }
-        val imageWidth = size.intrinsicWidth
-        val imageHeight = size.intrinsicHeight
+        val size = calculateEmojiSize(min((paint.textSize), 128f))
+        val imageWidth = size?.first ?: -1f
+        val imageHeight = size?.second?: -1f
 
         // 計算された画像サイズが適切なものかチェックする
         val unknownEmojiSize = imageWidth <= 0 || imageHeight <= 0
@@ -173,14 +123,58 @@ abstract class EmojiSpan<T: Any?>(val key: T, val aspectRatio: Float? = null) : 
             return
         }
 
-        val ratio = imageWidth.toFloat() / imageHeight.toFloat()
-
-        val scaledImageWidth = (emojiHeight * ratio).toInt()
-
         if (!isSizeComputed) {
             isSizeComputed = imageDrawable != null
-            imageDrawable?.setBounds(0, 0, scaledImageWidth, emojiHeight)
+            imageDrawable?.setBounds(0, 0, imageWidth.toInt(), imageHeight.toInt())
         }
+    }
+
+    private fun calculateEmojiSize(textSize: Float): Pair<Float, Float>? {
+        val drawable = imageDrawable
+        val size = key?.let {
+            drawableSizeCache[key]
+        } ?: drawable?.let {
+            // NOTE: drawableSizeCacheに画像のサイズが登録されていない場合は、drawableからサイズを取得する
+            EmojiSizeCache(
+                intrinsicHeight = it.intrinsicHeight,
+                intrinsicWidth = it.intrinsicWidth
+            )
+        } ?: aspectRatio?.let {
+            // NOTE: drawableが読み込まれていない状態の時は、文字の高さと画像の比率から横幅のサイズを取得する
+            EmojiSizeCache(
+                intrinsicHeight = textSize.toInt(),
+                intrinsicWidth = (textSize * aspectRatio).toInt()
+            )
+        }
+
+        // NOTE: keyが存在しかつdrawableが存在する場合は、drawableSizeCacheを更新する
+        key?.run {
+            drawableSizeCache[key] ?: drawable?.let {
+                EmojiSizeCache(
+                    intrinsicHeight = it.intrinsicHeight,
+                    intrinsicWidth = it.intrinsicWidth
+                )
+            }
+        }
+
+        // NOTE: 画像のサイズが不明なときはnullを返す
+        if (size == null) {
+            return null
+        }
+        key?.run {
+            drawableSizeCache[key] = size
+        }
+
+        val imageWidth = size.intrinsicWidth
+        val imageHeight = size.intrinsicHeight
+
+        // 画像がテキストの高さよりも大きい場合、画像をテキストと同じ高さに縮小する
+        val scale = textSize / imageHeight
+
+        // テキストの高さに合わせた画像の幅
+        val width = imageWidth * scale
+
+        return width to textSize
     }
 
 }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/DecorateTextHelper.kt
@@ -71,18 +71,21 @@ object DecorateTextHelper {
         }
     }
 
-    @BindingAdapter("textTypeSource")
+    @BindingAdapter("textTypeSource", "customEmojiScale")
     @JvmStatic
-    fun TextView.decorate(textType: TextType?) {
+    fun TextView.decorate(textType: TextType?, customEmojiScale: Float?) {
         textType ?: return
         stopDrawableAnimations(this)
+
+        val emojiScale = customEmojiScale ?: 1.0f
         when (textType) {
             is TextType.Mastodon -> {
                 val decoratedText = CustomEmojiDecorator().decorate(
                     textType.html.spanned,
                     textType.html.accountHost,
                     textType.html.parserResult,
-                    this
+                    this,
+                    emojiScale,
                 )
                 this.text = decoratedText
                 this.movementMethod = ClickListenableLinkMovementMethod { url ->
@@ -141,7 +144,7 @@ object DecorateTextHelper {
             }
             is TextType.Misskey -> {
                 this.movementMethod = LinkMovementMethod.getInstance()
-                this.text = MFMDecorator.decorate(this, textType.lazyDecorateResult)
+                this.text = MFMDecorator.decorate(this, textType.lazyDecorateResult, emojiScale)
             }
         }
 

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
@@ -34,6 +34,7 @@ object MFMDecorator {
     fun decorate(
         textView: TextView,
         lazyDecorateResult: LazyDecorateResult?,
+        customEmojiScale: Float = 1f,
         skipEmojis: SkipEmojiHolder = SkipEmojiHolder(),
     ): Spanned? {
         lazyDecorateResult ?: return null
@@ -45,6 +46,7 @@ object MFMDecorator {
             lazyDecorateResult,
             skipEmojis,
             emojiAdapter,
+            customEmojiScale,
         ).decorate()
     }
 
@@ -289,6 +291,7 @@ object MFMDecorator {
         private val lazyDecorateResult: LazyDecorateResult,
         private val skipEmojis: SkipEmojiHolder,
         private val emojiAdapter: EmojiAdapter,
+        private val customEmojiScale: Float,
     ) {
 
         private val spannableString = SpannableString(lazyDecorateResult.spanned)
@@ -309,7 +312,7 @@ object MFMDecorator {
                 return
             }
             textView.get()?.let { textView ->
-                val emojiSpan = DrawableEmojiSpan(emojiAdapter, emojiElement.emoji.url, emojiElement.emoji.aspectRatio)
+                val emojiSpan = DrawableEmojiSpan(emojiAdapter, emojiElement.emoji.url, emojiElement.emoji.aspectRatio, customEmojiScale)
                 spannableString.setSpan(emojiSpan, skippedEmoji.start, skippedEmoji.end, 0)
                 val height = max(textView.textSize * 0.75f, 10f)
                 val width = when(val aspectRatio = emojiElement.emoji.aspectRatio) {
@@ -318,7 +321,7 @@ object MFMDecorator {
                 }
                 GlideApp.with(textView)
                     .load(emojiElement.emoji.url)
-                    .override(width.toInt(), height.toInt())
+                    .override((width * customEmojiScale).toInt(), (height * customEmojiScale).toInt())
                     .into(emojiSpan.target)
             }
         }

--- a/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
+++ b/modules/common_android_ui/src/main/java/net/pantasystem/milktea/common_android_ui/MFMDecorator.kt
@@ -312,8 +312,9 @@ object MFMDecorator {
                 return
             }
             textView.get()?.let { textView ->
-                val emojiSpan = DrawableEmojiSpan(emojiAdapter, emojiElement.emoji.url, emojiElement.emoji.aspectRatio, customEmojiScale)
+                val emojiSpan = DrawableEmojiSpan(emojiAdapter, emojiElement.emoji.url, emojiElement.emoji.aspectRatio)
                 spannableString.setSpan(emojiSpan, skippedEmoji.start, skippedEmoji.end, 0)
+                spannableString.setSpan(RelativeSizeSpan(customEmojiScale), skippedEmoji.start, skippedEmoji.end, 0)
                 val height = max(textView.textSize * 0.75f, 10f)
                 val width = when(val aspectRatio = emojiElement.emoji.aspectRatio) {
                     null -> height

--- a/modules/common_resource/src/main/res/values-ja/strings.xml
+++ b/modules/common_resource/src/main/res/values-ja/strings.xml
@@ -595,6 +595,7 @@
     <string name="settings_note_content_font_size">ノートコンテンツ文字サイズ(%fsp)</string>
     <string name="settings_note_header_font_size">ノートヘッダー文字サイズ(%fsp)</string>
     <string name="settings_note_reaction_counter_font_size">ノートリアクション件数表示の絵文字および文字サイズ(%fsp, %fps)</string>
+    <string name="settings_note_custom_emoji_scale_size_in_text">ノートの本文中のカスタム絵文字の倍率(%f倍)</string>
     <string name="suggestion_users">おすすめユーザ</string>
     <string name="trend_posted_person_count_msg">%d人が投稿</string>
     <string name="notes_confirm_attach_quote_note_by_url">引用として添付しますか?</string>

--- a/modules/common_resource/src/main/res/values-zh/strings.xml
+++ b/modules/common_resource/src/main/res/values-zh/strings.xml
@@ -589,6 +589,7 @@
     <string name="settings_note_content_font_size">Note content font size(%fsp)</string>
     <string name="settings_note_header_font_size">Note header font size(%fsp)</string>
     <string name="settings_note_reaction_counter_font_size">Note reaction counter font size(%fsp, %fps)</string>
+    <string name="settings_note_custom_emoji_scale_size_in_text">Magnification for custom emoji in text(%fX)</string>
     <string name="suggestion_users">Suggestions</string>
     <string name="trend_posted_person_count_msg">%d people posting</string>
     <string name="notes_confirm_attach_quote_note_by_url">Attach as a quote post?</string>

--- a/modules/common_resource/src/main/res/values/strings.xml
+++ b/modules/common_resource/src/main/res/values/strings.xml
@@ -571,6 +571,7 @@
     <string name="settings_note_content_font_size">Note content font size(%fsp)</string>
     <string name="settings_note_header_font_size">Note header font size(%fsp)</string>
     <string name="settings_note_reaction_counter_font_size">Note reaction counter font size(%fsp, %fsp)</string>
+    <string name="settings_note_custom_emoji_scale_size_in_text">Magnification for custom emoji in text(%fX)</string>
 
 
     <!-- Settings -->

--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/settings/Config.kt
@@ -133,6 +133,9 @@ fun Config.Companion.from(map: Map<Keys, PrefType?>): Config {
         noteReactionCounterFontSize = map.getValue<PrefType.FloatPref>(
             Keys.NoteReactionCounterFontSize
         )?.value ?: DefaultConfig.config.noteReactionCounterFontSize,
+        noteCustomEmojiScaleSizeInText = map.getValue<PrefType.FloatPref>(
+            Keys.NoteCustomEmojiScaleSizeInText
+        )?.value ?: DefaultConfig.config.noteCustomEmojiScaleSizeInText,
     )
 }
 
@@ -240,6 +243,9 @@ fun Config.pref(key: Keys): PrefType {
         }
         Keys.NoteReactionCounterFontSize -> {
             PrefType.FloatPref(noteReactionCounterFontSize)
+        }
+        Keys.NoteCustomEmojiScaleSizeInText -> {
+            PrefType.FloatPref(noteCustomEmojiScaleSizeInText)
         }
     }
 }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/ConfigKtTest.kt
@@ -155,6 +155,10 @@ class ConfigKtTest {
                     config.noteReactionCounterFontSize,
                     (u as PrefType.FloatPref).value
                 )
+                Keys.NoteCustomEmojiScaleSizeInText -> Assertions.assertEquals(
+                    config.noteCustomEmojiScaleSizeInText,
+                    (u as PrefType.FloatPref).value
+                )
             }
         }
     }

--- a/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
+++ b/modules/data/src/test/java/net/pantasystem/milktea/data/infrastructure/settings/KeysKtTest.kt
@@ -116,6 +116,10 @@ class KeysKtTest {
                     "NoteReactionCounterFontSize",
                     key.str()
                 )
+                Keys.NoteCustomEmojiScaleSizeInText -> Assertions.assertEquals(
+                    "NoteCustomEmojiScaleSizeInText",
+                    key.str()
+                )
             }
         }
     }
@@ -123,8 +127,8 @@ class KeysKtTest {
 
     @Test
     fun checkAllKeysCount() {
-        Assertions.assertEquals(31, Keys.allKeys.size)
-        Assertions.assertEquals(31, Keys.allKeys.map { it.str() }.toSet().size)
+        Assertions.assertEquals(32, Keys.allKeys.size)
+        Assertions.assertEquals(32, Keys.allKeys.map { it.str() }.toSet().size)
     }
 
 

--- a/modules/features/note/src/main/res/layout/item_detail_note.xml
+++ b/modules/features/note/src/main/res/layout/item_detail_note.xml
@@ -161,6 +161,7 @@
                         android:textSize="@dimen/note_content_text_size"
                         android:visibility='@{note.text == null ? View.GONE : View.VISIBLE}'
                         textTypeSource="@{note.textNode}"
+                        customEmojiScale="@{note.config.noteCustomEmojiScaleSizeInText}"
                         tools:text="aoiwefjowiaejiowajefihawoefoiawehfioawheoifawoiefioawejfowaoeifjawoiejfoaw" />
 
                 <include
@@ -302,6 +303,7 @@
                             android:textSize="@dimen/note_content_text_size"
                             android:visibility="@{SafeUnbox.unboxBool(note.subContentFolding) ? View.GONE : View.VISIBLE }"
                             textTypeSource="@{note.subNoteTextNode}"
+                            customEmojiScale="@{note.config.noteCustomEmojiScaleSizeInText}"
                             tools:text="aowjfoiwajehofijawioefjioawejfiowajeiofhawoifahwoiefwaioe" />
 
                     <include

--- a/modules/features/note/src/main/res/layout/item_has_reply_to_note.xml
+++ b/modules/features/note/src/main/res/layout/item_has_reply_to_note.xml
@@ -129,6 +129,7 @@
                                 tools:text="aoiwefjowiaejiowajefihawoefoiawehfioawheoifawoiefioawejfowaoeifjawoiejfoaw"
                                 android:visibility='@{hasReplyToNote.replyTo.text == null ? View.GONE : View.VISIBLE}'
                                 textTypeSource="@{hasReplyToNote.replyTo.textNode}"
+                                customEmojiScale="@{hasReplyToNote.config.noteCustomEmojiScaleSizeInText}"
                                 />
 
                     </RelativeLayout>

--- a/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
+++ b/modules/features/note/src/main/res/layout/item_note_editor_reply_to_note.xml
@@ -190,6 +190,7 @@
                             android:layout_height="wrap_content"
                             android:textSize="@dimen/note_content_text_size"
                             textTypeSource="@{note.textNode}"
+                            customEmojiScale="@{note.config.noteCustomEmojiScaleSizeInText}"
                             tools:text="aoiwefjowiaejiowajefihawoefoiawehfioawheoifawoiefioawejfowaoeifjawoiejfoaw"
                             android:visibility='@{note.text == null ? View.GONE : View.VISIBLE}'
                             />
@@ -347,6 +348,7 @@
                                 android:id="@+id/subNoteText"
                                 tools:text="aowjfoiwajehofijawioefjioawejfiowajeiofhawoifahwoiefwaioe"
                                 textTypeSource="@{note.subNoteTextNode}"
+                                customEmojiScale="@{note.config.noteCustomEmojiScaleSizeInText}"
                                 app:layout_constraintTop_toBottomOf="@id/subContentFoldingButton"
                                 app:layout_constraintStart_toStartOf="parent"
                                 android:visibility="@{ note.subContentFolding || note.subNote.note.text == null ? View.GONE : View.VISIBLE }"/>

--- a/modules/features/note/src/main/res/layout/item_simple_note.xml
+++ b/modules/features/note/src/main/res/layout/item_simple_note.xml
@@ -196,6 +196,7 @@
                             android:layout_height="wrap_content"
                             android:textSize="@dimen/note_content_text_size"
                             textTypeSource="@{note.textNode}"
+                            customEmojiScale="@{note.config.noteCustomEmojiScaleSizeInText}"
                             tools:text="aoiwefjowiaejiowajefihawoefoiawehfioawheoifawoiefioawejfowaoeifjawoiejfoaw"
                             memoVisibility='@{note.text == null ? View.GONE : View.VISIBLE}'
 
@@ -354,6 +355,7 @@
                                 android:id="@+id/subNoteText"
                                 tools:text="aowjfoiwajehofijawioefjioawejfiowajeiofhawoifahwoiefwaioe"
                                 textTypeSource="@{note.subNoteTextNode}"
+                                customEmojiScale="@{note.config.noteCustomEmojiScaleSizeInText}"
                                 app:layout_constraintTop_toBottomOf="@id/subContentFoldingButton"
                                 app:layout_constraintStart_toStartOf="parent"
                                 memoVisibility="@{ note.subContentFolding || note.subNote.note.text == null ? View.GONE : View.VISIBLE }"/>

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
@@ -294,96 +294,110 @@ class SettingAppearanceActivity : AppCompatActivity() {
                                 modifier = Modifier.padding(horizontal = 16.dp)
                             )
 
-                            Text(
-                                stringResource(
-                                    id = R.string.settings_note_header_font_size,
-                                    currentConfigState.noteHeaderFontSize
-                                ),
-                                modifier = Modifier.padding(horizontal = 16.dp)
-                            )
-                            Text(
-                                stringResource(id = R.string.settings_app_restart_required),
-                                modifier = Modifier.padding(horizontal = 16.dp),
-                                color = MaterialTheme.colors.error,
-                                fontSize = 14.sp
-                            )
-                            Slider(
-                                value = currentConfigState.noteHeaderFontSize,
-                                valueRange = 10f..24f,
-                                onValueChange = {
-                                    currentConfigState =
-                                        currentConfigState.copy(noteHeaderFontSize = it)
-                                },
-                                modifier = Modifier.padding(horizontal = 16.dp)
-                            )
+                            Column(Modifier.fillMaxWidth()) {
+                                Text(
+                                    stringResource(
+                                        id = R.string.settings_note_header_font_size,
+                                        currentConfigState.noteHeaderFontSize
+                                    ),
+                                    modifier = Modifier.padding(horizontal = 16.dp)
+                                )
+                                Text(
+                                    stringResource(id = R.string.settings_app_restart_required),
+                                    modifier = Modifier.padding(horizontal = 16.dp),
+                                    color = MaterialTheme.colors.error,
+                                    fontSize = 14.sp
+                                )
+                                Slider(
+                                    value = currentConfigState.noteHeaderFontSize,
+                                    valueRange = 10f..24f,
+                                    onValueChange = {
+                                        currentConfigState =
+                                            currentConfigState.copy(noteHeaderFontSize = it)
+                                    },
+                                    modifier = Modifier.padding(horizontal = 16.dp)
+                                )
+                            }
 
-                            Text(
-                                stringResource(
-                                    id = R.string.settings_note_content_font_size,
-                                    currentConfigState.noteContentFontSize
-                                ),
-                                modifier = Modifier.padding(horizontal = 16.dp)
-                            )
-                            Text(
-                                stringResource(id = R.string.settings_app_restart_required),
-                                modifier = Modifier.padding(horizontal = 16.dp),
-                                color = MaterialTheme.colors.error,
-                                fontSize = 14.sp
-                            )
-                            Slider(
-                                value = currentConfigState.noteContentFontSize,
-                                valueRange = 10f..24f,
-                                onValueChange = {
-                                    currentConfigState =
-                                        currentConfigState.copy(noteContentFontSize = it)
-                                },
-                                modifier = Modifier.padding(horizontal = 16.dp)
-                            )
-
-                            Text(
-                                stringResource(
-                                    id = R.string.settings_note_reaction_counter_font_size,
-                                    currentConfigState.noteReactionCounterFontSize * 1.2f,
-                                    currentConfigState.noteReactionCounterFontSize
-                                ),
-                                modifier = Modifier.padding(horizontal = 16.dp)
-                            )
-                            Text(
-                                stringResource(id = R.string.settings_app_restart_required),
-                                modifier = Modifier.padding(horizontal = 16.dp),
-                                color = MaterialTheme.colors.error,
-                                fontSize = 14.sp
-                            )
-                            Slider(
-                                value = currentConfigState.noteReactionCounterFontSize,
-                                valueRange = 10f..24f,
-                                onValueChange = {
-                                    currentConfigState =
-                                        currentConfigState.copy(noteReactionCounterFontSize = it)
-                                },
-                                modifier = Modifier.padding(horizontal = 16.dp)
-                            )
+                            Column(Modifier.fillMaxWidth()) {
+                                Text(
+                                    stringResource(
+                                        id = R.string.settings_note_content_font_size,
+                                        currentConfigState.noteContentFontSize
+                                    ),
+                                    modifier = Modifier.padding(horizontal = 16.dp)
+                                )
+                                Text(
+                                    stringResource(id = R.string.settings_app_restart_required),
+                                    modifier = Modifier.padding(horizontal = 16.dp),
+                                    color = MaterialTheme.colors.error,
+                                    fontSize = 14.sp
+                                )
+                                Slider(
+                                    value = currentConfigState.noteContentFontSize,
+                                    valueRange = 10f..24f,
+                                    onValueChange = {
+                                        currentConfigState =
+                                            currentConfigState.copy(noteContentFontSize = it)
+                                    },
+                                    modifier = Modifier.padding(horizontal = 16.dp)
+                                )
+                            }
 
 
-                            Text(
-                                "ノート本文中のカスタム絵文字のスケール",
-                                modifier = Modifier.padding(horizontal = 16.dp)
-                            )
-                            Text(
-                                stringResource(id = R.string.settings_app_restart_required),
-                                modifier = Modifier.padding(horizontal = 16.dp),
-                                color = MaterialTheme.colors.error,
-                                fontSize = 14.sp
-                            )
-                            Slider(
-                                value = currentConfigState.noteCustomEmojiScaleSizeInText,
-                                valueRange = 0.5f..2f,
-                                onValueChange = {
-                                    currentConfigState =
-                                        currentConfigState.copy(noteCustomEmojiScaleSizeInText = it)
-                                },
-                                modifier = Modifier.padding(horizontal = 16.dp)
-                            )
+                            Column(Modifier.fillMaxWidth()) {
+                                Text(
+                                    stringResource(
+                                        id = R.string.settings_note_reaction_counter_font_size,
+                                        currentConfigState.noteReactionCounterFontSize * 1.2f,
+                                        currentConfigState.noteReactionCounterFontSize
+                                    ),
+                                    modifier = Modifier.padding(horizontal = 16.dp)
+                                )
+                                Text(
+                                    stringResource(id = R.string.settings_app_restart_required),
+                                    modifier = Modifier.padding(horizontal = 16.dp),
+                                    color = MaterialTheme.colors.error,
+                                    fontSize = 14.sp
+                                )
+                                Slider(
+                                    value = currentConfigState.noteReactionCounterFontSize,
+                                    valueRange = 10f..24f,
+                                    onValueChange = {
+                                        currentConfigState =
+                                            currentConfigState.copy(noteReactionCounterFontSize = it)
+                                    },
+                                    modifier = Modifier.padding(horizontal = 16.dp)
+                                )
+
+                            }
+
+                            Column(Modifier.fillMaxWidth()) {
+                                Text(
+                                    stringResource(
+                                        id = R.string.settings_note_custom_emoji_scale_size_in_text,
+                                        configState.noteCustomEmojiScaleSizeInText,
+                                    ),
+                                    modifier = Modifier.padding(horizontal = 16.dp)
+                                )
+                                Text(
+                                    stringResource(id = R.string.settings_app_restart_required),
+                                    modifier = Modifier.padding(horizontal = 16.dp),
+                                    color = MaterialTheme.colors.error,
+                                    fontSize = 14.sp
+                                )
+                                Slider(
+                                    value = currentConfigState.noteCustomEmojiScaleSizeInText,
+                                    valueRange = 0.5f..2f,
+                                    onValueChange = {
+                                        currentConfigState =
+                                            currentConfigState.copy(noteCustomEmojiScaleSizeInText = it)
+                                    },
+                                    modifier = Modifier.padding(horizontal = 16.dp)
+                                )
+                            }
+
+
 
 
                             SettingSwitchTile(

--- a/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
+++ b/modules/features/setting/src/main/java/net/pantasystem/milktea/setting/activities/SettingAppearanceActivity.kt
@@ -365,6 +365,27 @@ class SettingAppearanceActivity : AppCompatActivity() {
                             )
 
 
+                            Text(
+                                "ノート本文中のカスタム絵文字のスケール",
+                                modifier = Modifier.padding(horizontal = 16.dp)
+                            )
+                            Text(
+                                stringResource(id = R.string.settings_app_restart_required),
+                                modifier = Modifier.padding(horizontal = 16.dp),
+                                color = MaterialTheme.colors.error,
+                                fontSize = 14.sp
+                            )
+                            Slider(
+                                value = currentConfigState.noteCustomEmojiScaleSizeInText,
+                                valueRange = 0.5f..2f,
+                                onValueChange = {
+                                    currentConfigState =
+                                        currentConfigState.copy(noteCustomEmojiScaleSizeInText = it)
+                                },
+                                modifier = Modifier.padding(horizontal = 16.dp)
+                            )
+
+
                             SettingSwitchTile(
                                 checked = currentConfigState.isEnableNoteDivider,
                                 onChanged = {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Config.kt
@@ -84,6 +84,7 @@ data class Config(
     val noteContentFontSize: Float,
     val isDisplayTimestampsAsAbsoluteDates: Boolean,
     val noteReactionCounterFontSize: Float,
+    val noteCustomEmojiScaleSizeInText: Float,
 ) {
     companion object
 
@@ -143,6 +144,7 @@ object DefaultConfig {
         noteHeaderFontSize = 15f,
         isDisplayTimestampsAsAbsoluteDates = false,
         noteReactionCounterFontSize = 15f,
+        noteCustomEmojiScaleSizeInText = 1.2f,
     )
 
     fun getRememberVisibilityConfig(accountId: Long): RememberVisibility.Remember {

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/setting/Keys.kt
@@ -33,6 +33,7 @@ val Keys.Companion.allKeys by lazy {
         Keys.NoteContentFontSize,
         Keys.IsDisplayTimestampsAsAbsoluteDates,
         Keys.NoteReactionCounterFontSize,
+        Keys.NoteCustomEmojiScaleSizeInText,
     )
 }
 
@@ -94,6 +95,8 @@ sealed interface Keys {
 
     object NoteReactionCounterFontSize : Keys
 
+    object NoteCustomEmojiScaleSizeInText : Keys
+
     companion object
 }
 
@@ -130,5 +133,6 @@ fun Keys.str(): String {
         is Keys.NoteHeaderFontSize -> "NoteHeaderFontSize"
         is Keys.IsDisplayTimestampsAsAbsoluteDates -> "IsDisplayTimestampsAsAbsoluteDates"
         is Keys.NoteReactionCounterFontSize -> "NoteReactionCounterFontSize"
+        is Keys.NoteCustomEmojiScaleSizeInText -> "NoteCustomEmojiScaleSizeInText"
     }
 }


### PR DESCRIPTION
## やったこと
投稿の本文のカスタム絵文字の倍率を変更できるようにしました。
そのために、設定状態に倍率の状態を少数型で保持できるようにしました。
カスタム絵文字の装飾実装部分にスケールのサイズを反映する実装をしました。
またカスタム絵文字の装飾実装部分にスケールのサイズを受け渡せるようにしました。
設定画面を実装し設定状態を変更できるようにしました。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1719 


