### PR TITLE
プロフィール画面でアカウントを切り替えられるようにした

### DIFF
--- a/modules/common_resource/src/main/res/menu/activity_user_menu.xml
+++ b/modules/common_resource/src/main/res/menu/activity_user_menu.xml
@@ -45,4 +45,9 @@
     <item
             android:id="@+id/share"
             android:title="@string/share"/>
+
+    <item
+            android:id="@+id/nav_switch_account"
+            android:title="@string/switch_account"
+        />
 </menu>

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/FollowFollowerActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/FollowFollowerActivity.kt
@@ -16,7 +16,6 @@ import net.pantasystem.milktea.user.UserCardActionHandler
 import net.pantasystem.milktea.user.compose.screen.FollowFollowerRoute
 import net.pantasystem.milktea.user.viewmodel.FollowFollowerViewModel
 import net.pantasystem.milktea.user.viewmodel.ToggleFollowViewModel
-import net.pantasystem.milktea.user.viewmodel.UserDetailViewModel
 import net.pantasystem.milktea.user.viewmodel.provideFactory
 import javax.inject.Inject
 
@@ -42,8 +41,6 @@ class FollowFollowerActivity : AppCompatActivity() {
         }
     }
 
-    @Inject
-    lateinit var assistedFactory: UserDetailViewModel.ViewModelAssistedFactory
 
     @Inject
     lateinit var applyTheme: ApplyTheme

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
@@ -56,7 +56,6 @@ import net.pantasystem.milktea.user.profile.mute.SpecifyMuteExpiredAtDialog
 import net.pantasystem.milktea.user.reaction.UserReactionsFragment
 import net.pantasystem.milktea.user.viewmodel.UserDetailTabType
 import net.pantasystem.milktea.user.viewmodel.UserDetailViewModel
-import net.pantasystem.milktea.user.viewmodel.provideFactory
 import javax.inject.Inject
 
 class UserDetailNavigationImpl @Inject constructor(
@@ -80,11 +79,11 @@ class UserDetailNavigationImpl @Inject constructor(
 @AndroidEntryPoint
 class UserDetailActivity : AppCompatActivity() {
     companion object {
-        private const val EXTRA_USER_ID =
+        internal const val EXTRA_USER_ID =
             "net.pantasystem.milktea.user.activity.UserDetailActivity.EXTRA_USER_ID"
-        private const val EXTRA_USER_NAME =
+        internal const val EXTRA_USER_NAME =
             "net.pantasystem.milktea.user.activity.UserDetailActivity.EXTRA_USER_NAME"
-        private const val EXTRA_ACCOUNT_ID =
+        internal const val EXTRA_ACCOUNT_ID =
             "jp.panta.misskeyandroiclient.UserDetailActivity.EXTRA_ACCOUNT_ID"
         const val EXTRA_IS_MAIN_ACTIVE = "jp.panta.misskeyandroidclient.EXTRA_IS_MAIN_ACTIVE"
 
@@ -104,8 +103,6 @@ class UserDetailActivity : AppCompatActivity() {
         }
     }
 
-    @Inject
-    lateinit var assistedFactory: UserDetailViewModel.ViewModelAssistedFactory
 
     @Inject
     lateinit var accountStore: AccountStore
@@ -117,25 +114,27 @@ class UserDetailActivity : AppCompatActivity() {
     lateinit var searchNavigation: SearchNavigation
 
 
-    @ExperimentalCoroutinesApi
-    val mViewModel: UserDetailViewModel by viewModels {
-        val remoteUserId: String? = intent.getStringExtra(EXTRA_USER_ID)
-        val accountId: Long = intent.getLongExtra(EXTRA_ACCOUNT_ID, -1)
-        if (!(remoteUserId == null || accountId == -1L)) {
-            val userId = User.Id(accountId, remoteUserId)
-            return@viewModels UserDetailViewModel.provideFactory(assistedFactory, userId)
-        }
-        val userName = intent.data?.getQueryParameter("userName")
-            ?: intent.getStringExtra(EXTRA_USER_NAME)
-            ?: intent.data?.path?.let { path ->
-                if (path.startsWith("/")) {
-                    path.substring(1, path.length)
-                } else {
-                    path
-                }
-            }
-        return@viewModels UserDetailViewModel.provideFactory(assistedFactory, userName!!)
-    }
+//    @ExperimentalCoroutinesApi
+//    val mViewModel: UserDetailViewModel by viewModels {
+//        val remoteUserId: String? = intent.getStringExtra(EXTRA_USER_ID)
+//        val accountId: Long = intent.getLongExtra(EXTRA_ACCOUNT_ID, -1)
+//        if (!(remoteUserId == null || accountId == -1L)) {
+//            val userId = User.Id(accountId, remoteUserId)
+//            return@viewModels UserDetailViewModel.provideFactory(assistedFactory, userId)
+//        }
+//        val userName = intent.data?.getQueryParameter("userName")
+//            ?: intent.getStringExtra(EXTRA_USER_NAME)
+//            ?: intent.data?.path?.let { path ->
+//                if (path.startsWith("/")) {
+//                    path.substring(1, path.length)
+//                } else {
+//                    path
+//                }
+//            }
+//        return@viewModels UserDetailViewModel.provideFactory(assistedFactory, userName!!)
+//    }
+
+    private val mViewModel: UserDetailViewModel by viewModels()
 
 
     private var mUserId: User.Id? = null

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/activity/UserDetailActivity.kt
@@ -51,6 +51,7 @@ import net.pantasystem.milktea.user.activity.binder.UserDetailActivityMenuBinder
 import net.pantasystem.milktea.user.databinding.ActivityUserDetailBinding
 import net.pantasystem.milktea.user.nickname.EditNicknameDialog
 import net.pantasystem.milktea.user.profile.ConfirmUserBlockDialog
+import net.pantasystem.milktea.user.profile.ProfileAccountSwitchDialog
 import net.pantasystem.milktea.user.profile.UserProfileFieldListAdapter
 import net.pantasystem.milktea.user.profile.mute.SpecifyMuteExpiredAtDialog
 import net.pantasystem.milktea.user.reaction.UserReactionsFragment
@@ -337,7 +338,6 @@ class UserDetailActivity : AppCompatActivity() {
     }
 
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.activity_user_menu, menu)
 
@@ -411,6 +411,9 @@ class UserDetailActivity : AppCompatActivity() {
                         )
                     )
                 )
+            }
+            R.id.nav_switch_account -> {
+                ProfileAccountSwitchDialog().show(supportFragmentManager, "switchAccountDialog")
             }
             else -> return false
 

--- a/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/ProfileAccountSwitchDialog.kt
+++ b/modules/features/user/src/main/java/net/pantasystem/milktea/user/profile/ProfileAccountSwitchDialog.kt
@@ -1,0 +1,70 @@
+package net.pantasystem.milktea.user.profile
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.activityViewModels
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.composethemeadapter.MdcTheme
+import dagger.hilt.android.AndroidEntryPoint
+import net.pantasystem.milktea.common_android_ui.account.AccountSwitchingDialogLayout
+import net.pantasystem.milktea.common_navigation.AccountSettingNavigation
+import net.pantasystem.milktea.common_navigation.AuthorizationArgs
+import net.pantasystem.milktea.common_navigation.AuthorizationNavigation
+import net.pantasystem.milktea.common_navigation.UserDetailNavigation
+import net.pantasystem.milktea.common_navigation.UserDetailNavigationArgs
+import net.pantasystem.milktea.user.viewmodel.UserDetailViewModel
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class ProfileAccountSwitchDialog : BottomSheetDialogFragment() {
+    @Inject
+    lateinit var authorizationNavigation: AuthorizationNavigation
+
+    @Inject
+    lateinit var userDetailNavigation: UserDetailNavigation
+
+    @Inject
+    lateinit var accountSettingNavigation: AccountSettingNavigation
+
+    private val userDetailViewModel: UserDetailViewModel by activityViewModels()
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return super.onCreateDialog(savedInstanceState).apply {
+            val view = ComposeView(requireContext()).apply {
+                setContent {
+                    MdcTheme {
+                        val uiState by userDetailViewModel.accountUiState.collectAsState()
+                        AccountSwitchingDialogLayout(
+                            uiState = uiState,
+                            onSettingButtonClicked = {
+                                startActivity(accountSettingNavigation.newIntent(Unit))
+                                dismiss()
+                            },
+                            onAvatarIconClicked = { accountInfo ->
+                                startActivity(
+                                    userDetailNavigation.newIntent(UserDetailNavigationArgs.UserName(accountInfo.user?.let {
+                                        "@${it.userName}@${it.host}"
+                                    } ?: "@${accountInfo.account.userName}@${accountInfo.account.getHost()}"))
+                                )
+                                dismiss()
+                            },
+                            onAccountClicked = {
+                                userDetailViewModel.setCurrentAccount(it.account.accountId)
+                                dismiss()
+                            },
+                            onAddAccountButtonClicked = {
+                                requireActivity().startActivity(authorizationNavigation.newIntent(
+                                    AuthorizationArgs.New))
+                                dismiss()
+                            }
+                        )
+                    }
+                }
+            }
+            setContentView(view)
+        }
+    }
+}

--- a/modules/model/src/main/java/net/pantasystem/milktea/model/ap/ApResolverService.kt
+++ b/modules/model/src/main/java/net/pantasystem/milktea/model/ap/ApResolverService.kt
@@ -1,8 +1,11 @@
 package net.pantasystem.milktea.model.ap
 
 import net.pantasystem.milktea.common.mapCancellableCatching
+import net.pantasystem.milktea.common.runCancellableCatching
+import net.pantasystem.milktea.model.account.AccountRepository
 import net.pantasystem.milktea.model.notes.Note
 import net.pantasystem.milktea.model.notes.NoteRepository
+import net.pantasystem.milktea.model.user.User
 import net.pantasystem.milktea.model.user.UserRepository
 import javax.inject.Inject
 
@@ -10,6 +13,7 @@ class ApResolverService @Inject constructor(
     private val apResolverRepository: ApResolverRepository,
     private val noteRepository: NoteRepository,
     private val userRepository: UserRepository,
+    private val accountRepository: AccountRepository,
 ) {
 
     suspend fun resolve(noteId: Note.Id, resolveToAccountId: Long): Result<Note> {
@@ -25,5 +29,20 @@ class ApResolverService @Inject constructor(
         }
     }
 
-
+    suspend fun resolve(userId: User.Id, resolveToAccountId: Long): Result<User> = runCancellableCatching {
+        val user = (userRepository.find(userId, true) as User.Detail)
+        val resolveAccount = accountRepository.get(resolveToAccountId).getOrThrow()
+        if (resolveAccount.getHost() == user.host) {
+            return@runCancellableCatching userRepository.findByUserName(resolveToAccountId, user.userName, user.host)
+        }
+        val uri = user.getRemoteProfileUrl(
+            accountRepository.get(userId.accountId).getOrThrow()
+        )
+        apResolverRepository.resolve(resolveToAccountId, uri).mapCancellableCatching {
+            when (it) {
+                is ApResolver.TypeNote -> throw IllegalStateException("Cannot resolve note")
+                is ApResolver.TypeUser -> it.user
+            }
+        }.getOrThrow()
+    }
 }


### PR DESCRIPTION
## やったこと
プロフィール画面にアカウントを切り替えるための動線を追加しました。
アカウント切り替え時に、ActivityPubのリソース解決のためのAPIを呼び出し、
成功すれば実際にアカウントを切り替えるようにしました。


## 動作確認


## スクリーンショット(任意)


## 備考


## Issue番号
Closed #1688 


