### PR TITLE
ドライブ機能の不具合を修正

### DIFF
--- a/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/MediatorFilePropertyDataSource.kt
+++ b/modules/data/src/main/java/net/pantasystem/milktea/data/infrastructure/drive/MediatorFilePropertyDataSource.kt
@@ -1,7 +1,13 @@
 package net.pantasystem.milktea.data.infrastructure.drive
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
 import net.pantasystem.milktea.common.Logger
 import net.pantasystem.milktea.common.collection.LRUCache
@@ -144,6 +150,9 @@ class MediatorFilePropertyDataSource @Inject constructor(
     }
 
     override fun observeIn(ids: List<FileProperty.Id>): Flow<List<FileProperty>> {
+        if (ids.isEmpty()) {
+            return flowOf(emptyList())
+        }
         val accountIds = ids.map { it.accountId }.distinct()
         val flows = accountIds.map { accountId ->
             driveFileRecordDao.observeIn(

--- a/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/viewmodel/DriveViewModel.kt
+++ b/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/viewmodel/DriveViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -198,7 +199,7 @@ class DriveViewModel @Inject constructor(
     )
 
     init {
-        combine(currentAccount, currentDirectory) { ac, dir ->
+        combine(currentAccount.filterNotNull(), currentDirectory) { ac, dir ->
             ac to dir
         }.onEach { (ac, dir) ->
             refreshPagingState(ac, dir)

--- a/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/viewmodel/DriveViewModel.kt
+++ b/modules/features/drive/src/main/java/net/pantasystem/milktea/drive/viewmodel/DriveViewModel.kt
@@ -228,7 +228,7 @@ class DriveViewModel @Inject constructor(
     }
 
     fun popUntil(directory: Directory?) {
-        savedStateHandle[STATE_CURRENT_DIRECTORY_ID] = directory?.parent?.parent?.id
+        savedStateHandle[STATE_CURRENT_DIRECTORY_ID] = directory?.id?.directoryId
     }
 
     fun setUsingGridView(value: Boolean) {


### PR DESCRIPTION
## やったこと
ファイルが一つもないディレクトリを表示したときに、
ファイル一覧表示の内容が以前の画面の内容のままになってしまう問題を修正。
初回表示時にディレクトリ一覧が正しく読み込まれない問題を修正。

## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1754 

